### PR TITLE
Apply medium font weight to strong

### DIFF
--- a/assets/mantle.css
+++ b/assets/mantle.css
@@ -1479,6 +1479,10 @@
 	body {
 		@apply bg-white text-gray-900;
 	}
+
+	strong {
+		@apply font-medium;
+	}
 }
 
 @layer utilities {


### PR DESCRIPTION
Since we have a custom font with additional weights, we don't want the stock font weight of `bolder` from Tailwind's preflight. We actually want to spec `500` so we don't kick into faux bolding.