### PR TITLE
Dialog animation refinement

### DIFF
--- a/packages/dialog/src/dialog.tsx
+++ b/packages/dialog/src/dialog.tsx
@@ -37,7 +37,7 @@ const DialogContent = forwardRef<
 		<DialogPrimitive.Content
 			ref={ref}
 			className={cx(
-				"fixed left-1/2 top-1/2 z-50 flex max-h-[calc(100dvh_-_32px)] w-full max-w-lg -translate-x-1/2 -translate-y-1/2 flex-col rounded-xl border border-dialog bg-dialog shadow-lg transition-transform duration-200",
+				"fixed left-1/2 top-1/2 z-50 flex max-h-[calc(100dvh_-_2rem)] w-full max-w-lg -translate-x-1/2 -translate-y-1/2 flex-col rounded-xl border border-dialog bg-dialog shadow-lg transition-transform duration-200",
 				"data-state-closed:animate-out data-state-closed:fade-out-0 data-state-closed:zoom-out-95 data-state-closed:slide-out-to-left-1/2 data-state-closed:slide-out-to-top-[48%] data-state-open:animate-in data-state-open:fade-in-0 data-state-open:zoom-in-95 data-state-open:slide-in-from-left-1/2 data-state-open:slide-in-from-top-[48%]",
 				className,
 			)}

--- a/packages/dialog/src/dialog.tsx
+++ b/packages/dialog/src/dialog.tsx
@@ -37,7 +37,7 @@ const DialogContent = forwardRef<
 		<DialogPrimitive.Content
 			ref={ref}
 			className={cx(
-				"fixed left-1/2 top-1/2 z-50 flex max-h-[calc(100dvh_-_32px)] w-full max-w-lg -translate-x-1/2 -translate-y-1/2 flex-col rounded-xl border border-dialog bg-dialog shadow-lg duration-200",
+				"fixed left-1/2 top-1/2 z-50 flex max-h-[calc(100dvh_-_32px)] w-full max-w-lg -translate-x-1/2 -translate-y-1/2 flex-col rounded-xl border border-dialog bg-dialog shadow-lg transition-transform duration-200",
 				"data-state-closed:animate-out data-state-closed:fade-out-0 data-state-closed:zoom-out-95 data-state-closed:slide-out-to-left-1/2 data-state-closed:slide-out-to-top-[48%] data-state-open:animate-in data-state-open:fade-in-0 data-state-open:zoom-in-95 data-state-open:slide-in-from-left-1/2 data-state-open:slide-in-from-top-[48%]",
 				className,
 			)}


### PR DESCRIPTION
Our transitions were defaulting to `all` on the dialog, so when you scaled your browser, the size of the dialog was animating over 200ms. Simply adding `transition-transform` keeps all our animations and kills that unintended consequence. Also flips the inset to rems. Just in case, y'know?!