### PR TITLE
Remove devenv warning

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,3 +1,8 @@
+# hide warnings from direnv
+# see https://github.com/direnv/direnv/issues/419#issuecomment-442005962
+# see: https://direnv.net/man/direnv.toml.1.html#codewarntimeoutcode
+export DIRENV_WARN_TIMEOUT=876000h
+
 export NVM_DIR="$HOME/.nvm"
 
 # Check if nvm is installed, install if not
@@ -28,6 +33,3 @@ pnpm install
 
 pnpm_version=$(pnpm --version)
 echo -e "\nEnvironment is ready.\nUsing pnpm version: $pnpm_version\n"
-
-# hide warnings from direnv
-export DIRENV_WARN_TIMEOUT=0s

--- a/.envrc
+++ b/.envrc
@@ -28,3 +28,6 @@ pnpm install
 
 pnpm_version=$(pnpm --version)
 echo -e "\nEnvironment is ready.\nUsing pnpm version: $pnpm_version\n"
+
+# hide warnings from direnv
+export DIRENV_WARN_TIMEOUT=0s


### PR DESCRIPTION
This PR removes `direnv: ([/opt/homebrew/bin/direnv export zsh]) is taking a while to execute. Use CTRL-C to give up.` from the console.