### PR TITLE
Use `aria-disabled` instead of `disabled` on radio button groups

### DIFF
--- a/apps/www/app/routes/components.radio-group.tsx
+++ b/apps/www/app/routes/components.radio-group.tsx
@@ -111,6 +111,30 @@ export default function Page() {
 							</RadioListItem>
 						</RadioGroupList>
 
+						<RadioGroupList defaultValue="mixed">
+							<RadioListItem value="mixed" disabled id="rld1">
+								<RadioIndicator />
+								<RadioItemContent>
+									<label className="text-strong font-medium" htmlFor="rld1">
+										Mixed
+									</label>
+									<p className="text-body">
+										Only new workspace members are required to use SSO. Existing members can still log in with other
+										methods.
+									</p>
+								</RadioItemContent>
+							</RadioListItem>
+							<RadioListItem value="strict" id="rld2" disabled>
+								<RadioIndicator />
+								<RadioItemContent>
+									<label className="text-strong font-medium" htmlFor="rld2">
+										Strict
+									</label>
+									<p className="text-body">All workspace members are required to log in with SSO.</p>
+								</RadioItemContent>
+							</RadioListItem>
+						</RadioGroupList>
+
 						<RadioGroup className="grid grid-cols-1 gap-y-6 sm:grid-cols-3 sm:gap-x-4" defaultValue="existing">
 							<RadioCard className="flex" value="newsletter" id="radiocard-1">
 								<div className="flex-1">

--- a/packages/mantle/src/components/radio-group/radio-group.tsx
+++ b/packages/mantle/src/components/radio-group/radio-group.tsx
@@ -135,7 +135,7 @@ const RadioListItem = forwardRef<ElementRef<"div">, RadioListItemProps>(({ child
 				"focus-visible:ring-focus-accent aria-enabled:focus-visible:border-accent-600 focus-visible:ring-4",
 				"first-of-type:rounded-tl-md first-of-type:rounded-tr-md last-of-type:rounded-bl-md last-of-type:rounded-br-md",
 				"aria-disabled:border-form/50 aria-enabled:hover:z-1 aria-enabled:hover:border-accent-600",
-				"aria-checked:z-1 aria-checked:border-accent-500/40 aria-checked:bg-accent-500/10 dark-high-contrast:aria-checked:border-accent-400 high-contrast:aria-checked:border-accent-400 not-disabled:hover:aria-checked:border-accent-600",
+				"aria-checked:z-1 aria-checked:border-accent-500/40 aria-checked:bg-accent-500/10 dark-high-contrast:aria-checked:border-accent-400 high-contrast:aria-checked:border-accent-400 not-aria-disabled:hover:aria-checked:border-accent-600",
 				"has-[.radio-indicator:first-child]:pl-2 has-[.radio-indicator:last-child]:pr-2",
 				className,
 			)}

--- a/packages/mantle/src/tailwind-preset/tailwind.preset.ts
+++ b/packages/mantle/src/tailwind-preset/tailwind.preset.ts
@@ -496,6 +496,7 @@ const mantlePreset = {
 		}),
 		plugin(function ({ addVariant }) {
 			addVariant("not-disabled", ["&:not(:disabled)"]);
+			addVariant("not-aria-disabled", ['&:not(&[aria-disabled="true"])']);
 		}),
 	],
 } satisfies Config;


### PR DESCRIPTION
I _think_ we only want to have a hover state if something is not `aria-disabled`. Using just `disabled` meant our disabled, but selected radio group items were still getting a hover. This adds a helper and swaps for it.