### PR TITLE
firefox variant plugin: use replace() instead of replaceAll()

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -22,13 +22,13 @@ jobs:
       - name: Install Dependencies 📥
         run: | # Install npm packages
           pnpm install
-      
+
       - name: Lint and Type Check 🧹
         run: | # Run the lint and type check
           pnpm run typecheck
           pnpm run fmt:check
           pnpm run lint
-      
+
       - name: Test 🧪
         run: | # Run the tests
           pnpm run test
@@ -36,4 +36,3 @@ jobs:
       - name: Ensure Package is Publishable 🧐
         run: | # Run the prepublish hook to ensure the package is publishable
           pnpm run prepublishOnly
-

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -19,10 +19,21 @@ jobs:
         with:
           version: 8
 
-      - name: Install and Test 🔧
-        run: | # Install npm packages and build the Storybook files
+      - name: Install Dependencies 📥
+        run: | # Install npm packages
           pnpm install
+      
+      - name: Lint and Type Check 🧹
+        run: | # Run the lint and type check
           pnpm run typecheck
           pnpm run fmt:check
           pnpm run lint
-          pnpm run test run
+      
+      - name: Test 🧪
+        run: | # Run the tests
+          pnpm run test
+
+      - name: Ensure Package is Publishable 🧐
+        run: | # Run the prepublish hook to ensure the package is publishable
+          pnpm run prepublishOnly
+

--- a/components/tailwind-plugins/tailwind-plugin-firefox-variant.ts
+++ b/components/tailwind-plugins/tailwind-plugin-firefox-variant.ts
@@ -19,7 +19,7 @@ const firefoxVariantPlugin = plugin(
 			isFirefoxRule.append(container.nodes);
 			container.append(isFirefoxRule);
 			isFirefoxRule.walkRules((rule) => {
-				rule.selector = `.${api.e(`firefox${separator}${rule.selector.slice(1).replaceAll("\\", "")}`)}`;
+				rule.selector = `.${api.e(`firefox${separator}${rule.selector.slice(1).replace(/\\/g, "")}`)}`;
 			});
 		});
 	},


### PR DESCRIPTION
### Why?

Because `.replaceAll()` would mean we would need consumers to use ES2021+ (this is likely fine, but easy enough to use a regex replace all `/.../g` instead)