### PR TITLE
Allow `pnpm start` to run development mode by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "node": ">=20.0.0"
   },
   "scripts": {
+    "start": "pnpm run docs:dev",
     "build": "rm -rf dist && NODE_OPTIONS='--max-old-space-size=16384' tsup",
     "docs:build": "remix build",
     "docs:dev": "remix dev --manual",


### PR DESCRIPTION
Sometimes it's really nice to just run `pnpm start` and it does what you want 99% of the time.