### PR TITLE
Add "Nunito Sans" as a `font-body`

### DIFF
--- a/app/components/props-table.tsx
+++ b/app/components/props-table.tsx
@@ -19,7 +19,7 @@ export const PropsTable = ({ children, className, style }: PropsTableProps) => (
 					<TableHead>Description</TableHead>
 				</TableRow>
 			</TableHeader>
-			<TableBody className="text-xs text-body">{children}</TableBody>
+			<TableBody className="font-body text-xs text-body">{children}</TableBody>
 		</Table>
 	</div>
 );

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -22,7 +22,7 @@ export default function Page() {
 	return (
 		<div>
 			<h1 className="text-5xl font-medium">Mantle</h1>
-			<p className="font-weight mt-4 text-xl text-body">
+			<p className="font-weight font-body mt-4 text-xl text-body">
 				Mantle is <Anchor href="https://ngrok.com">ngrok</Anchor>
 				&rsquo;s UI library and design system that powers its front-end.
 			</p>
@@ -34,7 +34,7 @@ export default function Page() {
 			<h3 id="dependencies" className="mt-6 text-xl font-medium">
 				Dependencies
 			</h3>
-			<p className="mt-3 text-body">
+			<p className="font-body mt-3 text-body">
 				Mantle&rsquo;s styling is composed using <Anchor href="https://tailwindcss.com">Tailwind</Anchor>. Its{" "}
 				<Anchor href="https://react.dev">React</Anchor> components are inspired by{" "}
 				<Anchor href="https://ui.shadcn.com">shadcn/ui</Anchor>
@@ -45,22 +45,22 @@ export default function Page() {
 			<h3 id="status" className="mt-8 text-xl font-medium">
 				Status
 			</h3>
-			<p className="mt-3 text-body">
+			<p className="font-body mt-3 text-body">
 				Mantle is a work in progress that&rsquo;s currently adding components. It intends to replace new and existing
 				ngrok user interfaces.
 			</p>
 
-			<p className="mt-3 text-body">
+			<p className="font-body mt-3 text-body">
 				Mantle is available in its alpha state on{" "}
 				<Anchor href="https://www.npmjs.com/package/@ngrok/mantle">NPM</Anchor>. It is open source and available on{" "}
 				<Anchor href="https://github.com/ngrok-oss/mantle">GitHub</Anchor>.
 			</p>
 
 			<h2 className="mt-12 text-3xl font-medium">Setup</h2>
-			<p className="mt-3 text-body">
+			<p className="font-body mt-3 text-body">
 				Start by installing <InlineCode>@ngrok/mantle</InlineCode> with your preferred package manager:
 			</p>
-			<div className="mt-3 overflow-hidden rounded-lg border border-card">
+			<div className="mt-4 overflow-hidden rounded-lg border border-card">
 				<Table>
 					<TableHeader>
 						<TableRow>
@@ -117,13 +117,13 @@ export default function Page() {
 				</Table>
 			</div>
 
-			<section className="space-y-3">
+			<section>
 				<h2 className="mt-8 text-xl font-medium">Tailwind Configuration</h2>
-				<p className="mt-3 text-body">
+				<p className="font-body mt-3 text-body">
 					Then, add the <Anchor href="https://tailwindcss.com/docs/presets">tailwind preset</Anchor> to your tailwind
 					configuration:
 				</p>
-				<CodeBlock>
+				<CodeBlock className="mt-4">
 					<CodeBlockHeader>tailwind.config.ts</CodeBlockHeader>
 					<CodeBlockBody>
 						<CodeBlockCopyButton />
@@ -143,13 +143,13 @@ export default function Page() {
 				</CodeBlock>
 			</section>
 
-			<section className="space-y-3">
+			<section>
 				<h2 className="mt-8 text-xl font-medium">Application Scaffolding</h2>
-				<p className="text-body">
+				<p className="font-body mt-3 text-body">
 					In your application&rsquo;s entry/root, import the <InlineCode>mantle.css</InlineCode> file to apply the
 					mantle styles:
 				</p>
-				<CodeBlock>
+				<CodeBlock className="mt-4">
 					<CodeBlockHeader>root.tsx</CodeBlockHeader>
 					<CodeBlockBody>
 						<CodeBlockCopyButton />
@@ -179,11 +179,11 @@ export default function Page() {
 						/>
 					</CodeBlockBody>
 				</CodeBlock>
-				<p className="text-body">
+				<p className="font-body mt-8 text-body">
 					Next, you should add the <Link to="/components/theme-provider">Theme Provider</Link> to your application to
 					provide the mantle theme to your components. You are now ready to use mantle components in your application!
 				</p>
-				<p className="text-body">
+				<p className="font-body mt-4 text-body">
 					You are now ready to use mantle components in your application! For example, you can use the{" "}
 					<Link to="/components/button">Button</Link>!
 				</p>

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -22,7 +22,7 @@ export default function Page() {
 	return (
 		<div>
 			<h1 className="text-5xl font-medium">Mantle</h1>
-			<p className="font-weight font-body mt-4 text-xl text-body">
+			<p className="font-weight mt-4 font-body text-xl text-body">
 				Mantle is <Anchor href="https://ngrok.com">ngrok</Anchor>
 				&rsquo;s UI library and design system that powers its front-end.
 			</p>
@@ -34,7 +34,7 @@ export default function Page() {
 			<h3 id="dependencies" className="mt-6 text-xl font-medium">
 				Dependencies
 			</h3>
-			<p className="font-body mt-3 text-body">
+			<p className="mt-3 font-body text-body">
 				Mantle&rsquo;s styling is composed using <Anchor href="https://tailwindcss.com">Tailwind</Anchor>. Its{" "}
 				<Anchor href="https://react.dev">React</Anchor> components are inspired by{" "}
 				<Anchor href="https://ui.shadcn.com">shadcn/ui</Anchor>
@@ -45,19 +45,19 @@ export default function Page() {
 			<h3 id="status" className="mt-8 text-xl font-medium">
 				Status
 			</h3>
-			<p className="font-body mt-3 text-body">
+			<p className="mt-3 font-body text-body">
 				Mantle is a work in progress that&rsquo;s currently adding components. It intends to replace new and existing
 				ngrok user interfaces.
 			</p>
 
-			<p className="font-body mt-3 text-body">
+			<p className="mt-3 font-body text-body">
 				Mantle is available in its alpha state on{" "}
 				<Anchor href="https://www.npmjs.com/package/@ngrok/mantle">NPM</Anchor>. It is open source and available on{" "}
 				<Anchor href="https://github.com/ngrok-oss/mantle">GitHub</Anchor>.
 			</p>
 
 			<h2 className="mt-12 text-3xl font-medium">Setup</h2>
-			<p className="font-body mt-3 text-body">
+			<p className="mt-3 font-body text-body">
 				Start by installing <InlineCode>@ngrok/mantle</InlineCode> with your preferred package manager:
 			</p>
 			<div className="mt-4 overflow-hidden rounded-lg border border-card">
@@ -119,7 +119,7 @@ export default function Page() {
 
 			<section>
 				<h2 className="mt-8 text-xl font-medium">Tailwind Configuration</h2>
-				<p className="font-body mt-3 text-body">
+				<p className="mt-3 font-body text-body">
 					Then, add the <Anchor href="https://tailwindcss.com/docs/presets">tailwind preset</Anchor> to your tailwind
 					configuration:
 				</p>
@@ -145,7 +145,7 @@ export default function Page() {
 
 			<section>
 				<h2 className="mt-8 text-xl font-medium">Application Scaffolding</h2>
-				<p className="font-body mt-3 text-body">
+				<p className="mt-3 font-body text-body">
 					In your application&rsquo;s entry/root, import the <InlineCode>mantle.css</InlineCode> file to apply the
 					mantle styles:
 				</p>
@@ -179,11 +179,11 @@ export default function Page() {
 						/>
 					</CodeBlockBody>
 				</CodeBlock>
-				<p className="font-body mt-8 text-body">
+				<p className="mt-8 font-body text-body">
 					Next, you should add the <Link to="/components/theme-provider">Theme Provider</Link> to your application to
 					provide the mantle theme to your components. You are now ready to use mantle components in your application!
 				</p>
-				<p className="font-body mt-4 text-body">
+				<p className="mt-4 font-body text-body">
 					You are now ready to use mantle components in your application! For example, you can use the{" "}
 					<Link to="/components/button">Button</Link>!
 				</p>

--- a/app/routes/base.colors.tsx
+++ b/app/routes/base.colors.tsx
@@ -314,7 +314,7 @@ export default function Page() {
 			</nav>
 			<div className="flex-1">
 				<h1 className="text-5xl font-medium">Colors</h1>
-				<p className="mt-4 text-xl text-body">
+				<p className="font-body mt-4 text-xl text-body">
 					Colors are a key component of any design system. They are used to convey meaning, attract attention, and
 					provide feedback. Mantle&rsquo;s color system is designed to be accessible and flexible with dark and high
 					contrast modes.
@@ -323,7 +323,7 @@ export default function Page() {
 				<h2 id="tailwind" className="mt-8 text-3xl font-medium">
 					Tailwind
 				</h2>
-				<p className="mt-3 text-body">
+				<p className="font-body mt-3 text-body">
 					Mantle uses Tailwind under the hood for all its CSS styling. However, we differ from Tailwind when it comes to
 					colors. Mantle provides a full color library that automatically provides a dark and high contrast modes. This
 					is different from standard Tailwind usage that <em>requires</em> dark class variations. By simply specifying
@@ -334,7 +334,7 @@ export default function Page() {
 				<h2 id="variables" className="mt-8 text-3xl font-medium">
 					Variables
 				</h2>
-				<p className="mt-3 text-body">
+				<p className="font-body mt-3 text-body">
 					Mantle&rsquo;s colors are delivered as CSS variables via Tailwind&rsquo;s API eg.{" "}
 					<InlineCode>.text-blue-500</InlineCode>. They can be directly accessed via{" "}
 					<InlineCode>var(--blue-500)</InlineCode> but do note that you&rsquo;ll need to wrap everything in{" "}
@@ -345,7 +345,7 @@ export default function Page() {
 				<h2 id="overrides" className="mt-8 text-3xl font-medium">
 					Overrides
 				</h2>
-				<p className="mt-3 text-body">
+				<p className="font-body mt-3 text-body">
 					Most colors should appropriately swap for sensible values in dark and high contrast modes. However, there are
 					often cases where you&rsquo;ll need to specify an override. The <InlineCode>dark:</InlineCode> variant is
 					well-documented on <Anchor href="https://tailwindcss.com/docs/dark-mode">Tailwind&rsquo;s website</Anchor>.
@@ -356,7 +356,7 @@ export default function Page() {
 				<h2 id="functional-colors" className="mt-8 text-3xl font-medium">
 					Functional Colors
 				</h2>
-				<p className="mt-3 text-body">
+				<p className="font-body mt-3 text-body">
 					Mantle generally limits its color choices to the following functional colors for primary actions, and various
 					states like danger and warnings.
 				</p>
@@ -614,7 +614,7 @@ export default function Page() {
 				<h2 id="extended-palette" className="mt-16 text-3xl font-medium">
 					Extended Palette
 				</h2>
-				<p className="mt-3 text-body">
+				<p className="font-body mt-3 text-body">
 					Mantle also supports the entirety of Tailwind&rsquo;s color palette in light, dark, and high contrast
 					variants. These are to be used when there is no functional meaning behind the color choice. However,
 					we&rsquo;ve left out the extended collection of Tailwind&rsquo;s grays eg. slate, zinc, etc. since we only

--- a/app/routes/base.colors.tsx
+++ b/app/routes/base.colors.tsx
@@ -314,7 +314,7 @@ export default function Page() {
 			</nav>
 			<div className="flex-1">
 				<h1 className="text-5xl font-medium">Colors</h1>
-				<p className="font-body mt-4 text-xl text-body">
+				<p className="mt-4 font-body text-xl text-body">
 					Colors are a key component of any design system. They are used to convey meaning, attract attention, and
 					provide feedback. Mantle&rsquo;s color system is designed to be accessible and flexible with dark and high
 					contrast modes.
@@ -323,7 +323,7 @@ export default function Page() {
 				<h2 id="tailwind" className="mt-8 text-3xl font-medium">
 					Tailwind
 				</h2>
-				<p className="font-body mt-3 text-body">
+				<p className="mt-3 font-body text-body">
 					Mantle uses Tailwind under the hood for all its CSS styling. However, we differ from Tailwind when it comes to
 					colors. Mantle provides a full color library that automatically provides a dark and high contrast modes. This
 					is different from standard Tailwind usage that <em>requires</em> dark class variations. By simply specifying
@@ -334,7 +334,7 @@ export default function Page() {
 				<h2 id="variables" className="mt-8 text-3xl font-medium">
 					Variables
 				</h2>
-				<p className="font-body mt-3 text-body">
+				<p className="mt-3 font-body text-body">
 					Mantle&rsquo;s colors are delivered as CSS variables via Tailwind&rsquo;s API eg.{" "}
 					<InlineCode>.text-blue-500</InlineCode>. They can be directly accessed via{" "}
 					<InlineCode>var(--blue-500)</InlineCode> but do note that you&rsquo;ll need to wrap everything in{" "}
@@ -345,7 +345,7 @@ export default function Page() {
 				<h2 id="overrides" className="mt-8 text-3xl font-medium">
 					Overrides
 				</h2>
-				<p className="font-body mt-3 text-body">
+				<p className="mt-3 font-body text-body">
 					Most colors should appropriately swap for sensible values in dark and high contrast modes. However, there are
 					often cases where you&rsquo;ll need to specify an override. The <InlineCode>dark:</InlineCode> variant is
 					well-documented on <Anchor href="https://tailwindcss.com/docs/dark-mode">Tailwind&rsquo;s website</Anchor>.
@@ -356,7 +356,7 @@ export default function Page() {
 				<h2 id="functional-colors" className="mt-8 text-3xl font-medium">
 					Functional Colors
 				</h2>
-				<p className="font-body mt-3 text-body">
+				<p className="mt-3 font-body text-body">
 					Mantle generally limits its color choices to the following functional colors for primary actions, and various
 					states like danger and warnings.
 				</p>
@@ -614,7 +614,7 @@ export default function Page() {
 				<h2 id="extended-palette" className="mt-16 text-3xl font-medium">
 					Extended Palette
 				</h2>
-				<p className="font-body mt-3 text-body">
+				<p className="mt-3 font-body text-body">
 					Mantle also supports the entirety of Tailwind&rsquo;s color palette in light, dark, and high contrast
 					variants. These are to be used when there is no functional meaning behind the color choice. However,
 					we&rsquo;ve left out the extended collection of Tailwind&rsquo;s grays eg. slate, zinc, etc. since we only

--- a/app/routes/base.shadows.tsx
+++ b/app/routes/base.shadows.tsx
@@ -17,7 +17,7 @@ export default function Page() {
 	return (
 		<div>
 			<h1 className="text-5xl font-medium">Shadows</h1>
-			<p className="mt-4 text-xl text-body">Tokens for defining elevations.</p>
+			<p className="font-body mt-4 text-xl text-body">Tokens for defining elevations.</p>
 			<div className="mt-8 flex gap-8">
 				<div className="size-24 rounded-lg bg-card shadow-inner"></div>
 				<div className="size-24 rounded-lg bg-card shadow-sm"></div>

--- a/app/routes/base.shadows.tsx
+++ b/app/routes/base.shadows.tsx
@@ -17,7 +17,7 @@ export default function Page() {
 	return (
 		<div>
 			<h1 className="text-5xl font-medium">Shadows</h1>
-			<p className="font-body mt-4 text-xl text-body">Tokens for defining elevations.</p>
+			<p className="mt-4 font-body text-xl text-body">Tokens for defining elevations.</p>
 			<div className="mt-8 flex gap-8">
 				<div className="size-24 rounded-lg bg-card shadow-inner"></div>
 				<div className="size-24 rounded-lg bg-card shadow-sm"></div>

--- a/app/routes/base.tailwind-variants.tsx
+++ b/app/routes/base.tailwind-variants.tsx
@@ -20,7 +20,7 @@ export default function Page() {
 	return (
 		<div>
 			<h1 className="text-5xl font-medium">Tailwind Variants</h1>
-			<p className="mt-4 text-xl text-body">
+			<p className="font-body mt-4 text-xl text-body">
 				Additional tailwind variants added by our tailwind preset. The boxes below will have a green border and
 				checkmark if they match, else a red border and X.
 			</p>

--- a/app/routes/base.tailwind-variants.tsx
+++ b/app/routes/base.tailwind-variants.tsx
@@ -20,7 +20,7 @@ export default function Page() {
 	return (
 		<div>
 			<h1 className="text-5xl font-medium">Tailwind Variants</h1>
-			<p className="font-body mt-4 text-xl text-body">
+			<p className="mt-4 font-body text-xl text-body">
 				Additional tailwind variants added by our tailwind preset. The boxes below will have a green border and
 				checkmark if they match, else a red border and X.
 			</p>

--- a/app/routes/base.typography.tsx
+++ b/app/routes/base.typography.tsx
@@ -1,3 +1,5 @@
+import { InlineCode } from "@/inline-code";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/table";
 import type { HeadersFunction, MetaFunction } from "@remix-run/node";
 
 export const meta: MetaFunction = () => {
@@ -17,18 +19,118 @@ export default function Page() {
 	return (
 		<div>
 			<h1 className="text-5xl font-medium">Typography</h1>
-			<p className="mt-4 text-xl text-body">Very early explorations of typographic scale.</p>
-			<h1 className="mt-8 text-5xl font-medium">Heading 1</h1>
+			<p className="font-body mt-4 text-xl text-body">
+				Mantle provides various typography tokens for consistency and readability.
+			</p>
+
+			<h2 className="mt-8 text-3xl font-medium">Scale</h2>
+			<p className="font-body mt-3 text-body">
+				Mantle provides a general type scale for various headers throughout our products. Do note that our text styling
+				is independent of the actual markup, so a Heading 1 can be styled as a Heading 2 or Heading 5 as appropriate.
+			</p>
+
+			<h1 className="mt-4 text-5xl font-medium">Heading 1</h1>
 			<h2 className="mt-4 text-3xl font-medium">Heading 2</h2>
 			<h3 className="mt-4 text-2xl font-medium">Heading 3</h3>
 			<h4 className="mt-4 text-xl font-medium">Heading 4</h4>
 			<h5 className="mt-4 text-base font-medium">Heading 5</h5>
 			<h6 className="mt-4 text-xs font-medium uppercase tracking-widest">Heading 6</h6>
 
-			<div className="text-strong">Strong text</div>
-			<div className="text-body">Body text</div>
-			<div className="text-muted">Muted text</div>
-			<div className="text-placeholder">Placeholder text</div>
+			<h2 className="mt-12 text-3xl font-medium">Colors</h2>
+			<p className="font-body mt-3 text-body">
+				When possible, it’s preferred to render text using the following tokens. This helps provide heirarchy outside of
+				font size, and makes sure our type is the right color across various themes.
+			</p>
+
+			<div className="mt-3 flex flex-col gap-4 overflow-hidden text-xs md:flex-row">
+				<div className="flex flex-grow flex-col gap-1 text-strong">
+					<div className="h-10 w-full rounded bg-neutral-950"></div>
+					<div className="flex items-center justify-between">
+						Strong
+						<InlineCode>.text-strong</InlineCode>
+					</div>
+				</div>
+
+				<div className="flex flex-grow flex-col gap-1">
+					<div className="h-10 w-full rounded bg-neutral-950/75"></div>
+					<div className="flex items-center justify-between">
+						<span className="text-body">Body</span>
+						<InlineCode>.text-body</InlineCode>
+					</div>
+				</div>
+
+				<div className="flex flex-grow flex-col gap-1">
+					<div className="h-10 w-full rounded bg-neutral-950/60"></div>
+					<div className="flex items-center justify-between">
+						<span className="text-muted">Muted</span>
+						<InlineCode>.text-muted</InlineCode>
+					</div>
+				</div>
+
+				<div className="flex flex-grow flex-col gap-1">
+					<div className="h-10 w-full rounded bg-neutral-950/50"></div>
+					<div className="flex items-center justify-between">
+						<span className="text-placeholder">Placeholder</span>
+						<InlineCode>.text-placeholder</InlineCode>
+					</div>
+				</div>
+			</div>
+
+			<h2 className="mt-12 text-3xl font-medium">Fonts</h2>
+			<p className="font-body mt-3 text-body">
+				Mantle specifies Euclid as the default font for UI and headings. It extends Tailwind by providing Nunito Sans as
+				a <InlineCode>font-body</InlineCode>. We also use IBM Plex Mono as a monospace typeface.
+			</p>
+
+			<div className="mt-4 overflow-hidden rounded-lg border border-card">
+				<Table>
+					<TableHeader>
+						<TableRow>
+							<TableHead>Class</TableHead>
+							<TableHead>Fonts</TableHead>
+							<TableHead>Description</TableHead>
+						</TableRow>
+					</TableHeader>
+					<TableBody className="text-xs text-body">
+						<TableRow>
+							<TableCell>
+								<InlineCode className="break-keep">font-sans</InlineCode>{" "}
+								<InlineCode className="break-keep">default</InlineCode>
+							</TableCell>
+							<TableCell className="space-y-1">
+								<p className="font-sans">Euclid Square</p>
+								<p className="font-mono">"Euclid Square", ui-sans-serif, system-ui, sans-serif</p>
+							</TableCell>
+							<TableCell>The default font for rendering UI and headings.</TableCell>
+						</TableRow>
+						<TableRow>
+							<TableCell>
+								<InlineCode className="break-keep">font-body</InlineCode>
+							</TableCell>
+							<TableCell className="space-y-1">
+								<p className="font-body">Nunito Sans</p>
+								<p className="font-mono">"Nunito Sans", ui-sans-serif, system-ui, sans-serif</p>
+							</TableCell>
+							<TableCell>Best when used in longform writing like prose documentation.</TableCell>
+						</TableRow>
+						<TableRow>
+							<TableCell>
+								<InlineCode className="break-keep">font-mono</InlineCode>
+							</TableCell>
+							<TableCell className="space-y-1">
+								<p className="font-mono">IBM Plex Mono</p>
+								<p className="font-mono">
+									"IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier
+									New", monospace
+								</p>
+							</TableCell>
+							<TableCell>
+								Used to render code and tokens. Take care to adjust the size a step down in most applications.
+							</TableCell>
+						</TableRow>
+					</TableBody>
+				</Table>
+			</div>
 		</div>
 	);
 }

--- a/app/routes/base.typography.tsx
+++ b/app/routes/base.typography.tsx
@@ -19,12 +19,12 @@ export default function Page() {
 	return (
 		<div>
 			<h1 className="text-5xl font-medium">Typography</h1>
-			<p className="font-body mt-4 text-xl text-body">
+			<p className="mt-4 font-body text-xl text-body">
 				Mantle provides various typography tokens for consistency and readability.
 			</p>
 
 			<h2 className="mt-8 text-3xl font-medium">Scale</h2>
-			<p className="font-body mt-3 text-body">
+			<p className="mt-3 font-body text-body">
 				Mantle provides a general type scale for various headers throughout our products. Do note that our text styling
 				is independent of the actual markup, so a Heading 1 can be styled as a Heading 2 or Heading 5 as appropriate.
 			</p>
@@ -37,7 +37,7 @@ export default function Page() {
 			<h6 className="mt-4 text-xs font-medium uppercase tracking-widest">Heading 6</h6>
 
 			<h2 className="mt-12 text-3xl font-medium">Colors</h2>
-			<p className="font-body mt-3 text-body">
+			<p className="mt-3 font-body text-body">
 				When possible, it’s preferred to render text using the following tokens. This helps provide heirarchy outside of
 				font size, and makes sure our type is the right color across various themes.
 			</p>
@@ -77,7 +77,7 @@ export default function Page() {
 			</div>
 
 			<h2 className="mt-12 text-3xl font-medium">Fonts</h2>
-			<p className="font-body mt-3 text-body">
+			<p className="mt-3 font-body text-body">
 				Mantle specifies Euclid as the default font for UI and headings. It extends Tailwind by providing Nunito Sans as
 				a <InlineCode>font-body</InlineCode>. We also use IBM Plex Mono as a monospace typeface.
 			</p>

--- a/app/routes/components.alert.tsx
+++ b/app/routes/components.alert.tsx
@@ -37,7 +37,7 @@ export default function Page() {
 		<div className="space-y-16">
 			<section className="space-y-4">
 				<h1 className="text-5xl font-medium">Alert</h1>
-				<p className="text-xl text-body">Displays a callout for user attention.</p>
+				<p className="font-body text-xl text-body">Displays a callout for user attention.</p>
 				<div>
 					<Example className="flex-col gap-2">
 						<Alert>
@@ -130,7 +130,7 @@ export default function Page() {
 				<h2 id="composition" className="text-3xl font-medium">
 					Composition
 				</h2>
-				<p className="text-xl text-body">
+				<p className="font-body text-xl text-body">
 					You can mix and match what you put inside the <InlineCode>Alert</InlineCode> component to create different
 					types of Alert layouts.
 				</p>
@@ -236,7 +236,7 @@ export default function Page() {
 				<h2 id="example-banner" className="text-3xl font-medium">
 					Banners
 				</h2>
-				<p className="text-xl text-body">
+				<p className="font-body text-xl text-body">
 					For banner-like alerts, set <InlineCode>rounded-none</InlineCode> on the <InlineCode>Alert</InlineCode>{" "}
 					component.
 				</p>

--- a/app/routes/components.anchor.tsx
+++ b/app/routes/components.anchor.tsx
@@ -22,9 +22,9 @@ export default function Page() {
 		<div className="space-y-8">
 			<header className="space-y-4">
 				<h1 className="text-5xl font-medium">Anchor</h1>
-				<p className="text-xl text-body">Fundamental component for rendering links to external addresses.</p>
+				<p className="font-body text-xl text-body">Fundamental component for rendering links to external addresses.</p>
 			</header>
-			<div className="space-y-4 text-body">
+			<div className="font-body space-y-4 text-body">
 				<p>
 					The <InlineCode>&lt;Anchor&gt;</InlineCode> element, with its <InlineCode>href</InlineCode> attribute, creates
 					a hyperlink to web pages, files, email addresses, locations in the same page, or anything else a URL can

--- a/app/routes/components.anchor.tsx
+++ b/app/routes/components.anchor.tsx
@@ -24,7 +24,7 @@ export default function Page() {
 				<h1 className="text-5xl font-medium">Anchor</h1>
 				<p className="font-body text-xl text-body">Fundamental component for rendering links to external addresses.</p>
 			</header>
-			<div className="font-body space-y-4 text-body">
+			<div className="space-y-4 font-body text-body">
 				<p>
 					The <InlineCode>&lt;Anchor&gt;</InlineCode> element, with its <InlineCode>href</InlineCode> attribute, creates
 					a hyperlink to web pages, files, email addresses, locations in the same page, or anything else a URL can

--- a/app/routes/components.badge.tsx
+++ b/app/routes/components.badge.tsx
@@ -36,7 +36,7 @@ export default function Page() {
 		<div className="space-y-16">
 			<section className="space-y-4">
 				<h1 className="text-5xl font-medium">Badge</h1>
-				<p className="text-xl text-body">
+				<p className="font-body text-xl text-body">
 					A Badge is a non-interactive component used to highlight important information or to visually indicate the
 					status of an item.
 				</p>
@@ -81,7 +81,7 @@ export default function Page() {
 				<h2 id="api" className="text-3xl font-medium">
 					API Reference
 				</h2>
-				<p className="text-xl text-body">
+				<p className="font-body text-xl text-body">
 					The <InlineCode>Badge</InlineCode> accepts the following props in addition to the{" "}
 					<Anchor href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/span">
 						standard HTML span attributes

--- a/app/routes/components.button.tsx
+++ b/app/routes/components.button.tsx
@@ -48,7 +48,9 @@ export default function Page() {
 				<h1 id="button" className="text-5xl font-medium">
 					Button
 				</h1>
-				<p className="text-xl text-body">Initiates an action, such as completing a task or submitting information</p>
+				<p className="font-body text-xl text-body">
+					Initiates an action, such as completing a task or submitting information
+				</p>
 				<div>
 					<Example className="flex flex-wrap gap-6">
 						<div>
@@ -161,7 +163,7 @@ export default function Page() {
 				<h2 id="example-icon" className="text-3xl font-medium">
 					Icon and Positioning
 				</h2>
-				<p className="text-xl text-body">
+				<p className="font-body text-xl text-body">
 					Use the <InlineCode>icon</InlineCode> prop to add an icon to the button. By default, it will render on the
 					logical start side of the button. Use the <InlineCode>iconPlacement</InlineCode> prop to change the side the
 					icon is rendered on.
@@ -201,7 +203,7 @@ export default function Page() {
 				<h2 id="example-loading" className="text-3xl font-medium">
 					isLoading
 				</h2>
-				<p className="text-xl text-body">
+				<p className="font-body text-xl text-body">
 					<InlineCode>isLoading</InlineCode> determines whether or not the button is in a loading state, default{" "}
 					<InlineCode>false</InlineCode>. Setting <InlineCode>isLoading</InlineCode> will replace any{" "}
 					<InlineCode>icon</InlineCode> with a spinner, or add one if an icon wasn't given. It will also disable user
@@ -284,7 +286,7 @@ export default function Page() {
 				<h2 id="composition" className="text-3xl font-medium">
 					Composition
 				</h2>
-				<p className="text-xl text-body">
+				<p className="font-body text-xl text-body">
 					When you want to render <span className="italic">something else</span> as a <InlineCode>Button</InlineCode>,
 					you can use the <InlineCode>asChild</InlineCode> prop to compose. This is useful when you want to splat the{" "}
 					<InlineCode>Button</InlineCode> styling onto a <InlineCode>Link</InlineCode> from{" "}
@@ -322,7 +324,7 @@ export default function Page() {
 				<h2 id="api" className="text-3xl font-medium">
 					API Reference
 				</h2>
-				<p className="text-xl text-body">
+				<p className="font-body text-xl text-body">
 					The <InlineCode>Button</InlineCode> accepts the following props in addition to the{" "}
 					<Anchor href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button">
 						standard HTML button attributes

--- a/app/routes/components.card.tsx
+++ b/app/routes/components.card.tsx
@@ -20,7 +20,9 @@ export default function Page() {
 	return (
 		<div className="space-y-4">
 			<h1 className="text-5xl font-medium">Card</h1>
-			<p className="text-xl text-body">A container used to display content in a box, resembling a physical card.</p>
+			<p className="font-body text-xl text-body">
+				A container used to display content in a box, resembling a physical card.
+			</p>
 
 			<div>
 				<Example>

--- a/app/routes/components.checkbox.tsx
+++ b/app/routes/components.checkbox.tsx
@@ -35,7 +35,7 @@ export default function Page() {
 		<div className="space-y-16">
 			<section className="space-y-4">
 				<h1 className="text-5xl font-medium">Checkbox</h1>
-				<p className="text-xl text-body">
+				<p className="font-body text-xl text-body">
 					A form control that allows the user to toggle between checked and not checked.
 				</p>
 				<div>
@@ -106,7 +106,7 @@ export default function Page() {
 				<h2 id="api" className="text-3xl font-medium">
 					API Reference
 				</h2>
-				<p className="text-xl text-body">
+				<p className="font-body text-xl text-body">
 					The <InlineCode>Checkbox</InlineCode> accepts the following props in addition to the{" "}
 					<Anchor href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox">
 						standard HTML checkbox input attributes

--- a/app/routes/components.code-block.tsx
+++ b/app/routes/components.code-block.tsx
@@ -33,7 +33,9 @@ export default function Page() {
 		<div className="space-y-16">
 			<section className="space-y-4">
 				<h1 className="text-5xl font-medium">Code Block</h1>
-				<p className="text-xl text-body">Code blocks render and apply syntax highlighting to blocks of code.</p>
+				<p className="font-body text-xl text-body">
+					Code blocks render and apply syntax highlighting to blocks of code.
+				</p>
 
 				<div>
 					<Example>
@@ -136,7 +138,7 @@ export default function Page() {
 				<section className="space-y-4">
 					<header className="space-y-1">
 						<h3 className="text-xl font-medium">Single Line with a Header</h3>
-						<p className="text-body">
+						<p className="font-body text-body">
 							Many code blocks will be single line command line prompts and should be able to render with a header and
 							copy button. This makes it absolutely clear that this example is a command line prompt and not a code
 							sample.
@@ -185,7 +187,7 @@ export default function Page() {
 				<section className="space-y-4">
 					<header className="space-y-1">
 						<h3 className="text-xl font-medium">Horizontal Scrolling</h3>
-						<p className="text-body">
+						<p className="font-body text-body">
 							This example is included to demonstrate that code blocks can scroll horizontally if the content is too
 							wide. Mantle attempts to normalize scrollbar styling across browsers and platforms.
 						</p>
@@ -270,7 +272,7 @@ export default function Page() {
 				<section className="space-y-4">
 					<header className="space-y-1">
 						<h3 className="text-xl font-medium">No Header or Copy Button</h3>
-						<p className="text-body">
+						<p className="font-body text-body">
 							This is the most simple example of our code block component. While very useful, the copy button is
 							optional. It is also perfectly acceptable to render a code block without a header, especially if context
 							is provided in the surrounding content or the code block is self-explanatory eg. “In your index.js file,
@@ -335,7 +337,7 @@ export default function Page() {
 				<section className="space-y-4">
 					<header className="space-y-1">
 						<h3 className="text-xl font-medium">Single Line with Horizontal Scrolling</h3>
-						<p className="text-body">
+						<p className="font-body text-body">
 							This example is included to show the interaction between the copy button and horizontal scrolling on a
 							single verbose terminal command.
 						</p>
@@ -379,7 +381,7 @@ export default function Page() {
 				<h2 id="supported-languages" className="text-3xl font-medium">
 					Supported Languages
 				</h2>
-				<p className="text-xl text-body">Mantle supports the following languages:</p>
+				<p className="font-body text-xl text-body">Mantle supports the following languages:</p>
 
 				<Card className="font-mono text-xs">
 					<CardBody>

--- a/app/routes/components.dialog.tsx
+++ b/app/routes/components.dialog.tsx
@@ -32,7 +32,7 @@ export default function Page() {
 		<div className="space-y-16">
 			<section className="space-y-4">
 				<h1 className="text-5xl font-medium">Dialog</h1>
-				<p className="text-xl text-body">
+				<p className="font-body text-xl text-body">
 					A window overlaid on either the primary window or another dialog window, rendering the content underneath
 					inert.
 				</p>

--- a/app/routes/components.dropdown-menu.tsx
+++ b/app/routes/components.dropdown-menu.tsx
@@ -58,7 +58,7 @@ export default function Page() {
 		<div className="space-y-16">
 			<section className="space-y-4">
 				<h1 className="text-5xl font-medium">Dropdown Menu</h1>
-				<p className="text-xl text-body">
+				<p className="font-body text-xl text-body">
 					Displays a menu to the user — such as a set of actions or functions — triggered by a button.
 				</p>
 				<div>
@@ -299,7 +299,7 @@ export default function Page() {
 					<h2 id="api" className="text-3xl font-medium">
 						API Reference
 					</h2>
-					<p className="text-xl text-body">
+					<p className="font-body text-xl text-body">
 						The <InlineCode>DropdownMenu</InlineCode> components are built on top of{" "}
 						<Anchor
 							href="https://www.radix-ui.com/primitives/docs/components/dropdown-menu"

--- a/app/routes/components.icon-button.tsx
+++ b/app/routes/components.icon-button.tsx
@@ -47,7 +47,7 @@ export default function Page() {
 				<h1 id="icon-button" className="text-5xl font-medium">
 					Icon Button
 				</h1>
-				<p className="text-xl text-body">
+				<p className="font-body text-xl text-body">
 					Initiates an action, such as completing a task or submitting information. Renders only a single icon as
 					children with an accessible, screen-reader-only label.
 				</p>
@@ -120,7 +120,7 @@ export default function Page() {
 				<h2 id="example-loading" className="text-3xl font-medium">
 					isLoading
 				</h2>
-				<p className="text-xl text-body">
+				<p className="font-body text-xl text-body">
 					<InlineCode>isLoading</InlineCode> determines whether or not the icon button is in a loading state, default{" "}
 					<InlineCode>false</InlineCode>. Setting <InlineCode>isLoading</InlineCode> will replace the icon with a
 					spinner. It will also disable user interaction with the button and set <InlineCode>aria-disabled</InlineCode>.
@@ -167,7 +167,7 @@ export default function Page() {
 				<h2 id="composition" className="text-3xl font-medium">
 					Composition
 				</h2>
-				<p className="text-xl text-body">
+				<p className="font-body text-xl text-body">
 					When you want to render <span className="italic">something else</span> as a{" "}
 					<InlineCode>IconButton</InlineCode>, you can use the <InlineCode>asChild</InlineCode> prop to compose. This is
 					useful when you want to splat the <InlineCode>IconButton</InlineCode> styling onto a{" "}
@@ -205,7 +205,7 @@ export default function Page() {
 				<h2 id="api" className="text-3xl font-medium">
 					API Reference
 				</h2>
-				<p className="text-xl text-body">
+				<p className="font-body text-xl text-body">
 					The <InlineCode>IconButton</InlineCode> accepts the following props in addition to the{" "}
 					<Anchor href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button">
 						standard HTML button attributes

--- a/app/routes/components.icon.tsx
+++ b/app/routes/components.icon.tsx
@@ -72,7 +72,7 @@ export default function Page() {
 					The <InlineCode>Icon</InlineCode> merges <InlineCode>className</InlineCode> selectors with the following order
 					of precedence (last one wins):
 				</p>
-				<ol className="font-body ml-8 list-decimal text-body">
+				<ol className="ml-8 list-decimal font-body text-body">
 					<li>Icon base classes</li>
 					<li>svg className</li>
 					<li>Icon className</li>

--- a/app/routes/components.icon.tsx
+++ b/app/routes/components.icon.tsx
@@ -37,7 +37,7 @@ export default function Page() {
 				<h1 id="icon" className="text-5xl font-medium">
 					Icon
 				</h1>
-				<p className="text-xl text-body">
+				<p className="font-body text-xl text-body">
 					Decorates an svg icon with automatic sizing. Useful when applying base styles to{" "}
 					<Anchor href="https://phosphoricons.com">phosphor icons</Anchor>.
 				</p>
@@ -68,11 +68,11 @@ export default function Page() {
 				<h2 id="example-class-name" className="text-3xl font-medium">
 					Merging <InlineCode>className</InlineCode>s
 				</h2>
-				<p className="text-xl text-body">
+				<p className="font-body text-xl text-body">
 					The <InlineCode>Icon</InlineCode> merges <InlineCode>className</InlineCode> selectors with the following order
 					of precedence (last one wins):
 				</p>
-				<ol className="ml-8 list-decimal text-body">
+				<ol className="font-body ml-8 list-decimal text-body">
 					<li>Icon base classes</li>
 					<li>svg className</li>
 					<li>Icon className</li>
@@ -128,7 +128,7 @@ export default function Page() {
 				<h2 id="api" className="text-3xl font-medium">
 					API Reference
 				</h2>
-				<p className="text-xl text-body">
+				<p className="font-body text-xl text-body">
 					The <InlineCode>Icon</InlineCode> accepts the following props:
 				</p>
 				<PropsTable>

--- a/app/routes/components.inline-code.tsx
+++ b/app/routes/components.inline-code.tsx
@@ -20,7 +20,7 @@ export default function Page() {
 	return (
 		<div className="space-y-4">
 			<h1 className="text-5xl font-medium">Inline Code</h1>
-			<p className="text-xl text-body">Marks text to signify a short fragment of inline computer code.</p>
+			<p className="font-body text-xl text-body">Marks text to signify a short fragment of inline computer code.</p>
 
 			<div>
 				<Example>

--- a/app/routes/components.input.tsx
+++ b/app/routes/components.input.tsx
@@ -48,7 +48,7 @@ export default function Page() {
 				<h1 id="input" className="text-5xl font-medium">
 					Input
 				</h1>
-				<p className="text-xl text-body">Fundamental component for inputs.</p>
+				<p className="font-body text-xl text-body">Fundamental component for inputs.</p>
 				<div>
 					<Example className="flex flex-col gap-6">
 						<Label className="block w-full max-w-80 space-y-1">
@@ -96,7 +96,7 @@ export default function Page() {
 				<h2 id="composition" className="text-3xl font-medium">
 					Composition
 				</h2>
-				<p className="text-xl text-body">
+				<p className="font-body text-xl text-body">
 					You can compose additional visual or functional elements within the <InlineCode>Input</InlineCode> using{" "}
 					<InlineCode>children</InlineCode>. The examples below show you how to render start and end icons or buttons.
 					The{" "}
@@ -108,7 +108,7 @@ export default function Page() {
 					actual form <InlineCode>input</InlineCode> element! We provide an <InlineCode>InputCapture</InlineCode>{" "}
 					component for you when you don't use the <InlineCode>children</InlineCode> API.
 				</p>
-				<p className="text-xl text-body">
+				<p className="font-body text-xl text-body">
 					Note: when composing with interactive content (e.g. a <InlineCode>button</InlineCode>), you will need to
 					consider whether or not that element should be tab-indexable or receive focus!
 				</p>
@@ -225,7 +225,7 @@ export default function Page() {
 				<h2 id="api" className="text-3xl font-medium">
 					API Reference
 				</h2>
-				<p className="text-xl text-body">
+				<p className="font-body text-xl text-body">
 					The <InlineCode>Input</InlineCode> accepts the following props in addition to the{" "}
 					<Anchor href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input">
 						standard HTML input attributes

--- a/app/routes/components.label.tsx
+++ b/app/routes/components.label.tsx
@@ -22,7 +22,7 @@ export default function Page() {
 		<div className="space-y-16">
 			<section className="space-y-4">
 				<h1 className="text-5xl font-medium">Label</h1>
-				<p className="text-xl text-body">Renders an accessible label associated with controls.</p>
+				<p className="font-body text-xl text-body">Renders an accessible label associated with controls.</p>
 				<div>
 					<Example className="grid gap-6">
 						<Label htmlFor="name">
@@ -64,7 +64,7 @@ export default function Page() {
 				<h2 id="composition" className="text-3xl font-medium">
 					Composition
 				</h2>
-				<p className="text-xl text-body">
+				<p className="text-xl text-body font-body">
 					When you want to render <span className="italic">something else</span> as a <InlineCode>Button</InlineCode>,
 					you can use the <InlineCode>asChild</InlineCode> prop to compose. This is useful when you want to splat the{" "}
 					<InlineCode>Button</InlineCode> styling onto a <InlineCode>Link</InlineCode> from{" "}
@@ -102,7 +102,7 @@ export default function Page() {
 				<h2 id="api" className="text-3xl font-medium">
 					API Reference
 				</h2>
-				<p className="text-xl text-body">
+				<p className="text-xl text-body font-body">
 					The <InlineCode>Button</InlineCode> accepts the following props in addition to the{" "}
 					<Anchor href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button">
 						standard HTML button attributes

--- a/app/routes/components.media-object.tsx
+++ b/app/routes/components.media-object.tsx
@@ -22,13 +22,13 @@ export default function Page() {
 		<div className="space-y-8">
 			<header className="space-y-4">
 				<h1 className="text-5xl font-medium">Media Object</h1>
-				<p className="font-body my-4 text-xl text-body">
+				<p className="my-4 font-body text-xl text-body">
 					The Media Object is an image/icon (media) to the left, with descriptive content (title and
 					subtitle/description) to the right.
 				</p>
 			</header>
 
-			<section className="font-body space-y-4 text-body">
+			<section className="space-y-4 font-body text-body">
 				<p>
 					Change the spacing between the media and content by passing a <InlineCode>gap-*</InlineCode> class. The
 					default <InlineCode>gap</InlineCode> is <InlineCode>gap-4</InlineCode>.

--- a/app/routes/components.media-object.tsx
+++ b/app/routes/components.media-object.tsx
@@ -22,13 +22,13 @@ export default function Page() {
 		<div className="space-y-8">
 			<header className="space-y-4">
 				<h1 className="text-5xl font-medium">Media Object</h1>
-				<p className="my-4 text-xl text-body">
+				<p className="font-body my-4 text-xl text-body">
 					The Media Object is an image/icon (media) to the left, with descriptive content (title and
 					subtitle/description) to the right.
 				</p>
 			</header>
 
-			<section className="space-y-4 text-body">
+			<section className="font-body space-y-4 text-body">
 				<p>
 					Change the spacing between the media and content by passing a <InlineCode>gap-*</InlineCode> class. The
 					default <InlineCode>gap</InlineCode> is <InlineCode>gap-4</InlineCode>.

--- a/app/routes/components.password-input.tsx
+++ b/app/routes/components.password-input.tsx
@@ -57,7 +57,7 @@ export default function Page() {
 				<h1 id="password-input" className="text-5xl font-medium">
 					Password Input
 				</h1>
-				<p className="text-xl text-body">Fundamental component for password inputs.</p>
+				<p className="font-body text-xl text-body">Fundamental component for password inputs.</p>
 				<div>
 					<Example className="flex-col gap-4">
 						<Label className="block w-full max-w-64 space-y-1">
@@ -98,7 +98,7 @@ export default function Page() {
 				<h2 id="api" className="text-3xl font-medium">
 					API Reference
 				</h2>
-				<p className="text-xl text-body">
+				<p className="font-body text-xl text-body">
 					The <InlineCode>PasswordInput</InlineCode> accepts the following props in addition to the{" "}
 					<Anchor href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input">
 						standard HTML input attributes

--- a/app/routes/components.preview.calendar.tsx
+++ b/app/routes/components.preview.calendar.tsx
@@ -117,7 +117,7 @@ export default function Page() {
 					</h1>
 					<PreviewBadge />
 				</div>
-				<p className="text-xl text-body">A date field component that allows users to enter and edit date.</p>
+				<p className="font-body text-xl text-body">A date field component that allows users to enter and edit date.</p>
 				<div>
 					<Example className="flex flex-col gap-6">
 						<div className="space-y-2">
@@ -168,7 +168,7 @@ export default function Page() {
 				<h2 id="api" className="text-3xl font-medium">
 					API Reference
 				</h2>
-				<p className="text-xl text-body">
+				<p className="font-body text-xl text-body">
 					The <InlineCode>Calendar</InlineCode> is built on top of{" "}
 					<Anchor href="https://react-day-picker.js.org/">React DayPicker</Anchor>.
 				</p>

--- a/app/routes/components.preview.popover.tsx
+++ b/app/routes/components.preview.popover.tsx
@@ -26,7 +26,7 @@ export default function Page() {
 				<h1 className="text-5xl font-medium">Popover</h1>
 				<PreviewBadge />
 			</div>
-			<p className="text-xl text-body">Displays rich content in a portal, triggered by a button.</p>
+			<p className="font-body text-xl text-body">Displays rich content in a portal, triggered by a button.</p>
 			<div>
 				<Example className="gap-2">
 					<Popover>

--- a/app/routes/components.preview.tooltip.tsx
+++ b/app/routes/components.preview.tooltip.tsx
@@ -25,7 +25,7 @@ export default function Page() {
 				<h1 className="text-5xl font-medium">Tooltip</h1>
 				<PreviewBadge />
 			</div>
-			<p className="text-xl text-body">
+			<p className="font-body text-xl text-body">
 				A popup that displays information related to an element when the element receives keyboard focus or the mouse
 				hovers over it.
 			</p>

--- a/app/routes/components.progress-donut.tsx
+++ b/app/routes/components.progress-donut.tsx
@@ -34,10 +34,10 @@ export default function Page() {
 		<div className="space-y-16">
 			<div className="space-y-4">
 				<h1 className="text-5xl font-medium">Progress Donut</h1>
-				<p className="text-xl text-body">
+				<p className="font-body text-xl text-body">
 					Displays an indicator showing the completion progress of a task as a circular progress bar.
 				</p>
-				<p className="text-xl text-body">
+				<p className="font-body text-xl text-body">
 					The indicator color is inherited via <InlineCode>currentColor</InlineCode>. Override the default (
 					<InlineCode>accent-600</InlineCode>) by setting the
 					<InlineCode>ProgressDonutIndicator</InlineCode>'s text color.
@@ -131,7 +131,7 @@ export default function Page() {
 				<h2 id="indeterminate" className="text-3xl font-medium">
 					Indeterminate Value
 				</h2>
-				<p className="text-xl text-body">
+				<p className="font-body text-xl text-body">
 					You can set the <InlineCode>value</InlineCode> prop to <InlineCode>"indeterminate"</InlineCode> to show the
 					progress bar in an indeterminate state.
 				</p>
@@ -162,7 +162,7 @@ export default function Page() {
 				<h2 id="dynamic-colors" className="text-3xl font-medium">
 					Dynamic Colors
 				</h2>
-				<p className="text-xl text-body">
+				<p className="font-body text-xl text-body">
 					The color of the <InlineCode>ProgressDonutIndicator</InlineCode> is inherited from the parent text color using{" "}
 					<InlineCode>currentColor</InlineCode>. Using this, you can easily change the color of it based on the current
 					progress value.
@@ -222,7 +222,7 @@ export default function Page() {
 				<h2 id="api" className="text-3xl font-medium">
 					API Reference
 				</h2>
-				<p className="text-xl text-body">
+				<p className="font-body text-xl text-body">
 					The <InlineCode>ProgressDonut</InlineCode> accepts the following props in addition to the{" "}
 					<Anchor href="https://developer.mozilla.org/en-US/docs/Web/SVG/Element/svg#attributes">
 						standard HTML svg attributes

--- a/app/routes/components.radio-group.tsx
+++ b/app/routes/components.radio-group.tsx
@@ -31,7 +31,7 @@ export default function Page() {
 		<div className="space-y-16">
 			<section className="space-y-4">
 				<h1 className="text-5xl font-medium">Radio Group</h1>
-				<p className="text-xl text-body">
+				<p className="font-body text-xl text-body">
 					A set of checkable buttons—known as radio buttons—where no more than one of the buttons can be checked at a
 					time.
 				</p>
@@ -277,7 +277,7 @@ export default function Page() {
 				<h2 id="composition" className="text-3xl font-medium">
 					Composition
 				</h2>
-				<p className="text-xl text-body">
+				<p className="text-xl font-body">
 					When you want to render <span className="italic">something else</span> as a <InlineCode>Button</InlineCode>,
 					you can use the <InlineCode>asChild</InlineCode> prop to compose. This is useful when you want to splat the{" "}
 					<InlineCode>Button</InlineCode> styling onto a <InlineCode>Link</InlineCode> from{" "}

--- a/app/routes/components.select.tsx
+++ b/app/routes/components.select.tsx
@@ -47,7 +47,9 @@ export default function Page() {
 		<div className="space-y-16">
 			<section className="space-y-4">
 				<h1 className="text-5xl font-medium">Select</h1>
-				<p className="text-xl text-body">Displays a list of options for the user to pick from—triggered by a button.</p>
+				<p className="font-body text-xl text-body">
+					Displays a list of options for the user to pick from—triggered by a button.
+				</p>
 
 				<div>
 					<Example className="flex-col gap-4">
@@ -222,7 +224,7 @@ export default function Page() {
 				<section className="space-y-4">
 					<header className="space-y-1">
 						<h3 className="text-xl font-medium">Custom selected value</h3>
-						<p className="text-body">
+						<p className="font-body text-body">
 							By default the selected item's text will be rendered when selected. Sometimes you may need to render
 							something different. You can control the select and pass <InlineCode>children</InlineCode> instead.
 						</p>
@@ -279,7 +281,7 @@ export default function Page() {
 					<h2 id="api" className="text-3xl font-medium">
 						API Reference
 					</h2>
-					<p className="text-xl text-body">
+					<p className="font-body text-xl text-body">
 						The <InlineCode>Select</InlineCode> components are built on top of{" "}
 						<Anchor
 							href="https://www.radix-ui.com/primitives/docs/components/select"
@@ -296,7 +298,7 @@ export default function Page() {
 					<header className="space-y-1">
 						<h3 className="text-xl font-medium">Select</h3>
 
-						<p className="text-body">
+						<p className="font-body text-body">
 							All props from Radix{" "}
 							<Anchor
 								href="https://www.radix-ui.com/primitives/docs/components/select#root"
@@ -366,7 +368,7 @@ export default function Page() {
 					<header className="space-y-1">
 						<h3 className="text-xl font-medium">SelectTrigger</h3>
 
-						<p className="text-body">
+						<p className="font-body text-body">
 							All props from Radix{" "}
 							<Anchor
 								href="https://www.radix-ui.com/primitives/docs/components/select#trigger"
@@ -423,7 +425,7 @@ export default function Page() {
 				<section className="space-y-1">
 					<h3 className="text-xl font-medium">SelectValue</h3>
 
-					<p className="text-body">
+					<p className="font-body text-body">
 						Radix{" "}
 						<Anchor
 							href="https://www.radix-ui.com/primitives/docs/components/select#value"
@@ -440,7 +442,7 @@ export default function Page() {
 					<header className="space-y-1">
 						<h3 className="text-xl font-medium">SelectContent</h3>
 
-						<p className="text-body">
+						<p className="font-body text-body">
 							All props from Radix{" "}
 							<Anchor
 								href="https://www.radix-ui.com/primitives/docs/components/select#content"
@@ -482,7 +484,7 @@ export default function Page() {
 				<section className="space-y-1">
 					<h3 className="text-xl font-medium">SelectGroup</h3>
 
-					<p className="text-body">
+					<p className="font-body text-body">
 						Radix{" "}
 						<Anchor
 							href="https://www.radix-ui.com/primitives/docs/components/select#group"
@@ -498,7 +500,7 @@ export default function Page() {
 				<section className="space-y-1">
 					<h3 className="text-xl font-medium">SelectSeparator</h3>
 
-					<p className="text-body">
+					<p className="font-body text-body">
 						Used to visually separate items in the select. Composed from{" "}
 						<Link to="/components/separator">Mantle Separator</Link>.
 					</p>
@@ -507,7 +509,7 @@ export default function Page() {
 				<section className="space-y-1">
 					<h3 className="text-xl font-medium">SelectItem</h3>
 
-					<p className="text-body">
+					<p className="font-body text-body">
 						Radix{" "}
 						<Anchor
 							href="https://www.radix-ui.com/primitives/docs/components/select#item"
@@ -523,7 +525,7 @@ export default function Page() {
 				<section className="space-y-1">
 					<h3 className="text-xl font-medium">SelectLabel</h3>
 
-					<p className="text-body">
+					<p className="font-body text-body">
 						Radix{" "}
 						<Anchor
 							href="https://www.radix-ui.com/primitives/docs/components/select#label"
@@ -539,7 +541,7 @@ export default function Page() {
 				<section className="space-y-1">
 					<h3 className="text-xl font-medium">SelectScrollUpButton</h3>
 
-					<p className="text-body">
+					<p className="font-body text-body">
 						Radix{" "}
 						<Anchor
 							href="https://www.radix-ui.com/primitives/docs/components/select#scrollupbutton"
@@ -555,7 +557,7 @@ export default function Page() {
 				<section className="space-y-1">
 					<h3 className="text-xl font-medium">SelectScrollDownButton</h3>
 
-					<p className="text-body">
+					<p className="font-body text-body">
 						Radix{" "}
 						<Anchor
 							href="https://www.radix-ui.com/primitives/docs/components/select#scrolldownbutton"

--- a/app/routes/components.separator.tsx
+++ b/app/routes/components.separator.tsx
@@ -21,7 +21,7 @@ export default function Page() {
 		<div className="space-y-16">
 			<section className="space-y-4">
 				<h1 className="text-5xl font-medium">Separator</h1>
-				<p className="text-xl text-body">Visually or semantically separates content.</p>
+				<p className="font-body text-xl text-body">Visually or semantically separates content.</p>
 				<div>
 					<Example>
 						<div className="space-y-4">

--- a/app/routes/components.sheet.tsx
+++ b/app/routes/components.sheet.tsx
@@ -38,7 +38,7 @@ export default function Page() {
 	return (
 		<div className="space-y-4">
 			<h1 className="text-5xl font-medium">Sheet</h1>
-			<p className="text-xl text-body">
+			<p className="font-body text-xl text-body">
 				A container that overlays the current view from the edge of the screen. It is a lightweight way of allowing
 				users to complete a task without losing contextual information of the view beneath it.
 			</p>

--- a/app/routes/components.skeleton.tsx
+++ b/app/routes/components.skeleton.tsx
@@ -24,7 +24,7 @@ export default function Page() {
 		<div className="space-y-16">
 			<section className="space-y-4">
 				<h1 className="text-5xl font-medium">Skeleton</h1>
-				<p className="font-body mt-4 text-xl text-body">
+				<p className="mt-4 font-body text-xl text-body">
 					Use to show a placeholder while content is loading. By using a <InlineCode>Skeleton</InlineCode>, you can give
 					the user an idea of what the content will look like, reducing the perceived loading time and CLS (Cumulative
 					Layout Shift).
@@ -54,7 +54,7 @@ export default function Page() {
 					<h3 className="text-xl font-medium">
 						Skeleton <Link to="/components/media-object">Media Object</Link>
 					</h3>
-					<p className="font-body mt-1 text-body">
+					<p className="mt-1 font-body text-body">
 						The Skeleton component can be included within components. You can also pass Tailwind utility classes for
 						further control.
 					</p>

--- a/app/routes/components.skeleton.tsx
+++ b/app/routes/components.skeleton.tsx
@@ -24,7 +24,7 @@ export default function Page() {
 		<div className="space-y-16">
 			<section className="space-y-4">
 				<h1 className="text-5xl font-medium">Skeleton</h1>
-				<p className="mt-4 text-xl text-body">
+				<p className="font-body mt-4 text-xl text-body">
 					Use to show a placeholder while content is loading. By using a <InlineCode>Skeleton</InlineCode>, you can give
 					the user an idea of what the content will look like, reducing the perceived loading time and CLS (Cumulative
 					Layout Shift).
@@ -54,7 +54,7 @@ export default function Page() {
 					<h3 className="text-xl font-medium">
 						Skeleton <Link to="/components/media-object">Media Object</Link>
 					</h3>
-					<p className="mt-1 text-body">
+					<p className="font-body mt-1 text-body">
 						The Skeleton component can be included within components. You can also pass Tailwind utility classes for
 						further control.
 					</p>

--- a/app/routes/components.switch.tsx
+++ b/app/routes/components.switch.tsx
@@ -22,7 +22,9 @@ export default function Page() {
 		<div className="space-y-16">
 			<section className="space-y-4">
 				<h1 className="text-5xl font-medium">Switch</h1>
-				<p className="text-xl text-body">A control that allows the user to toggle between checked and not checked.</p>
+				<p className="font-body text-xl text-body">
+					A control that allows the user to toggle between checked and not checked.
+				</p>
 				<div>
 					<Example className="mt-4 grid gap-6">
 						<Label
@@ -85,7 +87,7 @@ export default function Page() {
 				<h2 id="composition" className="text-3xl font-medium">
 					Composition
 				</h2>
-				<p className="text-xl text-body">
+				<p className="text-xl text-body font-body">
 					When you want to render <span className="italic">something else</span> as a <InlineCode>Button</InlineCode>,
 					you can use the <InlineCode>asChild</InlineCode> prop to compose. This is useful when you want to splat the{" "}
 					<InlineCode>Button</InlineCode> styling onto a <InlineCode>Link</InlineCode> from{" "}
@@ -123,7 +125,7 @@ export default function Page() {
 				<h2 id="api" className="text-3xl font-medium">
 					API Reference
 				</h2>
-				<p className="text-xl text-body">
+				<p className="text-xl text-body font-body">
 					The <InlineCode>Button</InlineCode> accepts the following props in addition to the{" "}
 					<Anchor href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button">
 						standard HTML button attributes

--- a/app/routes/components.table.tsx
+++ b/app/routes/components.table.tsx
@@ -20,7 +20,7 @@ export default function Page() {
 	return (
 		<section className="space-y-4">
 			<h1 className="text-5xl font-medium">Table</h1>
-			<p className="text-xl text-body">A responsive table component.</p>
+			<p className="font-body text-xl text-body">A responsive table component.</p>
 			<div>
 				<Example className="gap-2">
 					<ExampleTable />

--- a/app/routes/components.tabs.tsx
+++ b/app/routes/components.tabs.tsx
@@ -27,7 +27,7 @@ export default function Page() {
 		<div className="space-y-16">
 			<section className="space-y-4">
 				<h1 className="text-5xl font-medium">Tabs</h1>
-				<p className="text-xl text-body">
+				<p className="font-body text-xl text-body">
 					A set of layered sections of content—known as tab panels—that are displayed one at a time.
 				</p>
 				<div>
@@ -290,7 +290,7 @@ export default function Page() {
 				<h2 id="composition" className="text-3xl font-medium">
 					Composition
 				</h2>
-				<p className="text-xl text-body">
+				<p className="text-xl text-body font-body">
 					When you want to render <span className="italic">something else</span> as a <InlineCode>Button</InlineCode>,
 					you can use the <InlineCode>asChild</InlineCode> prop to compose. This is useful when you want to splat the{" "}
 					<InlineCode>Button</InlineCode> styling onto a <InlineCode>Link</InlineCode> from{" "}
@@ -328,7 +328,7 @@ export default function Page() {
 				<h2 id="api" className="text-3xl font-medium">
 					API Reference
 				</h2>
-				<p className="text-xl text-body">
+				<p className="text-xl text-body font-body">
 					The <InlineCode>Button</InlineCode> accepts the following props in addition to the{" "}
 					<Anchor href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button">
 						standard HTML button attributes

--- a/app/routes/components.text-area.tsx
+++ b/app/routes/components.text-area.tsx
@@ -46,7 +46,9 @@ export default function Page() {
 				<h1 id="textarea" className="text-5xl font-medium">
 					TextArea
 				</h1>
-				<p className="text-xl text-body">Displays a form textarea or a component that looks like a textarea.</p>
+				<p className="font-body text-xl text-body">
+					Displays a form textarea or a component that looks like a textarea.
+				</p>
 
 				<div>
 					<Example className="grid grid-cols-2 gap-6">
@@ -109,7 +111,7 @@ export default function Page() {
 				<h2 id="api" className="text-3xl font-medium">
 					API Reference
 				</h2>
-				<p className="text-xl text-body">
+				<p className="font-body text-xl text-body">
 					The <InlineCode>TextArea</InlineCode> accepts the following props in addition to the{" "}
 					<Anchor href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea">
 						standard HTML textarea attributes

--- a/app/routes/components.theme-provider.tsx
+++ b/app/routes/components.theme-provider.tsx
@@ -37,7 +37,7 @@ export default function Page() {
 					change it.
 				</p>
 			</header>
-			<section className="font-body space-y-4 text-body">
+			<section className="space-y-4 font-body text-body">
 				<p>
 					To use the <InlineCode>ThemeProvider</InlineCode>, wrap your application&apos;s entry point. This should be
 					done as high in the component tree as possible.

--- a/app/routes/components.theme-provider.tsx
+++ b/app/routes/components.theme-provider.tsx
@@ -32,12 +32,12 @@ export default function Page() {
 		<div className="space-y-8">
 			<header className="space-y-4">
 				<h1 className="text-5xl font-medium">Theme Provider</h1>
-				<p className="text-xl text-body">
+				<p className="font-body text-xl text-body">
 					ThemeProvider is a React Context Provider that provides the current theme to the application and a function to
 					change it.
 				</p>
 			</header>
-			<section className="space-y-4 text-body">
+			<section className="font-body space-y-4 text-body">
 				<p>
 					To use the <InlineCode>ThemeProvider</InlineCode>, wrap your application&apos;s entry point. This should be
 					done as high in the component tree as possible.
@@ -87,7 +87,7 @@ export default function Page() {
 				</CodeBlock>
 			</section>
 			<section className="space-y-4">
-				<p className="text-body">
+				<p className="font-body text-body">
 					Sometimes you cannot use the <InlineCode>MantleThemeHeadContent</InlineCode> component because your webserver
 					is not able to render React components. In this case, you can use the copy the following script and add it to
 					your application&apos;s <InlineCode>&lt;head&gt;</InlineCode>:
@@ -111,7 +111,7 @@ ${preventWrongThemeFlashScriptContent({ defaultTheme: "system" })}
 				</CodeBlock>
 			</section>
 			<section className="space-y-4">
-				<p className="text-body">
+				<p className="font-body text-body">
 					You will also need to ensure that you add the <InlineCode>PreloadFonts</InlineCode> component to your app as
 					well.
 				</p>
@@ -132,7 +132,7 @@ ${preventWrongThemeFlashScriptContent({ defaultTheme: "system" })}
 				</CodeBlock>
 			</section>
 			<section className="space-y-4">
-				<p className="text-body">
+				<p className="font-body text-body">
 					Then, in your application, you can use the <InlineCode>useTheme</InlineCode> hook to get and change the
 					current theme:
 				</p>

--- a/assets/mantle.css
+++ b/assets/mantle.css
@@ -1,4 +1,5 @@
 @import url("https://cdn.ngrok.com/static/fonts/fonts.css");
+@import url('https://fonts.googleapis.com/css2?family=Nunito+Sans:ital,opsz,wght@0,6..12,200..1000;1,6..12,200..1000&display=swap');
 
 @tailwind base;
 @tailwind components;

--- a/assets/mantle.css
+++ b/assets/mantle.css
@@ -1,4 +1,6 @@
 @import url("https://cdn.ngrok.com/static/fonts/fonts.css");
+
+/* TODO: Host this on our CDN */
 @import url('https://fonts.googleapis.com/css2?family=Nunito+Sans:ital,opsz,wght@0,6..12,200..1000;1,6..12,200..1000&display=swap');
 
 @tailwind base;

--- a/assets/mantle.css
+++ b/assets/mantle.css
@@ -1,7 +1,7 @@
 @import url("https://cdn.ngrok.com/static/fonts/fonts.css");
 
 /* TODO: Host this on our CDN */
-@import url('https://fonts.googleapis.com/css2?family=Nunito+Sans:ital,opsz,wght@0,6..12,200..1000;1,6..12,200..1000&display=swap');
+@import url("https://fonts.googleapis.com/css2?family=Nunito+Sans:ital,opsz,wght@0,6..12,200..1000;1,6..12,200..1000&display=swap");
 
 @tailwind base;
 @tailwind components;

--- a/packages/tailwind-preset/src/tailwind.preset.ts
+++ b/packages/tailwind-preset/src/tailwind.preset.ts
@@ -442,6 +442,7 @@ const mantlePreset = {
 			fontFamily: {
 				sans: ["EuclidSquare", ...defaultTheme.fontFamily.sans],
 				mono: ["IBMPlexMono", ...defaultTheme.fontFamily.mono],
+				body: ["Nunito Sans", ...defaultTheme.fontFamily.sans],
 			},
 			fontSize: {
 				"size-inherit": "inherit",


### PR DESCRIPTION
We've had feedback over the years that EuclidSquare can be a little tricky to read on longform content. We've experimented with a few options, so let's see how the most popular one, Nunito Sans, fares on our Mantle documentation.