### PR TITLE
vertical margin and line-height tweaks to textarea

### DIFF
--- a/components/text-area/src/text-area.tsx
+++ b/components/text-area/src/text-area.tsx
@@ -5,7 +5,7 @@ import type { TextareaHTMLAttributes } from "react";
 import { cx } from "../../core";
 
 const textAreaVariants = cva(
-	"flex min-h-16 w-full rounded-md border border-input bg-white dark:bg-gray-50 px-3 py-2 shadow-sm focus-visible:outline-none focus-visible:ring-4 disabled:pointer-events-none disabled:opacity-50 sm:text-sm",
+	"flex min-h-[5.75rem] sm:min-h-[4.75rem] w-full rounded-md border border-input bg-white dark:bg-gray-50 px-3 py-[calc(theme(spacing[2.5])-1px)] sm:py-[calc(theme(spacing[2])-1px)] shadow-sm focus-visible:outline-none focus-visible:ring-4 disabled:pointer-events-none disabled:opacity-50 sm:text-sm",
 	{
 		variants: {
 			state: {


### PR DESCRIPTION
vertical margin and line-height tweaks to get 3 full lines without scrolling and matching the perceived vertical "padding" on inputs that is achieved with a set height.