### PR TITLE
fix: Install pnpm dependencies before publishing

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -20,6 +20,8 @@ jobs:
         with:
           version: 8
 
+      - run: pnpm install
+
       - run: pnpm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Need to actually install the dependencies before we can publish. 