### PR TITLE
Prevent `HoverCardContent` click events from bubbling up

### DIFF
--- a/packages/mantle/package.json
+++ b/packages/mantle/package.json
@@ -3,7 +3,7 @@
   "description": "mantle is ngrok's UI library and design system.",
   "author": "ngrok",
   "license": "MIT",
-  "version": "0.19.1",
+  "version": "0.19.2",
   "homepage": "https://mantle.ngrok.com",
   "repository": {
     "type": "git",

--- a/packages/mantle/src/components/hover-card/hover-card.tsx
+++ b/packages/mantle/src/components/hover-card/hover-card.tsx
@@ -27,7 +27,7 @@ const HoverCardPortal = HoverCardPrimitive.Portal;
 const HoverCardContent = forwardRef<
 	ElementRef<typeof HoverCardPrimitive.Content>,
 	ComponentPropsWithoutRef<typeof HoverCardPrimitive.Content>
->(({ className, align = "center", sideOffset = 4, ...props }, ref) => (
+>(({ className, onClick, align = "center", sideOffset = 4, ...props }, ref) => (
 	<HoverCardPortal>
 		<HoverCardPrimitive.Content
 			ref={ref}
@@ -38,6 +38,13 @@ const HoverCardContent = forwardRef<
 				"data-state-open:animate-in data-state-closed:animate-out data-state-closed:fade-out-0 data-state-open:fade-in-0 data-state-closed:zoom-out-95 data-state-open:zoom-in-95 data-side-bottom:slide-in-from-top-2 data-side-left:slide-in-from-right-2 data-side-right:slide-in-from-left-2 data-side-top:slide-in-from-bottom-2",
 				className,
 			)}
+			onClick={(event) => {
+				/**
+				 * Prevent the click event from propagating up to parent/containing elements
+				 */
+				event.stopPropagation();
+				onClick?.(event);
+			}}
 			{...props}
 		/>
 	</HoverCardPortal>


### PR DESCRIPTION
Prevent clicks in the hover card content from bubbling up to the parent, because:

> A portal only changes the physical placement of the DOM node. In every other way, the JSX you render into a portal acts as a child node of the React component that renders it. For example, **the child can access the context provided by the parent tree, and events bubble up from children to parents according to the React tree**.

https://react.dev/reference/react-dom/createPortal#reference
