### PR TITLE
Let the button link inherit font weight

### DIFF
--- a/components/button/src/button.tsx
+++ b/components/button/src/button.tsx
@@ -6,16 +6,16 @@ import type { WithAsChild } from "../../types/src/as-child";
 import type { VariantProps } from "../../types/src/variant-props";
 
 const buttonVariants = cva(
-	"items-center justify-center rounded-md font-medium focus-visible:outline-none focus-visible:ring-4 disabled:pointer-events-none disabled:opacity-50 whitespace-nowrap sm:text-sm",
+	"items-center justify-center rounded-md focus-visible:outline-none focus-visible:ring-4 disabled:pointer-events-none disabled:opacity-50 whitespace-nowrap sm:text-sm",
 	{
 		variants: {
 			appearance: {
 				outlined:
-					"inline-flex h-11 sm:h-9 px-3 border bg-white dark:bg-gray-50 border-blue-600 text-blue-600 hover:bg-blue-500/5 dark:hover:bg-blue-500/5 active:bg-blue-500/10 focus-visible:ring-blue-500/25",
+					"font-medium inline-flex h-11 sm:h-9 px-3 border bg-white dark:bg-gray-50 border-blue-600 text-blue-600 hover:bg-blue-500/5 dark:hover:bg-blue-500/5 active:bg-blue-500/10 focus-visible:ring-blue-500/25",
 				filled:
-					"inline-flex h-11 sm:h-9 px-3 border border-transparent bg-blue-500 text-[#fff] hover:bg-blue-600 dark:hover:bg-blue-400 active:bg-blue-700 dark:active:bg-blue-300 focus-visible:border-blue-600 focus-visible:ring-blue-500/25",
+					"font-medium inline-flex h-11 sm:h-9 px-3 border border-transparent bg-blue-500 text-[#fff] hover:bg-blue-600 dark:hover:bg-blue-400 active:bg-blue-700 dark:active:bg-blue-300 focus-visible:border-blue-600 focus-visible:ring-blue-500/25",
 				ghost:
-					"inline-flex h-11 sm:h-9 px-3 border border-transparent text-blue-600 hover:bg-blue-500/5 active:bg-blue-500/10 focus-visible:ring-blue-500/25",
+					"font-medium inline-flex h-11 sm:h-9 px-3 border border-transparent text-blue-600 hover:bg-blue-500/5 active:bg-blue-500/10 focus-visible:ring-blue-500/25",
 				link: "inline border-transparent cursor-pointer hover:underline text-blue-600 focus-visible:ring-blue-500/25",
 			},
 			priority: {


### PR DESCRIPTION
It was showing up as font-weight medium regardless, and now this'll inherit from the parent 🎉 