### PR TITLE
Extend preflight to make `fieldset` behave like regular block element

### DIFF
--- a/assets/mantle.css
+++ b/assets/mantle.css
@@ -1495,6 +1495,10 @@
 	th {
 		text-align: inherit;
 	}
+
+	fieldset {
+		min-width: 0;
+	}
 }
 
 @layer utilities {


### PR DESCRIPTION
[It's been flagged as a problem for a while](https://github.com/tailwindlabs/tailwindcss/discussions/8976) and I have indeed run into children spilling out of the fieldset (not just with `truncation` class).