### PR TITLE
Let's break long words in tooltips

### DIFF
--- a/packages/mantle/src/components/tooltip/tooltip.tsx
+++ b/packages/mantle/src/components/tooltip/tooltip.tsx
@@ -52,7 +52,7 @@ const TooltipContent = forwardRef<ElementRef<typeof Content>, ComponentPropsWith
 			ref={ref}
 			sideOffset={sideOffset}
 			className={cx(
-				"bg-tooltip text-tooltip animate-in fade-in-0 zoom-in-95 data-side-bottom:slide-in-from-top-2 data-side-left:slide-in-from-right-2 data-side-right:slide-in-from-left-2 data-side-top:slide-in-from-bottom-2 data-state-closed:animate-out data-state-closed:fade-out-0 data-state-closed:zoom-out-95 z-50 max-w-64 overflow-hidden rounded-md px-3 py-1.5 text-sm shadow",
+				"bg-tooltip text-tooltip animate-in fade-in-0 zoom-in-95 data-side-bottom:slide-in-from-top-2 data-side-left:slide-in-from-right-2 data-side-right:slide-in-from-left-2 data-side-top:slide-in-from-bottom-2 data-state-closed:animate-out data-state-closed:fade-out-0 data-state-closed:zoom-out-95 z-50 max-w-64 overflow-hidden break-words rounded-md px-3 py-1.5 text-sm shadow",
 				className,
 			)}
 			{...props}

--- a/packages/mantle/src/components/tooltip/tooltip.tsx
+++ b/packages/mantle/src/components/tooltip/tooltip.tsx
@@ -52,7 +52,7 @@ const TooltipContent = forwardRef<ElementRef<typeof Content>, ComponentPropsWith
 			ref={ref}
 			sideOffset={sideOffset}
 			className={cx(
-				"bg-tooltip text-tooltip animate-in fade-in-0 zoom-in-95 data-side-bottom:slide-in-from-top-2 data-side-left:slide-in-from-right-2 data-side-right:slide-in-from-left-2 data-side-top:slide-in-from-bottom-2 data-state-closed:animate-out data-state-closed:fade-out-0 data-state-closed:zoom-out-95 z-50 max-w-64 overflow-hidden break-words rounded-md px-3 py-1.5 text-sm shadow",
+				"bg-tooltip text-tooltip animate-in fade-in-0 zoom-in-95 data-side-bottom:slide-in-from-top-2 data-side-left:slide-in-from-right-2 data-side-right:slide-in-from-left-2 data-side-top:slide-in-from-bottom-2 data-state-closed:animate-out data-state-closed:fade-out-0 data-state-closed:zoom-out-95 z-50 max-w-72 overflow-hidden break-words rounded-md px-3 py-1.5 text-sm shadow",
 				className,
 			)}
 			{...props}


### PR DESCRIPTION
When we added a max width to these it didn't account for long, unwrappable words. Let's fix that!