### PR TITLE
Set up pipeline to deploy vercel production site on releases

### DIFF
--- a/.github/workflows/prod-publish.yml
+++ b/.github/workflows/prod-publish.yml
@@ -1,0 +1,25 @@
+name: Vercel
+env:
+  VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+  VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch: # Can be manually run as well
+
+jobs:
+  prod-deploy:
+    name: Deploy Production
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Vercel CLI
+        run: npm install --global vercel@latest
+      - name: Pull Vercel Environment Information
+        run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+      - name: Build Project Artifacts
+        run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
+      - name: Deploy Project Artifacts to Vercel
+        run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}


### PR DESCRIPTION
This will need some iteration to check that the release is the latest release and not a minor bump of a previous major, or likewise a patch bump of a previous minor, but we can add that later. The workflow dispatch will also let us trigger it manually as well.