### PR TITLE
fix: tailwind preset type declarations wiped out

### DIFF
--- a/packages/mantle/package.json
+++ b/packages/mantle/package.json
@@ -3,7 +3,7 @@
   "description": "mantle is ngrok's UI library and design system.",
   "author": "ngrok",
   "license": "MIT",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "homepage": "https://mantle.ngrok.com",
   "repository": {
     "type": "git",
@@ -26,14 +26,14 @@
   },
   "scripts": {
     "build": "NODE_OPTIONS='--max-old-space-size=16384' tsup",
-    "dev": "NODE_OPTIONS='--max-old-space-size=16384' tsup --watch",
-    "lint": "eslint .",
-    "test": "TZ=UTC vitest run",
-    "test:watch": "TZ=UTC vitest watch",
-    "test:ui": "TZ=UTC vitest --ui",
-    "typecheck": "tsc",
     "clean": "rm -rf dist",
-    "prepublishOnly": "pnpm run build"
+    "lint": "eslint .",
+    "prebuild": "rm -rf dist",
+    "prepublishOnly": "pnpm run build",
+    "test:ui": "TZ=UTC vitest --ui",
+    "test:watch": "TZ=UTC vitest watch",
+    "test": "TZ=UTC vitest run",
+    "typecheck": "tsc"
   },
   "dependencies": {
     "@headlessui/react": "2.1.5",

--- a/packages/mantle/tsup.config.ts
+++ b/packages/mantle/tsup.config.ts
@@ -40,7 +40,9 @@ const utilPackages = allUtils.reduce<Record<string, string>>((acc, name) => {
 
 const commonOptions = {
 	dts: true,
-	clean: true,
+	// if we set this to true, it will "race" between the two builds and wipe away type declarations
+	// for one of the builds. rm -rf dist is run as a "prebuild" script to avoid this issue
+	clean: false,
 	external: ["@phosphor-icons/react", "react", "react-dom", "tailwindcss", "zod"],
 	minify: true,
 	sourcemap: true,


### PR DESCRIPTION
This was a miss from #320, my b!

https://arethetypeswrong.github.io/?p=%40ngrok%2Fmantle%400.2.0

![image](https://github.com/user-attachments/assets/226e66f9-f7ee-48f9-911f-066b97ee4e72)

we don't want to use `clean: true` in `tsup` because it introduces a race condition :( 

https://www.loom.com/share/554049cd8b484089b2bc6c989d2b287e

