### PR TITLE
Add navigation-level scroll shadow to Mantle

### DIFF
--- a/packages/mantle/assets/mantle.css
+++ b/packages/mantle/assets/mantle.css
@@ -1618,4 +1618,21 @@
 			100% 14px;
 		background-attachment: local, local, scroll, scroll;
 	}
+
+	.nav-scroll-shadow {
+		background:
+			/* Shadow Cover TOP */
+			linear-gradient(hsl(var(--bg-popover)) 30%, hsl(var(--bg-popover) / 0%)) center top,
+			/* Shadow Cover BOTTOM */ linear-gradient(hsl(var(--bg-popover) / 0%), hsl(var(--bg-popover)) 70%) center bottom,
+			/* Shadow TOP */ radial-gradient(farthest-side at 50% 0, var(--navigation-shadow), rgb(0 0 0 / 0%)) center top,
+			/* Shadow BOTTOM */ radial-gradient(farthest-side at 50% 100%, var(--navigation-shadow), rgb(0 0 0 / 0%)) center
+				bottom;
+		background-repeat: no-repeat;
+		background-size:
+			100% 40px,
+			100% 40px,
+			100% 14px,
+			100% 14px;
+		background-attachment: local, local, scroll, scroll;
+	}
 }


### PR DESCRIPTION
This PR adds a nav-level scroll shadow to Mantle. This approach is done using only CSS but the drawback is that it isn't fully portable. You have to manually set the background color you want, so we've got `scroll-shadow` for bg-base and `nav-scroll-shadow` for popover level elements.

When this merges into Mantle, it can be removed from the global bundle in dashboard.

A fully portable solution that doesn't care about the background color would be preferred, but this gets us the effect we're looking for immediately.