### PR TITLE
Fix `ComboboxItem` bug where `setValueOnClick` prop was destructured but never used

### DIFF
--- a/.changeset/warm-lights-sin.md
+++ b/.changeset/warm-lights-sin.md
@@ -1,0 +1,5 @@
+---
+"@ngrok/mantle": patch
+---
+
+Fix bug where `setValueOnClick` prop was destructured (to set a default) but then never passed along and used (so the consumer could never override it).

--- a/packages/mantle/src/components/combobox/combobox.tsx
+++ b/packages/mantle/src/components/combobox/combobox.tsx
@@ -181,7 +181,6 @@ const ComboboxItem = forwardRef<
 			children,
 			className,
 			focusOnHover = true,
-			setValueOnClick = true,
 			value,
 			...props
 		},


### PR DESCRIPTION
Heh, it seems we got bit by Biome ignoring rest siblings, see: https://github.com/biomejs/biome/issues/1910

This was then never used on `Primitive.ComboboxItem` so the prop was never able to be overridden by the consumer in the end 😅 

I think we can just remove setting a default of `true` because [that's the default](https://ariakit.org/reference/combobox-item#setvalueonclick) under the hood.