### PR TITLE
Further shadow specification and refinement

### DIFF
--- a/app/routes/base.shadows.tsx
+++ b/app/routes/base.shadows.tsx
@@ -2,7 +2,7 @@ import type { HeadersFunction, MetaFunction } from "@remix-run/node";
 
 export const meta: MetaFunction = () => {
 	return [
-		{ title: "@ngrok/mantle — Typography" },
+		{ title: "@ngrok/mantle — Shadows" },
 		{ name: "description", content: "mantle is ngrok's UI library and design system" },
 	];
 };

--- a/app/routes/base.shadows.tsx
+++ b/app/routes/base.shadows.tsx
@@ -19,6 +19,9 @@ export default function Page() {
 			<h1 className="text-5xl font-medium">Shadows</h1>
 			<p className="mt-4 text-xl text-body">Tokens for defining elevations.</p>
 			<div className="mt-8 flex gap-8">
+				<div className="size-24 rounded-lg bg-card shadow-inner"></div>
+				<div className="size-24 rounded-lg bg-card shadow-sm"></div>
+				<div className="size-24 rounded-lg bg-card shadow"></div>
 				<div className="size-24 rounded-lg bg-card shadow-md"></div>
 				<div className="size-24 rounded-lg bg-card shadow-lg"></div>
 				<div className="size-24 rounded-lg bg-card shadow-xl"></div>

--- a/assets/mantle.css
+++ b/assets/mantle.css
@@ -613,9 +613,8 @@
 	/* shadow tokens */
 
 	--shadow-color: 0 0% 0%;
-	--shadow-first: 4%;
+	--shadow-first: 5%;
 	--shadow-second: 10%;
-	--shadow-third: 25%;
 }
 
 :root.dark {
@@ -909,7 +908,6 @@
 
 	--shadow-first: 15%;
 	--shadow-second: 30%;
-	--shadow-third: 90%;
 }
 
 :root.light-high-contrast {
@@ -1153,7 +1151,6 @@
 
 	--shadow-first: 100%;
 	--shadow-second: 100%;
-	--shadow-third: 100%;
 }
 
 :root.dark-high-contrast {
@@ -1406,7 +1403,6 @@
 
 	--shadow-first: 100%;
 	--shadow-second: 100%;
-	--shadow-third: 100%;
 }
 
 /**

--- a/packages/tailwind-preset/src/tailwind.preset.ts
+++ b/packages/tailwind-preset/src/tailwind.preset.ts
@@ -334,11 +334,15 @@ const mantlePreset = {
 				unchecked: 'checked="false"',
 			},
 			boxShadow: {
+				sm: "0px 1px 2px 0 hsl(var(--shadow-color) / var(--shadow-first))",
+				DEFAULT:
+					"0px 1px 2px -1px hsl(var(--shadow-color) / var(--shadow-second)), 0px 1px 3px 0px hsl(var(--shadow-color) / var(--shadow-second))",
 				md: "0px 2px 13px 0px hsl(var(--shadow-color) / var(--shadow-first)), 0px 2px 4px -2px hsl(var(--shadow-color) / var(--shadow-second)), 0px 4px 6px -1px hsl(var(--shadow-color) / var(--shadow-second))",
 				lg: "0px 1px 13px 0px hsl(var(--shadow-color) / var(--shadow-first)), 0px 4px 6px -4px hsl(var(--shadow-color) / var(--shadow-second)), 0px 10px 15px -3px hsl(var(--shadow-color) / var(--shadow-second))",
 				xl: "0px 0px 15px 0px hsl(var(--shadow-color) / var(--shadow-first)), 0px 8px 10px -6px hsl(var(--shadow-color) / var(--shadow-second)), 0px 20px 25px -5px hsl(var(--shadow-color) / var(--shadow-second))",
 				"2xl":
-					"0px 0px 15px 2px hsl(var(--shadow-color) / var(--shadow-first)), 0px 25px 50px -12px hsl(var(--shadow-color) / var(--shadow-third))",
+					"0px 0px 15px 0px hsl(var(--shadow-color) / var(--shadow-first)), 0px 11px 10px 0px hsl(var(--shadow-color) / var(--shadow-first)), 0px 17px 25px 2px hsl(var(--shadow-color) / var(--shadow-second))",
+				inner: "inset 0px 2px 4px 0px hsl(var(--shadow-color) / var(--shadow-first))",
 			},
 			backgroundColor: {
 				base: "hsl(var(--bg-base))",


### PR DESCRIPTION
This PR pushes our shadows a little further after a round of refinement in Figma.

<img width="924" alt="image" src="https://github.com/ngrok-oss/mantle/assets/1369864/97057328-909e-4e22-9989-f15a0645edbe">
