### PR TITLE
Link-style buttons should inherit their font size

### DIFF
--- a/apps/www/app/routes/components.button.tsx
+++ b/apps/www/app/routes/components.button.tsx
@@ -52,7 +52,7 @@ export default function Page() {
 					Initiates an action, such as completing a task or submitting information
 				</p>
 				<div>
-					<Example className="flex flex-wrap gap-6">
+					<Example className="flex flex-wrap gap-6 text-base sm:text-sm">
 						<div>
 							<p className="mb-2 text-center font-mono text-xs">Default</p>
 							<div className="flex items-center gap-2">

--- a/packages/mantle/src/components/button/button.tsx
+++ b/packages/mantle/src/components/button/button.tsx
@@ -24,7 +24,7 @@ const buttonVariants = cva(
 					"text-accent-600 focus-visible:ring-focus-accent not-disabled:hover:bg-accent-500/10 not-disabled:hover:text-accent-700 not-disabled:active:bg-accent-500/15 not-disabled:active:text-accent-700 h-11 border border-transparent px-3 text-base font-medium sm:h-9 sm:text-sm",
 				outlined:
 					"border-accent-600 bg-form text-accent-600 focus-visible:ring-focus-accent not-disabled:hover:border-accent-700 not-disabled:hover:bg-accent-500/10 not-disabled:hover:text-accent-700 not-disabled:active:border-accent-700 not-disabled:active:bg-accent-500/15 not-disabled:active:text-accent-700 h-11 border px-3 text-base font-medium sm:h-9 sm:text-sm",
-				link: "text-accent-600 focus-visible:ring-focus-accent not-disabled:hover:underline group border-transparent",
+				link: "text-accent-600 focus-visible:ring-focus-accent not-disabled:hover:underline text-size-inherit group border-transparent",
 			},
 			/**
 			 * Whether or not the button is in a loading state, default `false`. Setting `isLoading` will


### PR DESCRIPTION
Since we're usually putting these in the context of other text, they should inherit the parent font size. This updates our button variant and adds some guard rails to the documentation.