### PR TITLE
fix: import on sheet code example

### DIFF
--- a/apps/www/app/routes/components.sheet.tsx
+++ b/apps/www/app/routes/components.sheet.tsx
@@ -138,7 +138,7 @@ export default function Page() {
 									SheetTitle,
 									SheetTitleGroup,
 									SheetTrigger,
-								} from "@ngrok/mantle/ngrok/mantle/sheet";
+								} from "@ngrok/mantle/sheet";
 								import { ListMagnifyingGlass } from "@phosphor-icons/react/ListMagnifyingGlass";
 								import { TerminalWindow } from "@phosphor-icons/react/TerminalWindow";
 								import { TrashSimple } from "@phosphor-icons/react/TrashSimple";


### PR DESCRIPTION
Removes the double `ngrok/mantle` from the sheet preview import. Noticed this earlier when trying to use the sheet.