### PR TITLE
Fix safari scrollbar color

### DIFF
--- a/packages/mantle/assets/mantle.css
+++ b/packages/mantle/assets/mantle.css
@@ -1580,30 +1580,31 @@
 		color-scheme: dark;
 	}
 
-	.scrollbar::-webkit-scrollbar {
-		width: 0.5rem;
-		height: 0.5rem;
-		background-color: transparent;
-	}
+	@supports selector(::-webkit-scrollbar) {
+		.scrollbar::-webkit-scrollbar {
+			width: 0.5rem;
+			height: 0.5rem;
+			background-color: transparent;
+		}
 
-	.scrollbar::-webkit-scrollbar-track {
-		border-radius: 0.5rem;
-		background-color: transparent;
-	}
+		.scrollbar::-webkit-scrollbar-track {
+			border-radius: 0.5rem;
+			background-color: transparent;
+		}
 
-	.scrollbar::-webkit-scrollbar-thumb {
-		border-radius: 0.5rem;
-		background-color: hsl(var(--gray-800) / 0.5);
-	}
+		.scrollbar::-webkit-scrollbar-thumb {
+			border-radius: 0.5rem;
+			background-color: hsl(var(--gray-800) / 0.5);
+		}
 
-	.scrollbar::-webkit-scrollbar-corner {
-		background-color: transparent;
-		border-color: transparent;
+		.scrollbar::-webkit-scrollbar-corner {
+			background-color: transparent;
+			border-color: transparent;
+		}
 	}
 
 	.scrollbar {
 		scrollbar-color: hsl(var(--gray-800) / 0.5) transparent;
-		scrollbar-width: thin;
 	}
 
 	.scroll-shadow {


### PR DESCRIPTION
Safari now supports `scrollbar-width` in 18.2. According to MDN, `::webkit-scrollbar` pseudo styling is dropped when `scrollbar-width` is enabled.

This PR removes the scrollbar-width property since it isn't really needed. We'd rather control for the aesthetic than the width. This also moves `webkit` styling behind the `@supports` selector.