### PR TITLE
sizing and spacing refinement for alert

### DIFF
--- a/app/routes/components.alert.tsx
+++ b/app/routes/components.alert.tsx
@@ -29,35 +29,35 @@ export default function Page() {
 			<p className="mt-4 text-xl text-gray-600">Displays a callout for user attention.</p>
 			<Example className="mt-4 flex-col gap-2">
 				<Alert>
-					<Rocket className="h-6 w-6" />
+					<Rocket className="size-5" />
 					<AlertContent>
 						<AlertTitle>Default</AlertTitle>
 						<AlertDescription>This is a default alert.</AlertDescription>
 					</AlertContent>
 				</Alert>
 				<Alert priority="danger">
-					<Fire className="h-6 w-6" />
+					<Fire className="size-5" />
 					<AlertContent>
 						<AlertTitle>Danger</AlertTitle>
 						<AlertDescription>This is a danger alert.</AlertDescription>
 					</AlertContent>
 				</Alert>
 				<Alert priority="info">
-					<Info className="h-6 w-6" />
+					<Info className="size-5" />
 					<AlertContent>
 						<AlertTitle>Info</AlertTitle>
 						<AlertDescription>This is an info alert.</AlertDescription>
 					</AlertContent>
 				</Alert>
 				<Alert priority="success">
-					<CheckCircle className="h-6 w-6" />
+					<CheckCircle className="size-5" />
 					<AlertContent>
 						<AlertTitle>Success</AlertTitle>
 						<AlertDescription>This is a success alert.</AlertDescription>
 					</AlertContent>
 				</Alert>
 				<Alert priority="warning">
-					<Warning className="h-6 w-6" />
+					<Warning className="size-5" />
 					<AlertContent>
 						<AlertTitle>Warning</AlertTitle>
 						<AlertDescription>This is a warning alert.</AlertDescription>

--- a/components/alert/src/alert.tsx
+++ b/components/alert/src/alert.tsx
@@ -4,7 +4,7 @@ import type { HTMLAttributes } from "react";
 import { cx } from "../../core";
 import type { VariantProps } from "../../types";
 
-const alertVariants = cva("relative w-full rounded-lg border px-4 py-3 text-sm flex gap-4", {
+const alertVariants = cva("relative w-full rounded-md border p-2.5 text-sm flex gap-1.5", {
 	variants: {
 		priority: {
 			danger: "border-red-600 bg-red-500/5 text-red-700",
@@ -35,14 +35,14 @@ AlertContent.displayName = "AlertContent";
 
 const AlertTitle = forwardRef<HTMLParagraphElement, HTMLAttributes<HTMLHeadingElement>>(
 	({ className, ...props }, ref) => (
-		<h5 ref={ref} className={cx("mb-1 font-medium leading-none tracking-tight", className)} {...props} />
+		<h5 ref={ref} className={cx("font-medium", className)} {...props} />
 	),
 );
 AlertTitle.displayName = "AlertTitle";
 
 const AlertDescription = forwardRef<HTMLParagraphElement, HTMLAttributes<HTMLParagraphElement>>(
 	({ className, ...props }, ref) => (
-		<div ref={ref} className={cx("text-sm [&_p]:leading-relaxed", className)} {...props} />
+		<div ref={ref} className={cx("text-sm", className)} {...props} />
 	),
 );
 AlertDescription.displayName = "AlertDescription";

--- a/components/alert/src/alert.tsx
+++ b/components/alert/src/alert.tsx
@@ -34,16 +34,12 @@ const AlertContent = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(
 AlertContent.displayName = "AlertContent";
 
 const AlertTitle = forwardRef<HTMLParagraphElement, HTMLAttributes<HTMLHeadingElement>>(
-	({ className, ...props }, ref) => (
-		<h5 ref={ref} className={cx("font-medium", className)} {...props} />
-	),
+	({ className, ...props }, ref) => <h5 ref={ref} className={cx("font-medium", className)} {...props} />,
 );
 AlertTitle.displayName = "AlertTitle";
 
 const AlertDescription = forwardRef<HTMLParagraphElement, HTMLAttributes<HTMLParagraphElement>>(
-	({ className, ...props }, ref) => (
-		<div ref={ref} className={cx("text-sm", className)} {...props} />
-	),
+	({ className, ...props }, ref) => <div ref={ref} className={cx("text-sm", className)} {...props} />,
 );
 AlertDescription.displayName = "AlertDescription";
 


### PR DESCRIPTION
will align contents with buttons and form elements. icon will align perfectly with a single line of text.

new
<img width="419" alt="image" src="https://github.com/ngrok-oss/mantle/assets/780079/7fc5b42c-17da-4223-8ce4-6f44dc8ef37b">
new single line
<img width="315" alt="image" src="https://github.com/ngrok-oss/mantle/assets/780079/d62f24b5-1ce1-4870-af71-21f1fda0de49">


old
<img width="445" alt="image" src="https://github.com/ngrok-oss/mantle/assets/780079/f1884148-bf1f-43e2-aeb6-90f10e5889c7">

old single line
<img width="334" alt="image" src="https://github.com/ngrok-oss/mantle/assets/780079/e2153908-5ead-463f-9da2-114e8a1739f3">

