### PR TITLE
Don't change sizes on mobile with breakpoints, use pointer inputs

### DIFF
--- a/apps/www/app/components/layout.tsx
+++ b/apps/www/app/components/layout.tsx
@@ -1,5 +1,6 @@
-import { Button } from "@ngrok/mantle/button";
+import { Button, IconButton } from "@ngrok/mantle/button";
 import { cx } from "@ngrok/mantle/cx";
+import { Icon } from "@ngrok/mantle/icon";
 import { Select, SelectContent, SelectGroup, SelectItem, SelectLabel, SelectTrigger } from "@ngrok/mantle/select";
 import { $theme, isTheme, useTheme } from "@ngrok/mantle/theme-provider";
 import type { WithStyleProps } from "@ngrok/mantle/types";
@@ -46,19 +47,17 @@ export function Layout({ children, className, currentVersion, style }: Props) {
 	return (
 		<main className={cx("mx-auto h-full max-w-7xl sm:px-4", className)} style={style}>
 			<header className="flex h-20 items-center gap-4 px-4 sm:px-0">
-				<Button
-					type="button"
-					appearance="outlined"
-					priority="neutral"
-					className="w-11 sm:w-9 md:hidden"
+				<IconButton
+					className="md:hidden"
 					onClick={() => {
 						setShowNavigation(!showNavigation);
 					}}
-				>
-					{!showNavigation && <List className="h-6 w-6 shrink-0" />}
-
-					{showNavigation && <X className="h-6 w-6 shrink-0" />}
-				</Button>
+					type="button"
+					appearance="outlined"
+					label="Menu"
+					size="md"
+					icon={showNavigation ? <X /> : <List />}
+				/>
 
 				<Link to="/" className="static top-auto flex sm:top-[1.4rem] md:fixed">
 					<NgrokLogo />
@@ -82,7 +81,7 @@ export function Layout({ children, className, currentVersion, style }: Props) {
 						{/* TODO: this should probably have a title/tooltip instead that describes what it is since we ain't got a spot for a label */}
 						<span className="sr-only">Theme Switcher</span>
 						<SelectTrigger className="w-min">
-							<Sun className="mr-1 h-6 w-6" />
+							<Icon className="mr-1" svg={<Sun />} />
 						</SelectTrigger>
 					</div>
 					<SelectContent>

--- a/packages/mantle/src/components/alert-dialog/alert-dialog.tsx
+++ b/packages/mantle/src/components/alert-dialog/alert-dialog.tsx
@@ -152,7 +152,10 @@ const AlertDialogTitle = forwardRef<
 >(({ className, ...props }, ref) => (
 	<AlertDialogPrimitive.Title
 		ref={ref}
-		className={cx("text-strong text-center text-xl font-medium sm:text-start sm:text-lg", className)}
+		className={cx(
+			"text-strong pointer-coarse:text-xl pointer-fine:text-lg text-center font-medium sm:text-start",
+			className,
+		)}
 		{...props}
 	/>
 ));
@@ -170,7 +173,10 @@ const AlertDialogDescription = forwardRef<
 >(({ className, ...props }, ref) => (
 	<AlertDialogPrimitive.Description
 		ref={ref}
-		className={cx("text-body text-center text-base font-normal sm:text-start sm:text-sm", className)}
+		className={cx(
+			"text-body pointer-coarse:text-base pointer-fine:text-sm text-center font-normal sm:text-start",
+			className,
+		)}
 		{...props}
 	/>
 ));
@@ -265,7 +271,7 @@ const AlertDialogIcon = forwardRef<ElementRef<"svg">, AlertDialogIconProps>(({ c
 	return (
 		<SvgOnly
 			ref={ref}
-			className={cx("size-12 sm:size-7", defaultColor, className)}
+			className={cx("pointer-coarse:size-12 pointer-fine:size-7", defaultColor, className)}
 			svg={svg ?? defaultIcon}
 			{...props}
 		/>

--- a/packages/mantle/src/components/badge/badge.tsx
+++ b/packages/mantle/src/components/badge/badge.tsx
@@ -33,7 +33,7 @@ const Badge = ({ appearance, asChild = false, children, className, color = "neut
 	const textColor = computeTextColor(color, appearance);
 
 	const badgeClasses = cx(
-		"inline-flex w-fit shrink-0 cursor-default items-center gap-1 rounded px-1.5 py-0.5 text-sm font-medium sm:text-xs",
+		"inline-flex w-fit shrink-0 cursor-default items-center gap-1 rounded px-1.5 py-0.5 pointer-coarse:text-sm font-medium pointer-fine:text-xs",
 		icon && "ps-1",
 		bgColor,
 		textColor,
@@ -54,7 +54,7 @@ const Badge = ({ appearance, asChild = false, children, className, color = "neut
 					singleChild,
 					{},
 					<>
-						{icon && <SvgOnly className="size-5 sm:size-4" svg={icon} />}
+						{icon && <SvgOnly className="pointer-coarse:size-5 pointer-fine:size-4" svg={icon} />}
 						{grandchildren}
 					</>,
 				)}
@@ -64,7 +64,7 @@ const Badge = ({ appearance, asChild = false, children, className, color = "neut
 
 	return (
 		<span className={badgeClasses} {...props}>
-			{icon && <SvgOnly className="size-5 sm:size-4" svg={icon} />}
+			{icon && <SvgOnly className="pointer-coarse:size-5 pointer-fine:size-4" svg={icon} />}
 			{children}
 		</span>
 	);

--- a/packages/mantle/src/components/button/button.tsx
+++ b/packages/mantle/src/components/button/button.tsx
@@ -19,11 +19,11 @@ const buttonVariants = cva(
 			 */
 			appearance: {
 				filled:
-					"bg-filled-accent text-on-filled focus-visible:border-accent-600 focus-visible:ring-focus-accent not-disabled:hover:bg-filled-accent-hover not-disabled:active:bg-filled-accent-active h-11 border border-transparent px-3 text-base font-medium sm:h-9 sm:text-sm",
+					"bg-filled-accent text-on-filled focus-visible:border-accent-600 focus-visible:ring-focus-accent not-disabled:hover:bg-filled-accent-hover not-disabled:active:bg-filled-accent-active pointer-coarse:h-11 pointer-coarse:text-base pointer-fine:h-9 pointer-fine:text-sm border border-transparent px-3 font-medium",
 				ghost:
-					"text-accent-600 focus-visible:ring-focus-accent not-disabled:hover:bg-accent-500/10 not-disabled:hover:text-accent-700 not-disabled:active:bg-accent-500/15 not-disabled:active:text-accent-700 h-11 border border-transparent px-3 text-base font-medium sm:h-9 sm:text-sm",
+					"text-accent-600 focus-visible:ring-focus-accent not-disabled:hover:bg-accent-500/10 not-disabled:hover:text-accent-700 not-disabled:active:bg-accent-500/15 not-disabled:active:text-accent-700 pointer-coarse:h-11 pointer-coarse:text-base pointer-fine:h-9 pointer-fine:text-sm border border-transparent px-3 font-medium",
 				outlined:
-					"border-accent-600 bg-form text-accent-600 focus-visible:ring-focus-accent not-disabled:hover:border-accent-700 not-disabled:hover:bg-accent-500/10 not-disabled:hover:text-accent-700 not-disabled:active:border-accent-700 not-disabled:active:bg-accent-500/15 not-disabled:active:text-accent-700 h-11 border px-3 text-base font-medium sm:h-9 sm:text-sm",
+					"border-accent-600 bg-form text-accent-600 focus-visible:ring-focus-accent not-disabled:hover:border-accent-700 not-disabled:hover:bg-accent-500/10 not-disabled:hover:text-accent-700 not-disabled:active:border-accent-700 not-disabled:active:bg-accent-500/15 not-disabled:active:text-accent-700 pointer-coarse:h-11 pointer-coarse:text-base pointer-fine:h-9 pointer-fine:text-sm border px-3 font-medium",
 				link: "text-accent-600 focus-visible:ring-focus-accent not-disabled:hover:underline group border-transparent",
 			},
 			/**

--- a/packages/mantle/src/components/button/icon-button.tsx
+++ b/packages/mantle/src/components/button/icon-button.tsx
@@ -34,9 +34,9 @@ const iconButtonVariants = cva(
 			 * The size of the IconButton.
 			 */
 			size: {
-				xs: "size-7 sm:size-6",
-				sm: "size-9 sm:size-7",
-				md: "size-11 sm:size-9",
+				xs: "pointer-coarse:size-7 pointer-fine:size-6",
+				sm: "pointer-coarse:size-9 pointer-fine:size-7",
+				md: "pointer-coarse:size-11 pointer-fine:size-9",
 			},
 		},
 		defaultVariants: {

--- a/packages/mantle/src/components/calendar/calendar.tsx
+++ b/packages/mantle/src/components/calendar/calendar.tsx
@@ -26,7 +26,7 @@ function Calendar({ className, classNames, showOutsideDays = false, ...props }: 
 				caption: "flex justify-center pt-1 relative items-center",
 				caption_label: "text-sm font-medium",
 				nav: "flex items-center",
-				nav_button: cx(buttonVariants({ appearance: "ghost", priority: "neutral" }), "sm:h-7 sm:w-7 h-7 w-7"),
+				nav_button: cx(buttonVariants({ appearance: "ghost", priority: "neutral" }), "size-7"),
 				nav_button_previous: "absolute left-0",
 				nav_button_next: "absolute right-0",
 				table: "w-full border-collapse space-y-1",
@@ -34,7 +34,7 @@ function Calendar({ className, classNames, showOutsideDays = false, ...props }: 
 				head_cell: "text-body w-7 text-[0.8rem] text-center font-normal",
 				row: "flex w-full mt-1",
 				cell: cx(
-					"overflow-hidden text-center text-sm p-0 relative focus-within:relative focus-within:z-20 sm:h-7 sm:w-7 h-7 w-7 ",
+					"overflow-hidden text-center text-sm p-0 relative focus-within:relative focus-within:z-20 size-7",
 					props.mode === "range"
 						? "first:[&:has([aria-selected])]:rounded-l-md last:[&:has([aria-selected])]:rounded-r-md"
 						: "",
@@ -53,8 +53,8 @@ function Calendar({ className, classNames, showOutsideDays = false, ...props }: 
 				...classNames,
 			}}
 			components={{
-				IconLeft: () => <CaretLeft className="h-4 w-4 shrink-0" weight="bold" />,
-				IconRight: () => <CaretRight className="h-4 w-4 shrink-0" weight="bold" />,
+				IconLeft: () => <CaretLeft className="size-4 shrink-0" weight="bold" />,
+				IconRight: () => <CaretRight className="size-4 shrink-0" weight="bold" />,
 			}}
 			{...props}
 		/>

--- a/packages/mantle/src/components/dropdown-menu/dropdown-menu.tsx
+++ b/packages/mantle/src/components/dropdown-menu/dropdown-menu.tsx
@@ -26,9 +26,9 @@ const DropdownMenuSubTrigger = forwardRef<
 >(({ className, inset, children, ...props }, ref) => (
 	<DropdownMenuPrimitive.SubTrigger
 		className={cx(
-			"focus:bg-accent data-state-open:bg-accent relative flex cursor-pointer select-none items-center rounded py-1.5 pl-2 pr-9 text-base outline-none sm:text-sm",
+			"focus:bg-accent data-state-open:bg-accent pointer-coarse:text-base pointer-fine:text-sm relative flex cursor-pointer select-none items-center rounded py-1.5 pl-2 pr-9 outline-none",
 			"data-highlighted:bg-popover-hover data-state-open:bg-popover-hover",
-			"[&>svg]:size-6 [&>svg]:sm:size-5 [&_svg]:shrink-0",
+			"[&>svg]:pointer-coarse:size-6 [&>svg]:pointer-fine:size-5 [&_svg]:shrink-0",
 			inset && "pl-8",
 			className,
 		)}
@@ -37,7 +37,7 @@ const DropdownMenuSubTrigger = forwardRef<
 	>
 		{children}
 		<span className="absolute right-2 flex items-center">
-			<CaretRight className="size-5 shrink-0 sm:size-4" weight="bold" />
+			<CaretRight className="pointer-coarse:size-5 pointer-fine:size-4 shrink-0" weight="bold" />
 		</span>
 	</DropdownMenuPrimitive.SubTrigger>
 ));
@@ -108,8 +108,8 @@ const DropdownMenuItem = forwardRef<
 	<DropdownMenuPrimitive.Item
 		ref={ref}
 		className={cx(
-			"focus:bg-accent focus:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50 data-highlighted:bg-popover-hover data-active-item:dark:bg-popover-hover relative flex cursor-pointer select-none items-center rounded px-2 py-1.5 text-base font-normal outline-none transition-colors sm:text-sm",
-			"[&>svg]:size-6 [&>svg]:sm:size-5 [&_svg]:shrink-0",
+			"focus:bg-accent focus:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50 data-highlighted:bg-popover-hover data-active-item:dark:bg-popover-hover pointer-coarse:text-base pointer-fine:text-sm relative flex cursor-pointer select-none items-center rounded px-2 py-1.5 font-normal outline-none transition-colors",
+			"[&>svg]:pointer-coarse:size-6 [&>svg]:pointer-fine:size-5 [&_svg]:shrink-0",
 			inset && "pl-8",
 			className,
 		)}
@@ -125,10 +125,10 @@ const DropdownMenuCheckboxItem = forwardRef<
 	<DropdownMenuPrimitive.CheckboxItem
 		ref={ref}
 		className={cx(
-			"text-strong data-disabled:pointer-events-none data-disabled:opacity-50 relative flex cursor-pointer select-none items-center gap-2 rounded py-1.5 pl-2 pr-9 text-base font-normal outline-none sm:text-sm",
+			"text-strong data-disabled:pointer-events-none data-disabled:opacity-50 pointer-coarse:text-base pointer-fine:text-sm relative flex cursor-pointer select-none items-center gap-2 rounded py-1.5 pl-2 pr-9 font-normal outline-none",
 			"data-highlighted:bg-popover-hover data-highlighted:dark:bg-popover-hover",
 			"aria-checked:!bg-filled-accent aria-checked:text-on-filled aria-checked:font-medium",
-			"[&>svg]:size-6 [&>svg]:sm:size-5 [&_svg]:shrink-0",
+			"[&>svg]:pointer-coarse:size-6 [&>svg]:pointer-fine:size-5 [&_svg]:shrink-0",
 			className,
 		)}
 		checked={checked}
@@ -136,7 +136,7 @@ const DropdownMenuCheckboxItem = forwardRef<
 	>
 		<span className="absolute right-2 flex items-center">
 			<DropdownMenuPrimitive.ItemIndicator>
-				<Check className="size-5 shrink-0 sm:size-4" weight="bold" />
+				<Check className="pointer-coarse:size-5 pointer-fine:size-4 shrink-0" weight="bold" />
 			</DropdownMenuPrimitive.ItemIndicator>
 		</span>
 		{children}
@@ -153,10 +153,10 @@ const DropdownMenuRadioItem = forwardRef<ElementRef<"input">, DropdownMenuRadioI
 	({ className, children, ...props }, ref) => (
 		<DropdownMenuPrimitive.RadioItem
 			className={cx(
-				"text-strong data-disabled:pointer-events-none data-disabled:opacity-50 relative flex cursor-pointer select-none items-center gap-2 rounded py-1.5 pl-2 pr-9 text-base font-normal outline-none sm:text-sm",
+				"text-strong data-disabled:pointer-events-none data-disabled:opacity-50 pointer-coarse:text-base pointer-fine:text-sm relative flex cursor-pointer select-none items-center gap-2 rounded py-1.5 pl-2 pr-9 font-normal outline-none",
 				"data-highlighted:bg-popover-hover data-highlighted:dark:bg-popover-hover",
 				"aria-checked:!bg-filled-accent aria-checked:text-on-filled aria-checked:font-medium",
-				"[&>svg]:size-6 [&>svg]:sm:size-5 [&_svg]:shrink-0",
+				"[&>svg]:pointer-coarse:size-6 [&>svg]:pointer-fine:size-5 [&_svg]:shrink-0",
 				className,
 			)}
 			ref={ref}
@@ -164,7 +164,7 @@ const DropdownMenuRadioItem = forwardRef<ElementRef<"input">, DropdownMenuRadioI
 		>
 			<span className="absolute right-2 flex items-center">
 				<DropdownMenuPrimitive.ItemIndicator>
-					<Check className="size-5 shrink-0 sm:size-4" weight="bold" />
+					<Check className="pointer-coarse:size-5 pointer-fine:size-4 shrink-0" weight="bold" />
 				</DropdownMenuPrimitive.ItemIndicator>
 			</span>
 			{children}

--- a/packages/mantle/src/components/icon/icon.tsx
+++ b/packages/mantle/src/components/icon/icon.tsx
@@ -19,7 +19,13 @@ type IconProps = Omit<SvgAttributes, "children"> & {
  * 4. svg className
  */
 const Icon = forwardRef<ElementRef<"svg">, IconProps>(({ className, style, svg, ...props }, ref) => (
-	<SvgOnly ref={ref} className={cx("size-6 sm:size-5", className)} style={style} svg={svg} {...props} />
+	<SvgOnly
+		ref={ref}
+		className={cx("pointer-coarse:size-6 pointer-fine:size-5", className)}
+		style={style}
+		svg={svg}
+		{...props}
+	/>
 ));
 
 export {

--- a/packages/mantle/src/components/input/input.tsx
+++ b/packages/mantle/src/components/input/input.tsx
@@ -138,10 +138,10 @@ const InputContainer = ({
 				aria-disabled={disabled ?? _ariaDisabled}
 				data-validation={validation || undefined}
 				className={cx(
-					"h-11 text-base sm:h-9 sm:text-sm",
+					"pointer-coarse:h-11 pointer-coarse:text-base pointer-fine:h-9 pointer-fine:text-sm",
 					"bg-form relative flex w-full items-center gap-1.5 rounded-md border px-3 py-2 file:border-0 file:bg-transparent file:text-sm file:font-medium focus-within:outline-none focus-within:ring-4 focus-visible:outline-none focus-visible:ring-4",
 					"aria-disabled:opacity-50",
-					"has-[input:not(:first-child)]:ps-2.5 has-[input:not(:last-child)]:pe-2.5 [&>:not(input)]:shrink-0 [&_svg]:size-6 sm:[&_svg]:size-5",
+					"pointer-coarse:[&_svg]:size-6 pointer-fine:[&_svg]:size-5 has-[input:not(:first-child)]:ps-2.5 has-[input:not(:last-child)]:pe-2.5 [&>:not(input)]:shrink-0",
 					"border-form text-strong has-[:focus-visible]:border-accent-600 has-[:focus-visible]:ring-focus-accent",
 					"data-validation-success:border-success-600 has-[:focus-visible]:data-validation-success:border-success-600 has-[:focus-visible]:data-validation-success:ring-focus-success",
 					"data-validation-warning:border-warning-600 has-[:focus-visible]:data-validation-warning:border-warning-600 has-[:focus-visible]:data-validation-warning:ring-focus-warning",

--- a/packages/mantle/src/components/radio-group/radio-group.tsx
+++ b/packages/mantle/src/components/radio-group/radio-group.tsx
@@ -51,7 +51,7 @@ type RadioItemProps = Omit<HeadlessRadioProps, "children"> & PropsWithChildren;
 const RadioItem = forwardRef<ElementRef<"div">, RadioItemProps>(({ children, className, ...props }, ref) => (
 	<HeadlessRadio
 		className={cx(
-			"group/radio aria-enabled:cursor-pointer [&_label]:cursor-inherit flex cursor-default gap-2 py-1 text-base focus:outline-none sm:text-sm",
+			"group/radio aria-enabled:cursor-pointer [&_label]:cursor-inherit pointer-coarse:text-base pointer-fine:text-sm flex cursor-default gap-2 py-1 focus:outline-none",
 			className,
 		)}
 		as="div"
@@ -98,7 +98,10 @@ const RadioIndicator = ({ children, className, ...props }: RadioIndicatorProps) 
 
 	return (
 		<div
-			className={cx("radio-indicator inline-flex size-6 select-none items-center justify-center sm:size-5", className)}
+			className={cx(
+				"radio-indicator pointer-coarse:size-6 pointer-fine:size-5 inline-flex select-none items-center justify-center",
+				className,
+			)}
 			{...props}
 		>
 			{children == null ? (
@@ -130,7 +133,7 @@ const RadioListItem = forwardRef<ElementRef<"div">, RadioListItemProps>(({ child
 		<HeadlessRadio
 			as="div"
 			className={cx(
-				"group/radio border-form [&_label]:cursor-inherit relative flex select-none gap-2 border px-3 py-2 text-base sm:text-sm",
+				"group/radio border-form [&_label]:cursor-inherit pointer-coarse:text-base pointer-fine:text-sm relative flex select-none gap-2 border px-3 py-2",
 				"aria-enabled:cursor-pointer focus:outline-none",
 				"focus-visible:ring-focus-accent aria-enabled:focus-visible:border-accent-600 focus-visible:ring-4",
 				"first-of-type:rounded-tl-md first-of-type:rounded-tr-md last-of-type:rounded-bl-md last-of-type:rounded-br-md",
@@ -164,7 +167,7 @@ const RadioCard = forwardRef<ElementRef<"div">, RadioCardProps>(({ children, cla
 		<HeadlessRadio
 			as="div"
 			className={clsx(
-				"group/radio border-card bg-card [&_label]:cursor-inherit relative rounded-md border p-4 text-base sm:text-sm",
+				"group/radio border-card bg-card [&_label]:cursor-inherit pointer-coarse:text-base pointer-fine:text-sm relative rounded-md border p-4",
 				"aria-enabled:cursor-pointer focus:outline-none",
 				"focus-visible:ring-focus-accent aria-enabled:focus-visible:border-accent-600 focus-visible:ring-4",
 				"first-of-type:rounded-tl-md first-of-type:rounded-tr-md last-of-type:rounded-bl-md last-of-type:rounded-br-md",
@@ -218,8 +221,8 @@ const RadioButton = forwardRef<ElementRef<"div">, RadioButtonProps>(({ children,
 		<HeadlessRadio
 			as="div"
 			className={cx(
-				"group/radio border-form [&_label]:cursor-inherit relative flex flex-1 select-none items-center justify-center gap-2 border px-3 text-base sm:text-sm",
-				"h-11 sm:h-9",
+				"group/radio border-form [&_label]:cursor-inherit pointer-coarse:text-base pointer-fine:text-sm relative flex flex-1 select-none items-center justify-center gap-2 border px-3",
+				"pointer-coarse:h-11 pointer-fine:h-9",
 				"focus-visible:ring-focus-accent aria-enabled:focus-visible:border-accent-600 focus-visible:ring-4",
 				"aria-enabled:cursor-pointer focus:outline-none",
 				"first-of-type:rounded-bl-md first-of-type:rounded-tl-md last-of-type:rounded-br-md last-of-type:rounded-tr-md",

--- a/packages/mantle/src/components/select/select.tsx
+++ b/packages/mantle/src/components/select/select.tsx
@@ -93,7 +93,7 @@ const SelectTrigger = forwardRef<ElementRef<typeof SelectPrimitive.Trigger>, Sel
 				aria-invalid={ariaInvalid}
 				data-validation={validation || undefined}
 				className={cx(
-					"h-11 text-base sm:h-9 sm:text-sm",
+					"pointer-coarse:h-11 pointer-coarse:text-base pointer-fine:h-9 pointer-fine:text-sm",
 					"border-form bg-form text-strong placeholder:text-placeholder hover:bg-form-hover hover:text-strong flex w-full items-center justify-between gap-1.5 rounded-md border px-3 py-2 hover:border-neutral-400 disabled:pointer-events-none disabled:opacity-50 [&>span]:line-clamp-1 [&>span]:text-left",
 					"focus:outline-none focus:ring-4 aria-expanded:ring-4",
 					"focus:border-accent-600 focus:ring-focus-accent aria-expanded:border-accent-600 aria-expanded:ring-focus-accent",

--- a/packages/mantle/src/components/switch/switch.tsx
+++ b/packages/mantle/src/components/switch/switch.tsx
@@ -21,7 +21,7 @@ const Switch = forwardRef<ElementRef<typeof SwitchPrimitiveRoot>, SwitchProps>(
 			<SwitchPrimitiveRoot
 				aria-readonly={readOnly}
 				className={cx(
-					"peer inline-flex h-6 w-10 shrink-0 cursor-pointer items-center rounded-full outline-none sm:h-5 sm:w-9",
+					"pointer-coarse:h-6 pointer-coarse:w-10 pointer-fine:h-5 pointer-fine:w-9 peer inline-flex shrink-0 cursor-pointer items-center rounded-full outline-none",
 					"disabled:cursor-default disabled:opacity-50",
 					"focus-visible:border-accent-600 focus-visible:ring-focus-accent focus-visible:outline-none focus-visible:ring-4",
 					"data-state-checked:bg-blue-500 data-state-unchecked:bg-gray-400",
@@ -41,7 +41,7 @@ const Switch = forwardRef<ElementRef<typeof SwitchPrimitiveRoot>, SwitchProps>(
 			>
 				<SwitchPrimitiveThumb
 					className={clsx(
-						"pointer-events-none block size-5 rounded-full bg-[#fff] shadow-md ring-0 transition-transform sm:size-4",
+						"pointer-coarse:size-5 pointer-fine:size-4 pointer-events-none block rounded-full bg-[#fff] shadow-md ring-0 transition-transform",
 						"data-state-checked:translate-x-[1.125rem] data-state-unchecked:translate-x-[0.125rem]",
 					)}
 				/>

--- a/packages/mantle/src/components/tabs/tabs.tsx
+++ b/packages/mantle/src/components/tabs/tabs.tsx
@@ -66,7 +66,7 @@ const TabsTrigger = forwardRef<ElementRef<typeof TabsPrimitiveTrigger>, TabsTrig
 					"ring-focus-accent outline-none",
 					"disabled:cursor-default disabled:opacity-50",
 					"focus-visible:ring-4",
-					"[&>svg]:size-6 [&>svg]:shrink-0 [&>svg]:sm:size-5",
+					"[&>svg]:pointer-coarse:size-6 [&>svg]:pointer-fine:size-5 [&>svg]:shrink-0",
 					"not-disabled:hover:text-gray-900 not-disabled:hover:data-state-active:text-blue-600",
 					"data-state-active:text-blue-600",
 					className,

--- a/packages/mantle/src/components/text-area/text-area.tsx
+++ b/packages/mantle/src/components/text-area/text-area.tsx
@@ -6,14 +6,14 @@ import { cx } from "../../utils/cx/cx.js";
 import type { WithValidation } from "../input/types.js";
 
 const textAreaVariants = cva(
-	"border-input bg-form data-drag-over:border-dashed data-drag-over:ring-4 flex min-h-24 w-full rounded-md border px-3 py-[calc(theme(spacing[2.5])-1px)] text-base focus-visible:outline-none focus-visible:ring-4 disabled:pointer-events-none disabled:opacity-50 sm:py-[calc(theme(spacing[2])-1px)] sm:text-sm",
+	"border-input bg-form data-drag-over:border-dashed data-drag-over:ring-4 pointer-coarse:py-[calc(theme(spacing[2.5])-1px)] pointer-coarse:text-base pointer-fine:py-[calc(theme(spacing[2])-1px)] pointer-fine:text-sm flex min-h-24 w-full rounded-md border px-3 focus-visible:outline-none focus-visible:ring-4 disabled:pointer-events-none disabled:opacity-50",
 	{
 		variants: {
 			/**
 			 * The visual style of the textarea.
 			 */
 			appearance: {
-				monospaced: "font-mono text-[0.9375rem] sm:text-[0.8125rem]",
+				monospaced: "pointer-coarse:text-[0.9375rem] pointer-fine:text-[0.8125rem] font-mono",
 			},
 		},
 	},
@@ -54,8 +54,8 @@ const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
 				aria-invalid={ariaInvalid}
 				data-validation={validation || undefined}
 				className={cx(
-					appearance === "monospaced" && "font-mono text-[0.9375rem] sm:text-[0.8125rem]",
-					"border-input bg-form data-drag-over:border-dashed data-drag-over:ring-4 flex min-h-24 w-full rounded-md border px-3 py-[calc(theme(spacing[2.5])-1px)] focus-visible:outline-none focus-visible:ring-4 disabled:pointer-events-none disabled:opacity-50 sm:py-[calc(theme(spacing[2])-1px)] sm:text-sm",
+					appearance === "monospaced" && "pointer-coarse:text-[0.9375rem] pointer-fine:text-[0.8125rem] font-mono",
+					"border-input bg-form data-drag-over:border-dashed data-drag-over:ring-4 pointer-coarse:py-[calc(theme(spacing[2.5])-1px)] pointer-fine:py-[calc(theme(spacing[2])-1px)] pointer-coarse:text-base pointer-fine:text-sm flex min-h-24 w-full rounded-md border px-3 focus-visible:outline-none focus-visible:ring-4 disabled:pointer-events-none disabled:opacity-50",
 					"placeholder:text-placeholder data-drag-over:border-dashed",
 					"border-form text-strong ring-focus-accent focus:border-accent-600 data-drag-over:border-accent-600",
 					"data-validation-error:border-danger-600 data-validation-error:ring-focus-danger data-validation-error:focus-visible:border-danger-600 data-validation-error:data-drag-over:border-danger-600",

--- a/packages/mantle/src/components/toast/toast.tsx
+++ b/packages/mantle/src/components/toast/toast.tsx
@@ -126,7 +126,7 @@ const Toast = forwardRef<ElementRef<"div">, ToastProps>(({ asChild, children, cl
 		<ToastStateContext.Provider value={{ priority }}>
 			<Component
 				className={cx(
-					"relative flex items-start gap-2 text-base sm:text-sm",
+					"pointer-coarse:text-base pointer-fine:text-sm relative flex items-start gap-2",
 					"p-3 pl-[0.9375rem]",
 					"bg-popover high-contrast:border-popover rounded rounded-r-[0.3125rem] border border-gray-500/35 shadow-lg",
 					/**


### PR DESCRIPTION
This has been bugging me for a while, and I was inspired by a thread in a Design Systems Slack group I'm in.

This PR explores switching to pointer precision instead of breakpoints to adjust sizes of things. We were penalizing small window'd desktop users by making everything bigger. Now we'll only make things bigger if they're on a device that only has touch input—phones usually, but _not_ an iPad with a trackpad.

What'chy'all think?