### PR TITLE
Add transparent background on `InputCapture`

### DIFF
--- a/packages/mantle/src/components/input/input.tsx
+++ b/packages/mantle/src/components/input/input.tsx
@@ -62,7 +62,7 @@ const InputCapture = forwardRef<HTMLInputElement, InputCaptureProps>(
 				<input
 					aria-invalid={ariaInvalid}
 					data-validation={validation || undefined}
-					className={cx("bg-form placeholder:text-placeholder w-full focus:outline-none", className)}
+					className={cx("placeholder:text-placeholder w-full bg-transparent focus:outline-none", className)}
 					ref={composeRefs(ref, ctxForwardedRef, ctxInnerRef)}
 					{...props}
 				/>


### PR DESCRIPTION
Allows for changing the background color of `<Input>`. Fixes this visual glitch when you try to change the color (using red as an example):

<img width="346" alt="Screenshot 2024-10-17 at 3 13 00 PM" src="https://github.com/user-attachments/assets/4794a718-a663-4cd7-a428-a2458baa7114">
