### PR TITLE
Add a sensible max-width to tooltips

### DIFF
--- a/apps/www/app/routes/components.preview.tooltip.tsx
+++ b/apps/www/app/routes/components.preview.tooltip.tsx
@@ -35,11 +35,11 @@ export default function Page() {
 						<Tooltip>
 							<TooltipTrigger asChild>
 								<Button type="button" appearance="filled" priority="default">
-									Hover
+									Add to library
 								</Button>
 							</TooltipTrigger>
 							<TooltipContent>
-								<p>Add to library</p>
+								<p>This feature is part of your plan</p>
 							</TooltipContent>
 						</Tooltip>
 					</TooltipProvider>

--- a/packages/mantle/src/components/tooltip/tooltip.tsx
+++ b/packages/mantle/src/components/tooltip/tooltip.tsx
@@ -52,7 +52,7 @@ const TooltipContent = forwardRef<ElementRef<typeof Content>, ComponentPropsWith
 			ref={ref}
 			sideOffset={sideOffset}
 			className={cx(
-				"bg-tooltip text-tooltip animate-in fade-in-0 zoom-in-95 data-side-bottom:slide-in-from-top-2 data-side-left:slide-in-from-right-2 data-side-right:slide-in-from-left-2 data-side-top:slide-in-from-bottom-2 data-state-closed:animate-out data-state-closed:fade-out-0 data-state-closed:zoom-out-95 z-50 overflow-hidden rounded-md px-3 py-1.5 text-sm shadow",
+				"bg-tooltip text-tooltip animate-in fade-in-0 zoom-in-95 data-side-bottom:slide-in-from-top-2 data-side-left:slide-in-from-right-2 data-side-right:slide-in-from-left-2 data-side-top:slide-in-from-bottom-2 data-state-closed:animate-out data-state-closed:fade-out-0 data-state-closed:zoom-out-95 z-50 max-w-64 overflow-hidden rounded-md px-3 py-1.5 text-sm shadow",
 				className,
 			)}
 			{...props}


### PR DESCRIPTION
If you've got more than a trivial amount of text in your tooltip, it can take up the entire browser window. Not great, Bob!