### PR TITLE
DataTable: export both DataTableHeaderSortButton and DataTableHeader, decouple behavior to make it fully customizable

### DIFF
--- a/.changeset/young-crews-yell.md
+++ b/.changeset/young-crews-yell.md
@@ -1,0 +1,5 @@
+---
+"@ngrok/mantle": patch
+---
+
+DataTable: export both DataTableHeaderSortButton and DataTableHeader, decouple behavior to make it fully customizable

--- a/apps/www/app/routes/components.preview.data-table.tsx
+++ b/apps/www/app/routes/components.preview.data-table.tsx
@@ -8,6 +8,7 @@ import {
 } from "@ngrok/mantle/code-block";
 import {
 	DataTableHeader,
+	DataTableHeaderSortButton,
 	createColumnHelper,
 	flexRender,
 	getCoreRowModel,
@@ -205,38 +206,70 @@ const columns = [
 	columnHelper.accessor("id", {
 		id: "id",
 		header: (props) => (
-			<DataTableHeader column={props.column} sortingMode="alphanumeric">
-				ID
+			<DataTableHeader>
+				<DataTableHeaderSortButton
+					column={props.column}
+					sortingMode="alphanumeric"
+				>
+					ID
+				</DataTableHeaderSortButton>
 			</DataTableHeader>
 		),
-		cell: (props) => <TableCell>{props.getValue()}</TableCell>,
+		cell: (props) => (
+			<TableCell key={props.cell.id}>{props.getValue()}</TableCell>
+		),
 	}),
 	columnHelper.accessor("amount", {
 		id: "amount",
 		header: (props) => (
-			<DataTableHeader column={props.column} sortingMode="alphanumeric">
-				Amount
+			<DataTableHeader className="w-[200px]">
+				<DataTableHeaderSortButton
+					className="justify-end"
+					column={props.column}
+					iconPlacement="start"
+					sortingMode="alphanumeric"
+				>
+					Amount
+				</DataTableHeaderSortButton>
 			</DataTableHeader>
 		),
-		cell: (props) => <TableCell>{props.getValue()}</TableCell>,
+		cell: (props) => (
+			<TableCell key={props.cell.id} className="text-right">
+				{props.getValue()}
+			</TableCell>
+		),
 	}),
 	columnHelper.accessor("status", {
 		id: "status",
 		header: (props) => (
-			<DataTableHeader column={props.column} sortingMode="alphanumeric">
-				Status
+			<DataTableHeader>
+				<DataTableHeaderSortButton
+					column={props.column}
+					sortingMode="alphanumeric"
+				>
+					Status
+				</DataTableHeaderSortButton>
 			</DataTableHeader>
 		),
-		cell: (props) => <TableCell>{props.getValue()}</TableCell>,
+		cell: (props) => (
+			<TableCell key={props.cell.id}>{props.getValue()}</TableCell>
+		),
 	}),
 	columnHelper.accessor("email", {
 		id: "email",
 		header: (props) => (
-			<DataTableHeader column={props.column} sortingMode="alphanumeric">
-				Email
+			<DataTableHeader>
+				<DataTableHeaderSortButton
+					column={props.column}
+					sortingMode="alphanumeric"
+				>
+					Email
+				</DataTableHeaderSortButton>
 			</DataTableHeader>
 		),
-		cell: (props) => <TableCell>{props.getValue()}</TableCell>,
+		cell: (props) => (
+			<TableCell key={props.cell.id}>{props.getValue()}</TableCell>
+		),
 	}),
 ];
 

--- a/apps/www/tailwind.config.ts
+++ b/apps/www/tailwind.config.ts
@@ -1,7 +1,17 @@
-import { mantlePreset } from "@ngrok/mantle/tailwind-preset";
+import { createRequire } from "node:module";
+import {
+	mantlePreset,
+	resolveMantleContentGlob,
+} from "@ngrok/mantle/tailwind-preset";
 import type { Config } from "tailwindcss";
+
+const require = createRequire(import.meta.url);
 
 export default {
 	presets: [mantlePreset],
-	content: ["./app/**/*.tsx", "../../packages/mantle/src/**/*.{ts,tsx}"],
+	content: [
+		resolveMantleContentGlob(require),
+		"./app/**/*.tsx",
+		"../../packages/mantle/src/**/*.{ts,tsx}",
+	],
 } satisfies Config;

--- a/apps/www/vite.config.ts
+++ b/apps/www/vite.config.ts
@@ -14,4 +14,7 @@ export default defineConfig({
 	resolve: {
 		conditions: ["@ngrok/mantle/source"],
 	},
+	optimizeDeps: {
+		exclude: ["@ngrok/mantle"],
+	},
 });

--- a/packages/mantle/src/components/data-table/data-table.tsx
+++ b/packages/mantle/src/components/data-table/data-table.tsx
@@ -86,7 +86,7 @@ function DataTableHeaderSortButton<TData, TValue>({
 	...props
 }: DataTableHeaderSortButtonProps<TData, TValue>) {
 	const _sortDirection = column.getIsSorted();
-	const canSort = !disableSorting || column.getCanSort();
+	const canSort = !disableSorting && column.getCanSort();
 
 	const sortDirection: SortDirection =
 		canSort && typeof _sortDirection === "string" ? _sortDirection : "unsorted";

--- a/packages/mantle/src/components/data-table/index.ts
+++ b/packages/mantle/src/components/data-table/index.ts
@@ -3,4 +3,5 @@ export * from "@tanstack/react-table";
 export {
 	//,
 	DataTableHeader,
+	DataTableHeaderSortButton,
 } from "./data-table.js";


### PR DESCRIPTION
also fixes some vite and tailwind config to improve performance in ~dev mode~ 🤫 <img src="https://emojis.slackmojis.com/emojis/images/1643514586/5893/figma.png" alt="figma" width="16" height="16"> local dev


