### PR TITLE
fix start: bring back build dependsOn

### DIFF
--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -7,12 +7,13 @@
   },
   "scripts": {
     "build": "react-router build",
+    "clean": "rm -rf .vercel build",
+    "prebuild": "pnpm run clean",
     "serve": "react-router-serve build/server/index.js",
     "start": "react-router dev --host",
     "test": "vitest run --passWithNoTests",
     "test:watch": "vitest watch",
-    "typecheck": "react-router typegen && tsc",
-    "clean": "rm -rf build && rm -rf .turbo"
+    "typecheck": "react-router typegen && tsc"
   },
   "dependencies": {
     "@ngrok/mantle": "workspace:*",

--- a/packages/mantle/package.json
+++ b/packages/mantle/package.json
@@ -27,7 +27,7 @@
   "scripts": {
     "build": "NODE_OPTIONS='--max-old-space-size=16384' tsup",
     "clean": "rm -rf dist",
-    "prebuild": "rm -rf dist",
+    "prebuild": "pnpm run clean",
     "test:watch": "TZ=UTC vitest watch",
     "test": "TZ=UTC vitest run",
     "typecheck": "tsc"

--- a/turbo.json
+++ b/turbo.json
@@ -27,12 +27,11 @@
       "outputs": ["public/build/**"]
     },
     "start": {
+      "dependsOn": ["^build"],
       "cache": false,
       "persistent": true
     },
-    "test": {
-      "outputs": []
-    },
+    "test": {},
     "test:watch": {
       "cache": false,
       "persistent": true


### PR DESCRIPTION
this will fix caching issues with `pnpm start`

i removed the `"dependsOn": ["^build"]` before to optimize cold starts, but this was a mistake: vite cannot resolve typescript imports from monorepo node_modules even with custom conditions applied

so, if someone were to clone the repo, `direnv allow`, and `pnpm start`, it would error because we are missing the mantle `/dist` build!