### PR TITLE
Wrap `HoverCardContent` in portal by default

### DIFF
--- a/packages/mantle/src/components/hover-card/hover-card.tsx
+++ b/packages/mantle/src/components/hover-card/hover-card.tsx
@@ -16,27 +16,38 @@ HoverCard.displayName = "HoverCard";
 
 const HoverCardTrigger = HoverCardPrimitive.Trigger;
 
+/**
+ * The portal for a HoverCard. Should be rendered as a child of the `HoverCard` component.
+ * Renders a portal that the `HoverCardContent` is rendered into.
+ *
+ * You likely don't need to use this component directly, as it is used internally by the `HoverCardContent` component.
+ */
+const HoverCardPortal = HoverCardPrimitive.Portal;
+
 const HoverCardContent = forwardRef<
 	ElementRef<typeof HoverCardPrimitive.Content>,
 	ComponentPropsWithoutRef<typeof HoverCardPrimitive.Content>
 >(({ className, align = "center", sideOffset = 4, ...props }, ref) => (
-	<HoverCardPrimitive.Content
-		ref={ref}
-		align={align}
-		sideOffset={sideOffset}
-		className={cx(
-			"bg-popover border-popover z-50 w-64 rounded-md border p-4 shadow-md outline-none",
-			"data-state-open:animate-in data-state-closed:animate-out data-state-closed:fade-out-0 data-state-open:fade-in-0 data-state-closed:zoom-out-95 data-state-open:zoom-in-95 data-side-bottom:slide-in-from-top-2 data-side-left:slide-in-from-right-2 data-side-right:slide-in-from-left-2 data-side-top:slide-in-from-bottom-2",
-			className,
-		)}
-		{...props}
-	/>
+	<HoverCardPortal>
+		<HoverCardPrimitive.Content
+			ref={ref}
+			align={align}
+			sideOffset={sideOffset}
+			className={cx(
+				"bg-popover border-popover z-50 w-64 rounded-md border p-4 shadow-md outline-none",
+				"data-state-open:animate-in data-state-closed:animate-out data-state-closed:fade-out-0 data-state-open:fade-in-0 data-state-closed:zoom-out-95 data-state-open:zoom-in-95 data-side-bottom:slide-in-from-top-2 data-side-left:slide-in-from-right-2 data-side-right:slide-in-from-left-2 data-side-top:slide-in-from-bottom-2",
+				className,
+			)}
+			{...props}
+		/>
+	</HoverCardPortal>
 ));
 HoverCardContent.displayName = HoverCardPrimitive.Content.displayName;
 
 export {
 	//,
 	HoverCard,
-	HoverCardTrigger,
 	HoverCardContent,
+	HoverCardPortal,
+	HoverCardTrigger,
 };


### PR DESCRIPTION
Follows our `Sheet` and `Dialog` behavior.