### PR TITLE
Allow `className` to be truly optional for `anchorClassNames`

### DIFF
--- a/.changeset/silver-dragons-reply.md
+++ b/.changeset/silver-dragons-reply.md
@@ -1,0 +1,5 @@
+---
+"@ngrok/mantle": patch
+---
+
+Make the `className` arg on `anchorClassNames` optional

--- a/packages/mantle/src/components/anchor/anchor.tsx
+++ b/packages/mantle/src/components/anchor/anchor.tsx
@@ -8,7 +8,7 @@ import type { Rel, Target } from "./types.js";
 /**
  * The class names for the `Anchor` component which define the styles for the component.
  */
-const anchorClassNames = (className: string | undefined) =>
+const anchorClassNames = (className?: string) =>
 	cx(
 		"cursor-pointer rounded bg-transparent text-accent-600 hover:underline focus:outline-none focus-visible:ring focus-visible:ring-focus-accent",
 		className,


### PR DESCRIPTION
Fixes the typing. `className` is actually truly optional if you want to use the styles as-is.

Before:
<img width="400" alt="Screenshot 2025-01-27 at 6 14 16 PM" src="https://github.com/user-attachments/assets/edbbeace-1544-4d49-819f-5cd653559e88" />

After:
<img width="400" alt="Screenshot 2025-01-27 at 6 14 26 PM" src="https://github.com/user-attachments/assets/8920ad60-4e99-444f-8b65-47dfb1bda985" />
