### PR TITLE
Prep for react 19: swap react-19-deprecated ElementRef type for ComponentRef type

### DIFF
--- a/.changeset/twelve-parks-see.md
+++ b/.changeset/twelve-parks-see.md
@@ -1,0 +1,5 @@
+---
+"@ngrok/mantle": patch
+---
+
+Prep for react 19: swap react-19-deprecated ElementRef type for ComponentRef type

--- a/packages/mantle/src/components/accordion/accordion.tsx
+++ b/packages/mantle/src/components/accordion/accordion.tsx
@@ -4,14 +4,14 @@ import { CaretDown } from "@phosphor-icons/react/CaretDown";
 import * as AccordionPrimitive from "@radix-ui/react-accordion";
 import {
 	type ComponentPropsWithoutRef,
-	type ElementRef,
+	type ComponentRef,
 	forwardRef,
 } from "react";
 import { cx } from "../../utils/cx/cx.js";
 import { Icon, type IconProps } from "../icon/icon.js";
 
 const Accordion = forwardRef<
-	ElementRef<"div">,
+	ComponentRef<"div">,
 	ComponentPropsWithoutRef<typeof AccordionPrimitive.Root>
 >(({ className, ...props }, ref) => (
 	<AccordionPrimitive.Root
@@ -26,7 +26,7 @@ const AccordionItem = AccordionPrimitive.Item;
 AccordionItem.displayName = "AccordionItem";
 
 const AccordionHeading = forwardRef<
-	ElementRef<"div">,
+	ComponentRef<"div">,
 	ComponentPropsWithoutRef<typeof AccordionPrimitive.Header>
 >(({ className, ...props }, ref) => (
 	<AccordionPrimitive.Header
@@ -38,7 +38,7 @@ const AccordionHeading = forwardRef<
 AccordionHeading.displayName = "AccordionHeading";
 
 const AccordionTrigger = forwardRef<
-	ElementRef<"button">,
+	ComponentRef<"button">,
 	ComponentPropsWithoutRef<typeof AccordionPrimitive.Trigger>
 >(({ className, children, ...props }, ref) => (
 	<AccordionPrimitive.Trigger
@@ -63,7 +63,7 @@ const AccordionTriggerIcon = ({
 );
 
 const AccordionContent = forwardRef<
-	ElementRef<"div">,
+	ComponentRef<"div">,
 	ComponentPropsWithoutRef<typeof AccordionPrimitive.Content>
 >(({ className, children, ...props }, ref) => (
 	<AccordionPrimitive.Content
@@ -82,9 +82,9 @@ AccordionContent.displayName = "AccordionContent";
 export {
 	//,
 	Accordion,
-	AccordionItem,
-	AccordionTrigger,
 	AccordionContent,
 	AccordionHeading,
+	AccordionItem,
+	AccordionTrigger,
 	AccordionTriggerIcon,
 };

--- a/packages/mantle/src/components/alert-dialog/alert-dialog.tsx
+++ b/packages/mantle/src/components/alert-dialog/alert-dialog.tsx
@@ -5,7 +5,7 @@ import { Warning } from "@phosphor-icons/react/Warning";
 import {
 	type ComponentProps,
 	type ComponentPropsWithoutRef,
-	type ElementRef,
+	type ComponentRef,
 	type ReactNode,
 	createContext,
 	forwardRef,
@@ -72,7 +72,7 @@ const AlertDialogPortal = AlertDialogPrimitive.Portal;
  * A layer that covers the inert portion of the view when the dialog is open.
  */
 const AlertDialogOverlay = forwardRef<
-	ElementRef<typeof AlertDialogPrimitive.Overlay>,
+	ComponentRef<typeof AlertDialogPrimitive.Overlay>,
 	ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Overlay>
 >(({ className, ...props }, ref) => (
 	<AlertDialogPrimitive.Overlay
@@ -92,7 +92,7 @@ AlertDialogOverlay.displayName = "AlertDialogOverlay";
  * Renders on top of the overlay and is centered in the viewport.
  */
 const AlertDialogContent = forwardRef<
-	ElementRef<typeof AlertDialogPrimitive.Content>,
+	ComponentRef<typeof AlertDialogPrimitive.Content>,
 	ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Content>
 >(({ className, onInteractOutside, onPointerDownOutside, ...props }, ref) => (
 	<AlertDialogPortal>
@@ -166,7 +166,7 @@ AlertDialogFooter.displayName = "AlertDialogFooter";
  * `AlertDialogContent` and exclude this component.
  */
 const AlertDialogTitle = forwardRef<
-	ElementRef<typeof AlertDialogPrimitive.Title>,
+	ComponentRef<typeof AlertDialogPrimitive.Title>,
 	ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Title>
 >(({ className, ...props }, ref) => (
 	<AlertDialogPrimitive.Title
@@ -187,7 +187,7 @@ AlertDialogTitle.displayName = "AlertDialogTitle";
  * exclude this component.
  */
 const AlertDialogDescription = forwardRef<
-	ElementRef<typeof AlertDialogPrimitive.Description>,
+	ComponentRef<typeof AlertDialogPrimitive.Description>,
 	ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Description>
 >(({ className, ...props }, ref) => (
 	<AlertDialogPrimitive.Description
@@ -210,7 +210,7 @@ AlertDialogDescription.displayName = "AlertDialogDescription";
  *
  * Composes around the mantle Button component.
  */
-const AlertDialogAction = forwardRef<ElementRef<"button">, ButtonProps>(
+const AlertDialogAction = forwardRef<ComponentRef<"button">, ButtonProps>(
 	(
 		{
 			//,
@@ -246,7 +246,7 @@ AlertDialogAction.displayName = "AlertDialogAction";
  *
  * Composes around the mantle Button component.
  */
-const AlertDialogCancel = forwardRef<ElementRef<"button">, ButtonProps>(
+const AlertDialogCancel = forwardRef<ComponentRef<"button">, ButtonProps>(
 	(
 		{
 			//,
@@ -282,7 +282,7 @@ type AlertDialogIconProps = Omit<SvgAttributes, "children"> & {
  *
  * Can be overridden with a custom icon using the `svg` prop.
  */
-const AlertDialogIcon = forwardRef<ElementRef<"svg">, AlertDialogIconProps>(
+const AlertDialogIcon = forwardRef<ComponentRef<"svg">, AlertDialogIconProps>(
 	({ className, svg, ...props }, ref) => {
 		const ctx = useAlertDialogContext();
 		const defaultColor =

--- a/packages/mantle/src/components/button/button-group.tsx
+++ b/packages/mantle/src/components/button/button-group.tsx
@@ -1,5 +1,5 @@
 import { cva } from "class-variance-authority";
-import { type ComponentProps, type ElementRef, forwardRef } from "react";
+import { type ComponentProps, type ComponentRef, forwardRef } from "react";
 import type { VariantProps } from "../../types/index.js";
 import { cx } from "../../utils/cx/cx.js";
 
@@ -27,7 +27,7 @@ type ButtonGroupProps = ComponentProps<"fieldset"> & ButtonGroupVariants;
 /**
  * A contained group of related buttons.
  */
-const ButtonGroup = forwardRef<ElementRef<"fieldset">, ButtonGroupProps>(
+const ButtonGroup = forwardRef<ComponentRef<"fieldset">, ButtonGroupProps>(
 	({ appearance, className, children, ...props }, ref) => {
 		return (
 			<fieldset

--- a/packages/mantle/src/components/checkbox/checkbox.tsx
+++ b/packages/mantle/src/components/checkbox/checkbox.tsx
@@ -1,6 +1,6 @@
 import clsx from "clsx";
 import { forwardRef, useEffect, useRef, useState } from "react";
-import type { ComponentPropsWithoutRef, ElementRef } from "react";
+import type { ComponentPropsWithoutRef, ComponentRef } from "react";
 import { composeRefs } from "../../utils/compose-refs/index.js";
 import type { WithValidation } from "../input/index.js";
 
@@ -28,7 +28,7 @@ type Props = Omit<
 /**
  * A form control that allows the user to toggle between checked and not checked.
  */
-const Checkbox = forwardRef<ElementRef<"input">, Props>(
+const Checkbox = forwardRef<ComponentRef<"input">, Props>(
 	(
 		{
 			"aria-invalid": _ariaInvalid,
@@ -43,7 +43,7 @@ const Checkbox = forwardRef<ElementRef<"input">, Props>(
 		},
 		ref,
 	) => {
-		const innerRef = useRef<ElementRef<"input">>(null);
+		const innerRef = useRef<ComponentRef<"input">>(null);
 		const [defaultChecked] = useState(_defaultChecked);
 		const isInvalid = _ariaInvalid != null && _ariaInvalid !== "false";
 		const validation = isInvalid

--- a/packages/mantle/src/components/dialog/dialog.tsx
+++ b/packages/mantle/src/components/dialog/dialog.tsx
@@ -2,7 +2,7 @@ import { X } from "@phosphor-icons/react/X";
 import type {
 	ComponentProps,
 	ComponentPropsWithoutRef,
-	ElementRef,
+	ComponentRef,
 } from "react";
 import { forwardRef } from "react";
 import { cx } from "../../utils/cx/cx.js";
@@ -19,7 +19,7 @@ const DialogPortal = DialogPrimitive.Portal;
 const DialogClose = DialogPrimitive.Close;
 
 const DialogOverlay = forwardRef<
-	ElementRef<"div">,
+	ComponentRef<"div">,
 	ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
 >(({ className, ...props }, ref) => (
 	<DialogPrimitive.Overlay
@@ -34,7 +34,7 @@ const DialogOverlay = forwardRef<
 DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
 
 const DialogContent = forwardRef<
-	ElementRef<"div">,
+	ComponentRef<"div">,
 	ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
 >(
 	(
@@ -129,7 +129,7 @@ const DialogFooter = ({ className, ...props }: ComponentProps<"div">) => (
 DialogFooter.displayName = "DialogFooter";
 
 const DialogTitle = forwardRef<
-	ElementRef<typeof DialogPrimitive.Title>,
+	ComponentRef<typeof DialogPrimitive.Title>,
 	ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
 >(({ className, ...props }, ref) => (
 	<DialogPrimitive.Title
@@ -141,7 +141,7 @@ const DialogTitle = forwardRef<
 DialogTitle.displayName = DialogPrimitive.Title.displayName;
 
 const DialogDescription = forwardRef<
-	ElementRef<"p">,
+	ComponentRef<"p">,
 	ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
 >(({ className, ...props }, ref) => (
 	<DialogPrimitive.Description

--- a/packages/mantle/src/components/dialog/primitive.tsx
+++ b/packages/mantle/src/components/dialog/primitive.tsx
@@ -1,7 +1,7 @@
 import * as DialogPrimitive from "@radix-ui/react-dialog";
 import {
 	type ComponentPropsWithoutRef,
-	type ElementRef,
+	type ComponentRef,
 	createContext,
 	forwardRef,
 	useContext,
@@ -40,7 +40,7 @@ const Close = DialogPrimitive.Close;
 const Overlay = DialogPrimitive.Overlay;
 
 const Content = forwardRef<
-	ElementRef<"div">,
+	ComponentRef<"div">,
 	ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
 >((props, ref) => {
 	const ctx = useContext(InternalDialogContext);
@@ -58,7 +58,7 @@ const Content = forwardRef<
 const Title = DialogPrimitive.Title;
 
 const Description = forwardRef<
-	ElementRef<"p">,
+	ComponentRef<"p">,
 	ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
 >((props, ref) => {
 	const ctx = useContext(InternalDialogContext);

--- a/packages/mantle/src/components/dropdown-menu/dropdown-menu.tsx
+++ b/packages/mantle/src/components/dropdown-menu/dropdown-menu.tsx
@@ -1,7 +1,7 @@
 import { CaretRight } from "@phosphor-icons/react/CaretRight";
 import { Check } from "@phosphor-icons/react/Check";
 import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
-import type { ComponentPropsWithoutRef, ElementRef } from "react";
+import type { ComponentPropsWithoutRef, ComponentRef } from "react";
 import { forwardRef } from "react";
 import { cx } from "../../utils/cx/cx.js";
 import { Separator } from "../separator/separator.js";
@@ -19,7 +19,7 @@ const DropdownMenuSub = DropdownMenuPrimitive.Sub;
 const DropdownMenuRadioGroup = DropdownMenuPrimitive.RadioGroup;
 
 const DropdownMenuSubTrigger = forwardRef<
-	ElementRef<typeof DropdownMenuPrimitive.SubTrigger>,
+	ComponentRef<typeof DropdownMenuPrimitive.SubTrigger>,
 	ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubTrigger> & {
 		inset?: boolean;
 	}
@@ -44,7 +44,7 @@ const DropdownMenuSubTrigger = forwardRef<
 DropdownMenuSubTrigger.displayName = "DropdownMenuSubTrigger";
 
 const DropdownMenuSubContent = forwardRef<
-	ElementRef<typeof DropdownMenuPrimitive.SubContent>,
+	ComponentRef<typeof DropdownMenuPrimitive.SubContent>,
 	ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubContent>
 >(({ className, loop = true, ...props }, ref) => (
 	<DropdownMenuPortal>
@@ -73,7 +73,7 @@ type DropdownMenuContentProps = ComponentPropsWithoutRef<
 };
 
 const DropdownMenuContent = forwardRef<
-	ElementRef<typeof DropdownMenuPrimitive.Content>,
+	ComponentRef<typeof DropdownMenuPrimitive.Content>,
 	DropdownMenuContentProps
 >(({ className, onClick, loop = true, width, ...props }, ref) => (
 	<DropdownMenuPortal>
@@ -103,7 +103,7 @@ const DropdownMenuContent = forwardRef<
 DropdownMenuContent.displayName = "DropdownMenuContent";
 
 const DropdownMenuItem = forwardRef<
-	ElementRef<typeof DropdownMenuPrimitive.Item>,
+	ComponentRef<typeof DropdownMenuPrimitive.Item>,
 	ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item> & {
 		inset?: boolean;
 	}
@@ -122,7 +122,7 @@ const DropdownMenuItem = forwardRef<
 DropdownMenuItem.displayName = "DropdownMenuItem";
 
 const DropdownMenuCheckboxItem = forwardRef<
-	ElementRef<typeof DropdownMenuPrimitive.CheckboxItem>,
+	ComponentRef<typeof DropdownMenuPrimitive.CheckboxItem>,
 	ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.CheckboxItem>
 >(({ className, children, checked, ...props }, ref) => (
 	<DropdownMenuPrimitive.CheckboxItem
@@ -155,7 +155,7 @@ type DropdownMenuRadioItemProps = ComponentPropsWithoutRef<
 };
 
 const DropdownMenuRadioItem = forwardRef<
-	ElementRef<"input">,
+	ComponentRef<"input">,
 	DropdownMenuRadioItemProps
 >(({ className, children, ...props }, ref) => (
 	<DropdownMenuPrimitive.RadioItem
@@ -181,7 +181,7 @@ const DropdownMenuRadioItem = forwardRef<
 DropdownMenuRadioItem.displayName = "DropdownMenuRadioItem";
 
 const DropdownMenuLabel = forwardRef<
-	ElementRef<typeof DropdownMenuPrimitive.Label>,
+	ComponentRef<typeof DropdownMenuPrimitive.Label>,
 	ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Label> & {
 		inset?: boolean;
 	}
@@ -199,7 +199,7 @@ const DropdownMenuLabel = forwardRef<
 DropdownMenuLabel.displayName = "DropdownMenuLabel";
 
 const DropdownMenuSeparator = forwardRef<
-	ElementRef<typeof Separator>,
+	ComponentRef<typeof Separator>,
 	ComponentPropsWithoutRef<typeof Separator>
 >(({ className, ...props }, ref) => (
 	<Separator

--- a/packages/mantle/src/components/hover-card/hover-card.tsx
+++ b/packages/mantle/src/components/hover-card/hover-card.tsx
@@ -2,7 +2,7 @@
 
 import * as HoverCardPrimitive from "@radix-ui/react-hover-card";
 import { forwardRef } from "react";
-import type { ComponentPropsWithoutRef, ElementRef } from "react";
+import type { ComponentPropsWithoutRef, ComponentRef } from "react";
 import { cx } from "../../utils/cx/cx.js";
 
 const HoverCard = ({
@@ -29,7 +29,7 @@ const HoverCardTrigger = HoverCardPrimitive.Trigger;
 const HoverCardPortal = HoverCardPrimitive.Portal;
 
 const HoverCardContent = forwardRef<
-	ElementRef<typeof HoverCardPrimitive.Content>,
+	ComponentRef<typeof HoverCardPrimitive.Content>,
 	ComponentPropsWithoutRef<typeof HoverCardPrimitive.Content>
 >(({ className, onClick, align = "center", sideOffset = 4, ...props }, ref) => (
 	<HoverCardPortal>

--- a/packages/mantle/src/components/icon/icon.tsx
+++ b/packages/mantle/src/components/icon/icon.tsx
@@ -1,4 +1,4 @@
-import { type ElementRef, type ReactNode, forwardRef } from "react";
+import { type ComponentRef, type ReactNode, forwardRef } from "react";
 import { cx } from "../../utils/cx/cx.js";
 import { SvgOnly } from "./svg-only.js";
 import type { SvgAttributes } from "./types.js";
@@ -18,7 +18,7 @@ type IconProps = Omit<SvgAttributes, "children"> & {
  * 3. Icon className
  * 4. svg className
  */
-const Icon = forwardRef<ElementRef<"svg">, IconProps>(
+const Icon = forwardRef<ComponentRef<"svg">, IconProps>(
 	({ className, style, svg, ...props }, ref) => (
 		<SvgOnly
 			ref={ref}

--- a/packages/mantle/src/components/icon/svg-only.tsx
+++ b/packages/mantle/src/components/icon/svg-only.tsx
@@ -1,4 +1,4 @@
-import type { ElementRef, ReactNode } from "react";
+import type { ComponentRef, ReactNode } from "react";
 import { Children, cloneElement, forwardRef, isValidElement } from "react";
 import invariant from "tiny-invariant";
 import { cx } from "../../utils/cx/cx.js";
@@ -24,7 +24,7 @@ type SvgOnlyProps = Omit<SvgAttributes, "children"> & {
  * The main difference between `Icon` and `SvgOnly` is that `SvgOnly` does not
  * apply any default sizing styles, only `shrink-0`.
  */
-const SvgOnly = forwardRef<ElementRef<"svg">, SvgOnlyProps>(
+const SvgOnly = forwardRef<ComponentRef<"svg">, SvgOnlyProps>(
 	({ className, style, svg, ...props }, ref) => {
 		invariant(
 			isValidElement<SvgAttributes>(svg) && Children.only(svg),

--- a/packages/mantle/src/components/input/input.test.tsx
+++ b/packages/mantle/src/components/input/input.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { userEvent } from "@testing-library/user-event";
 import { act, useEffect, useRef, useState } from "react";
-import type { ElementRef } from "react";
+import type { ComponentRef } from "react";
 import { describe, expect, test } from "vitest";
 import { Input, InputCapture } from "./input.js";
 
@@ -132,7 +132,7 @@ describe("Input", () => {
 
 	test("without children, passes ref through and allows focus on mount", async () => {
 		const Subject = () => {
-			const inputRef = useRef<ElementRef<"input">>(null);
+			const inputRef = useRef<ComponentRef<"input">>(null);
 
 			useEffect(() => {
 				inputRef.current?.focus();
@@ -152,7 +152,7 @@ describe("Input", () => {
 
 	test("with children, passes ref through from Input and allows focus on mount", async () => {
 		const Subject = () => {
-			const inputRef = useRef<ElementRef<"input">>(null);
+			const inputRef = useRef<ComponentRef<"input">>(null);
 
 			useEffect(() => {
 				inputRef.current?.focus();
@@ -176,7 +176,7 @@ describe("Input", () => {
 
 	test("with children, passes ref through from InputCapture and allows focus on mount", async () => {
 		const Subject = () => {
-			const inputRef = useRef<ElementRef<"input">>(null);
+			const inputRef = useRef<ComponentRef<"input">>(null);
 
 			useEffect(() => {
 				inputRef.current?.focus();

--- a/packages/mantle/src/components/input/input.tsx
+++ b/packages/mantle/src/components/input/input.tsx
@@ -3,7 +3,7 @@ import { Warning } from "@phosphor-icons/react/Warning";
 import { WarningDiamond } from "@phosphor-icons/react/WarningDiamond";
 import clsx from "clsx";
 import type {
-	ElementRef,
+	ComponentRef,
 	ForwardedRef,
 	InputHTMLAttributes,
 	MutableRefObject,
@@ -37,7 +37,7 @@ type InputProps = Omit<
 const Input = forwardRef<HTMLInputElement, InputProps>(
 	({ children, className, ...props }, forwardedRef) => {
 		const hasChildren = Boolean(children);
-		const innerRef = useRef<ElementRef<"input">>(null);
+		const innerRef = useRef<ComponentRef<"input">>(null);
 
 		if (hasChildren) {
 			return (

--- a/packages/mantle/src/components/label/label.tsx
+++ b/packages/mantle/src/components/label/label.tsx
@@ -1,12 +1,12 @@
 import { forwardRef } from "react";
-import type { ComponentPropsWithoutRef, ElementRef } from "react";
+import type { ComponentPropsWithoutRef, ComponentRef } from "react";
 import { cx } from "../../utils/cx/cx.js";
 
 type LabelProps = ComponentPropsWithoutRef<"label"> & {
 	disabled?: boolean;
 };
 
-const Label = forwardRef<ElementRef<"label">, LabelProps>(
+const Label = forwardRef<ComponentRef<"label">, LabelProps>(
 	(
 		{
 			"aria-disabled": _ariaDisabled,

--- a/packages/mantle/src/components/pagination/cursor-pagination.tsx
+++ b/packages/mantle/src/components/pagination/cursor-pagination.tsx
@@ -3,7 +3,7 @@ import { CaretRight } from "@phosphor-icons/react/dist/icons/CaretRight";
 import { Slot } from "@radix-ui/react-slot";
 import {
 	type ComponentProps,
-	type ElementRef,
+	type ComponentRef,
 	createContext,
 	forwardRef,
 	useContext,
@@ -107,7 +107,7 @@ type CursorButtonsProps = Omit<
  * A pair of buttons for navigating between pages of data when using cursor-based pagination.
  */
 const CursorButtons = forwardRef<
-	ElementRef<typeof ButtonGroup>,
+	ComponentRef<typeof ButtonGroup>,
 	CursorButtonsProps
 >(
 	(
@@ -163,7 +163,7 @@ type CursorPageSizeSelectProps = Omit<
  * A select input for changing the number of items per page when using cursor-based pagination.
  */
 const CursorPageSizeSelect = forwardRef<
-	ElementRef<typeof SelectTrigger>,
+	ComponentRef<typeof SelectTrigger>,
 	CursorPageSizeSelectProps
 >(
 	(

--- a/packages/mantle/src/components/popover/popover.tsx
+++ b/packages/mantle/src/components/popover/popover.tsx
@@ -1,6 +1,6 @@
 import * as PopoverPrimitive from "@radix-ui/react-popover";
 import { forwardRef } from "react";
-import type { ComponentPropsWithoutRef, ElementRef } from "react";
+import type { ComponentPropsWithoutRef, ComponentRef } from "react";
 import { cx } from "../../utils/cx/cx.js";
 
 /**
@@ -58,7 +58,7 @@ PopoverClose.displayName = "PopoverClose";
  * https://github.com/ngrok-oss/mantle/issues
  */
 const PopoverContent = forwardRef<
-	ElementRef<typeof PopoverPrimitive.Content>,
+	ComponentRef<typeof PopoverPrimitive.Content>,
 	ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
 >(({ className, align = "center", sideOffset = 4, ...props }, ref) => (
 	<PopoverPrimitive.Portal>

--- a/packages/mantle/src/components/radio-group/radio-group.tsx
+++ b/packages/mantle/src/components/radio-group/radio-group.tsx
@@ -18,7 +18,7 @@ import {
 	useRef,
 } from "react";
 import type {
-	ElementRef,
+	ComponentRef,
 	HTMLAttributes,
 	PropsWithChildren,
 	ReactNode,
@@ -35,7 +35,7 @@ type RadioGroupProps = PropsWithChildren<
  * A group of radio items. It manages the state of the children radios. Unstyled and simple.
  */
 const RadioGroup = forwardRef<
-	ElementRef<typeof HeadlessRadioGroup>,
+	ComponentRef<typeof HeadlessRadioGroup>,
 	RadioGroupProps
 >((props, ref) => <HeadlessRadioGroup {...props} ref={ref} />);
 RadioGroup.displayName = "RadioGroup";
@@ -70,7 +70,7 @@ type RadioItemProps = Omit<HeadlessRadioProps, "children"> & PropsWithChildren;
  * A simple radio item that can be used inside a radio group. The "conventional" use-case.
  * Must be a child of `RadioGroup`.
  */
-const RadioItem = forwardRef<ElementRef<"div">, RadioItemProps>(
+const RadioItem = forwardRef<ComponentRef<"div">, RadioItemProps>(
 	({ children, className, ...props }, ref) => (
 		<HeadlessRadio
 			className={cx(
@@ -156,7 +156,7 @@ const RadioIndicator = ({
  * A group of radio list items. Use RadioListItem as direct children.
  */
 const RadioGroupList = forwardRef<
-	ElementRef<typeof RadioGroup>,
+	ComponentRef<typeof RadioGroup>,
 	RadioGroupProps
 >(({ className, ...props }, ref) => {
 	return (
@@ -174,7 +174,7 @@ type RadioListItemProps = RadioItemProps;
 /**
  * A radio list item that is used inside a `RadioGroupList`.
  */
-const RadioListItem = forwardRef<ElementRef<"div">, RadioListItemProps>(
+const RadioListItem = forwardRef<ComponentRef<"div">, RadioListItemProps>(
 	({ children, className, ...props }, ref) => {
 		return (
 			<HeadlessRadio
@@ -212,7 +212,7 @@ type RadioCardProps = RadioItemProps;
 /**
  * A radio card item. Use it as a child of `RadioGroup`
  */
-const RadioCard = forwardRef<ElementRef<"div">, RadioCardProps>(
+const RadioCard = forwardRef<ComponentRef<"div">, RadioCardProps>(
 	({ children, className, ...props }, ref) => {
 		return (
 			<HeadlessRadio
@@ -273,7 +273,7 @@ const RadioItemContent = ({
  * An inline group of radio buttons. Use RadioButton as direct children.
  */
 const RadioButtonGroup = forwardRef<
-	ElementRef<typeof RadioGroup>,
+	ComponentRef<typeof RadioGroup>,
 	RadioGroupProps
 >(({ className, ...props }, ref) => {
 	return (
@@ -291,7 +291,7 @@ type RadioButtonProps = RadioItemProps;
 /**
  * A radio button that is used inside a `RadioButtonGroup`.
  */
-const RadioButton = forwardRef<ElementRef<"div">, RadioButtonProps>(
+const RadioButton = forwardRef<ComponentRef<"div">, RadioButtonProps>(
 	({ children, className, ...props }, ref) => {
 		return (
 			<HeadlessRadio

--- a/packages/mantle/src/components/select/select.tsx
+++ b/packages/mantle/src/components/select/select.tsx
@@ -5,7 +5,7 @@ import * as SelectPrimitive from "@radix-ui/react-select";
 import type {
 	ComponentProps,
 	ComponentPropsWithoutRef,
-	ElementRef,
+	ComponentRef,
 	FocusEvent,
 	Ref,
 	SelectHTMLAttributes,
@@ -102,7 +102,7 @@ type SelectTriggerProps = ComponentPropsWithoutRef<
  * The button that toggles the select. The Select.Content will position itself adjacent to the trigger.
  */
 const SelectTrigger = forwardRef<
-	ElementRef<typeof SelectPrimitive.Trigger>,
+	ComponentRef<typeof SelectPrimitive.Trigger>,
 	SelectTriggerProps
 >(
 	(
@@ -157,7 +157,7 @@ const SelectTrigger = forwardRef<
 SelectTrigger.displayName = "SelectTrigger";
 
 const SelectScrollUpButton = forwardRef<
-	ElementRef<typeof SelectPrimitive.ScrollUpButton>,
+	ComponentRef<typeof SelectPrimitive.ScrollUpButton>,
 	ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollUpButton>
 >(({ className, ...props }, ref) => (
 	<SelectPrimitive.ScrollUpButton
@@ -174,7 +174,7 @@ const SelectScrollUpButton = forwardRef<
 SelectScrollUpButton.displayName = "SelectScrollUpButton";
 
 const SelectScrollDownButton = forwardRef<
-	ElementRef<typeof SelectPrimitive.ScrollDownButton>,
+	ComponentRef<typeof SelectPrimitive.ScrollDownButton>,
 	ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollDownButton>
 >(({ className, ...props }, ref) => (
 	<SelectPrimitive.ScrollDownButton
@@ -201,7 +201,7 @@ type SelectContentProps = ComponentPropsWithoutRef<
  * It contains a scrolling viewport of the select items.
  */
 const SelectContent = forwardRef<
-	ElementRef<typeof SelectPrimitive.Content>,
+	ComponentRef<typeof SelectPrimitive.Content>,
 	SelectContentProps
 >(({ className, children, position = "popper", width, ...props }, ref) => (
 	<SelectPrimitive.Portal>
@@ -238,7 +238,7 @@ SelectContent.displayName = "SelectContent";
  * Used to render the label of a group. It won't be focusable using arrow keys.
  */
 const SelectLabel = forwardRef<
-	ElementRef<typeof SelectPrimitive.Label>,
+	ComponentRef<typeof SelectPrimitive.Label>,
 	ComponentPropsWithoutRef<typeof SelectPrimitive.Label>
 >(({ className, ...props }, ref) => (
 	<SelectPrimitive.Label
@@ -255,7 +255,7 @@ SelectLabel.displayName = "SelectLabel";
  * Displays the children as the option's text.
  */
 const SelectItem = forwardRef<
-	ElementRef<typeof SelectPrimitive.Item>,
+	ComponentRef<typeof SelectPrimitive.Item>,
 	ComponentPropsWithoutRef<typeof SelectPrimitive.Item>
 >(({ className, children, ...props }, ref) => (
 	<SelectPrimitive.Item
@@ -282,7 +282,7 @@ SelectItem.displayName = "SelectItem";
  * Used to visually separate items in the select.
  */
 const SelectSeparator = forwardRef<
-	ElementRef<typeof Separator>,
+	ComponentRef<typeof Separator>,
 	ComponentPropsWithoutRef<typeof Separator>
 >(({ className, ...props }, ref) => (
 	<Separator

--- a/packages/mantle/src/components/separator/separator.tsx
+++ b/packages/mantle/src/components/separator/separator.tsx
@@ -3,7 +3,7 @@ import { Slot } from "@radix-ui/react-slot";
 import { createContext, forwardRef, useContext } from "react";
 import type {
 	ComponentPropsWithoutRef,
-	ElementRef,
+	ComponentRef,
 	HTMLAttributes,
 } from "react";
 import type { WithAsChild } from "../../types/as-child.js";
@@ -50,7 +50,7 @@ type SeparatorProps = ComponentPropsWithoutRef<typeof SeparatorPrimitive.Root>;
  * Visually or semantically separates content.
  */
 const Separator = forwardRef<
-	ElementRef<typeof SeparatorPrimitive.Root>,
+	ComponentRef<typeof SeparatorPrimitive.Root>,
 	SeparatorProps
 >(
 	(

--- a/packages/mantle/src/components/sheet/sheet.tsx
+++ b/packages/mantle/src/components/sheet/sheet.tsx
@@ -2,7 +2,7 @@ import { X } from "@phosphor-icons/react/X";
 import { type VariantProps, cva } from "class-variance-authority";
 import type {
 	ComponentPropsWithoutRef,
-	ElementRef,
+	ComponentRef,
 	HTMLAttributes,
 } from "react";
 import { forwardRef } from "react";
@@ -43,7 +43,7 @@ const SheetPortal = SheetPrimitive.Portal;
  * You likely don't need to use this component directly, as it is used internally by the `SheetContent` component.
  */
 const SheetOverlay = forwardRef<
-	ElementRef<typeof SheetPrimitive.Overlay>,
+	ComponentRef<typeof SheetPrimitive.Overlay>,
 	ComponentPropsWithoutRef<typeof SheetPrimitive.Overlay>
 >(({ className, ...props }, ref) => (
 	<SheetPrimitive.Overlay
@@ -85,7 +85,7 @@ type SheetContentProps = {} & ComponentPropsWithoutRef<
  * The main container for a sheet. Renders on top of the overlay backdrop.
  * Should compose the `SheetHeader`, `SheetBody`, and `SheetFooter`.
  */
-const SheetContent = forwardRef<ElementRef<"div">, SheetContentProps>(
+const SheetContent = forwardRef<ComponentRef<"div">, SheetContentProps>(
 	(
 		{
 			children,
@@ -194,7 +194,7 @@ const SheetFooter = ({
  * Defaults to an `h2` element, but can be changed via the `asChild` prop.
  */
 const SheetTitle = forwardRef<
-	ElementRef<typeof SheetPrimitive.Title>,
+	ComponentRef<typeof SheetPrimitive.Title>,
 	ComponentPropsWithoutRef<typeof SheetPrimitive.Title>
 >(({ className, ...props }, ref) => (
 	<SheetPrimitive.Title
@@ -209,7 +209,7 @@ SheetTitle.displayName = SheetPrimitive.Title.displayName;
  * A group container for the title and actions of a sheet. Typically rendered as a child of `SheetHeader`.
  */
 const SheetTitleGroup = forwardRef<
-	ElementRef<"div">,
+	ComponentRef<"div">,
 	HTMLAttributes<HTMLDivElement>
 >(({ children, className, ...props }, ref) => (
 	<div
@@ -226,7 +226,7 @@ SheetTitleGroup.displayName = "SheetTitleGroup";
  * A description for a sheet. Typically rendered as a child of `SheetHeader`.
  */
 const SheetDescription = forwardRef<
-	ElementRef<typeof SheetPrimitive.Description>,
+	ComponentRef<typeof SheetPrimitive.Description>,
 	ComponentPropsWithoutRef<typeof SheetPrimitive.Description>
 >(({ className, ...props }, ref) => (
 	<SheetPrimitive.Description
@@ -241,7 +241,7 @@ SheetDescription.displayName = SheetPrimitive.Description.displayName;
  * A group container for the actions of a sheet. Typically rendered as a child of `SheetTitleGroup`.
  */
 const SheetActions = forwardRef<
-	ElementRef<"div">,
+	ComponentRef<"div">,
 	HTMLAttributes<HTMLDivElement>
 >(({ children, className, ...props }, ref) => (
 	<div

--- a/packages/mantle/src/components/switch/switch.tsx
+++ b/packages/mantle/src/components/switch/switch.tsx
@@ -4,7 +4,7 @@ import {
 } from "@radix-ui/react-switch";
 import clsx from "clsx";
 import { forwardRef } from "react";
-import type { ComponentPropsWithoutRef, ElementRef } from "react";
+import type { ComponentPropsWithoutRef, ComponentRef } from "react";
 import { parseBooleanish } from "../../types/booleanish.js";
 import { cx } from "../../utils/cx/cx.js";
 
@@ -16,7 +16,10 @@ type SwitchProps = ComponentPropsWithoutRef<typeof SwitchPrimitiveRoot> & {
 	readOnly?: boolean;
 };
 
-const Switch = forwardRef<ElementRef<typeof SwitchPrimitiveRoot>, SwitchProps>(
+const Switch = forwardRef<
+	ComponentRef<typeof SwitchPrimitiveRoot>,
+	SwitchProps
+>(
 	(
 		{
 			"aria-readonly": _ariaReadOnly,

--- a/packages/mantle/src/components/tabs/tabs.tsx
+++ b/packages/mantle/src/components/tabs/tabs.tsx
@@ -7,7 +7,7 @@ import {
 import clsx from "clsx";
 import type {
 	ComponentPropsWithoutRef,
-	ElementRef,
+	ComponentRef,
 	HTMLAttributes,
 } from "react";
 import {
@@ -31,7 +31,7 @@ const TabsStateContext = createContext<TabsStateContextValue>({
 });
 
 const Tabs = forwardRef<
-	ElementRef<typeof TabsPrimitiveRoot>,
+	ComponentRef<typeof TabsPrimitiveRoot>,
 	ComponentPropsWithoutRef<typeof TabsPrimitiveRoot>
 >(({ className, children, orientation = "horizontal", ...props }, ref) => (
 	<TabsPrimitiveRoot
@@ -52,7 +52,7 @@ const Tabs = forwardRef<
 Tabs.displayName = "Tabs";
 
 const TabsList = forwardRef<
-	ElementRef<typeof TabsPrimitiveList>,
+	ComponentRef<typeof TabsPrimitiveList>,
 	ComponentPropsWithoutRef<typeof TabsPrimitiveList>
 >(({ className, ...props }, ref) => {
 	const ctx = useContext(TabsStateContext);
@@ -94,7 +94,7 @@ const TabsTriggerDecoration = () => {
 };
 
 const TabsTrigger = forwardRef<
-	ElementRef<typeof TabsPrimitiveTrigger>,
+	ComponentRef<typeof TabsPrimitiveTrigger>,
 	TabsTriggerProps
 >(
 	(
@@ -198,7 +198,7 @@ const TabBadge = ({
 );
 
 const TabsContent = forwardRef<
-	ElementRef<typeof TabsPrimitiveContent>,
+	ComponentRef<typeof TabsPrimitiveContent>,
 	ComponentPropsWithoutRef<typeof TabsPrimitiveContent>
 >(({ className, ...props }, ref) => (
 	<TabsPrimitiveContent

--- a/packages/mantle/src/components/toast/toast.tsx
+++ b/packages/mantle/src/components/toast/toast.tsx
@@ -7,7 +7,7 @@ import { WarningDiamond } from "@phosphor-icons/react/WarningDiamond";
 import { Slot } from "@radix-ui/react-slot";
 import {
 	type ComponentProps,
-	type ElementRef,
+	type ComponentRef,
 	type ReactNode,
 	createContext,
 	forwardRef,
@@ -133,7 +133,7 @@ type ToastProps = ComponentProps<"div"> &
  * A succinct message with a priority that is displayed temporarily.
  * Toasts are used to provide feedback to the user without interrupting their workflow.
  */
-const Toast = forwardRef<ElementRef<"div">, ToastProps>(
+const Toast = forwardRef<ComponentRef<"div">, ToastProps>(
 	({ asChild, children, className, priority, ...props }, ref) => {
 		const Component = asChild ? Slot : "div";
 
@@ -168,7 +168,7 @@ type ToastIconProps = Partial<SvgOnlyProps>;
  * An icon that visually represents the priority of the toast.
  * If you do not provide an icon, the default icon and color for the priority is used.
  */
-const ToastIcon = forwardRef<ElementRef<"svg">, ToastIconProps>(
+const ToastIcon = forwardRef<ComponentRef<"svg">, ToastIconProps>(
 	({ className, svg, ...props }, ref) => {
 		const ctx = useContext(ToastStateContext);
 
@@ -222,7 +222,7 @@ type ToastActionProps = ComponentProps<"button"> & WithAsChild;
  * A button that dismisses the toast when clicked.
  * You can prevent the toast from being dismissed `onClick` by calling `event.preventDefault()`
  */
-const ToastAction = forwardRef<ElementRef<"button">, ToastActionProps>(
+const ToastAction = forwardRef<ComponentRef<"button">, ToastActionProps>(
 	({ asChild, className, onClick, ...props }, ref) => {
 		const ctx = useContext(ToastIdContext);
 
@@ -256,7 +256,7 @@ type ToastMessageProps = ComponentProps<"p"> & WithAsChild;
 /**
  * The message content of the toast.
  */
-const ToastMessage = forwardRef<ElementRef<"p">, ToastMessageProps>(
+const ToastMessage = forwardRef<ComponentRef<"p">, ToastMessageProps>(
 	({ asChild, className, ...props }, ref) => {
 		const Component = asChild ? Slot : "p";
 

--- a/packages/mantle/src/components/tooltip/tooltip.tsx
+++ b/packages/mantle/src/components/tooltip/tooltip.tsx
@@ -1,6 +1,6 @@
 import { Content, Provider, Root, Trigger } from "@radix-ui/react-tooltip";
 import { forwardRef } from "react";
-import type { ComponentPropsWithoutRef, ElementRef } from "react";
+import type { ComponentPropsWithoutRef, ComponentRef } from "react";
 import { cx } from "../../utils/cx/cx.js";
 
 /**
@@ -50,7 +50,7 @@ const TooltipTrigger = Trigger;
  * https://github.com/ngrok-oss/mantle/issues
  */
 const TooltipContent = forwardRef<
-	ElementRef<typeof Content>,
+	ComponentRef<typeof Content>,
 	ComponentPropsWithoutRef<typeof Content>
 >(({ children, className, sideOffset = 4, ...props }, ref) => (
 	<Content


### PR DESCRIPTION
### Why

In react 19, `type ElementRef` is deprecated in favor of the existing `type ComponentRef`