### PR TITLE
fix hover / active issue for code block button

### DIFF
--- a/components/code-block/src/code-block.tsx
+++ b/components/code-block/src/code-block.tsx
@@ -220,7 +220,7 @@ const CodeBlockCopyButton = forwardRef<HTMLButtonElement, CodeBlockCopyButtonPro
 				className={cx(
 					"absolute right-3 top-3 z-10 flex h-7 w-7 items-center justify-center rounded border border-gray-300 bg-gray-50 shadow-[-1rem_0_0.75rem_-0.375rem_hsl(var(--gray-50)),1rem_0_0_-0.25rem_hsl(var(--gray-50))] hover:border-gray-400 hover:bg-gray-200 focus-visible:border-accent-600 focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-focus-accent",
 					copied &&
-						"w-auto gap-1 border-transparent bg-filled-success pl-2 pr-1.5 text-on-filled hover:border-transparent hover:bg-filled-success-hover focus:bg-filled-success-active focus-visible:border-success-600 focus-visible:ring-focus-success",
+						"w-auto gap-1 border-transparent bg-filled-success pl-2 pr-1.5 text-on-filled hover:border-transparent hover:bg-filled-success focus:bg-filled-success focus-visible:border-success-600 focus-visible:ring-focus-success",
 					className,
 				)}
 				ref={ref}


### PR DESCRIPTION
just uses the same bg across default, focus, and active for the green "copied" state. We don't really need different backgrounds on this as it's just informative and actually feels weird anyway. This keeps the focus ring however, as it feels more natural transitioning from  the initial copy button.
<img width="172" alt="image" src="https://github.com/ngrok-oss/mantle/assets/780079/cb62b2de-4df1-44c8-b81d-0b88b3bf676b">
