### PR TITLE
Fix Mantle source resolution for SSR

### DIFF
--- a/apps/www/vite.config.ts
+++ b/apps/www/vite.config.ts
@@ -17,6 +17,8 @@ export default defineConfig({
 		tsconfigPaths(),
 	],
 	resolve: {
+		// Ensure Mantle components resolve to source in dev mode (not dist)
+		// so client HMR picks up changes immediately
 		conditions: ["@ngrok/mantle/source"],
 	},
 	server: {
@@ -32,5 +34,11 @@ export default defineConfig({
 			// https://github.com/phosphor-icons/react/issues/45#issuecomment-2721119452
 			"@phosphor-icons/react",
 		],
+		resolve: {
+			// Same as above, but for the SSR renderer.
+			// Without this, the server falls back to dist and causes hydration mismatches
+			// (className warnings, missing styles, etc.) on hard refresh.
+			conditions: ["@ngrok/mantle/source"],
+		},
 	},
 });


### PR DESCRIPTION
Ran into a weird hydration mismatch when adding new classes to Mantle components under the hood, and looking at them over in the docs site locally:

- HMR looked fine (client picked up the new class right away)
- On hard refresh, SSR was still rendering the old dist build and console warned that `className` didn't match
- Restarting the dev server fixed it, but that obviously shouldn't be needed

Turns out our vite config only set `resolve.conditions` for the client 😅

**Fix:**

Added under `ssr.resolve.conditions` as well so SSR also uses the source build during dev 🎉 