### PR TITLE
ProgressDonut: add new indeterminateRotationSpeed prop and fix animation duration override

### DIFF
--- a/.changeset/cool-rocks-rest.md
+++ b/.changeset/cool-rocks-rest.md
@@ -1,0 +1,5 @@
+---
+"@ngrok/mantle": patch
+---
+
+ProgressDonut: add `indeterminateRotationSpeed` prop to control spin speed. Fix default `animation-duration-[15s]` so it no longer overrides consumer-provided `animation-duration-*` classes.

--- a/apps/www/app/routes/components.progress-donut.tsx
+++ b/apps/www/app/routes/components.progress-donut.tsx
@@ -90,7 +90,7 @@ export default function Page() {
 								<div className="grid w-6 place-items-center">
 									<ProgressDonut.Root
 										className="size-4"
-										value="indeterminate"
+										value={25}
 										strokeWidth="0.1875rem"
 									>
 										<ProgressDonut.Indicator />
@@ -157,11 +157,23 @@ export default function Page() {
 					<Code>"indeterminate"</Code> to show the progress bar in an
 					indeterminate state.
 				</p>
+				<p className="font-body text-body">
+					You can control the rotation speed with the{" "}
+					<Code>indeterminateRotationSpeed</Code> prop.
+				</p>
 				<div>
-					<Example>
+					<Example className="flex-col gap-6">
 						<ProgressDonut.Root
 							className="size-10"
 							value="indeterminate"
+							strokeWidth="0.375rem"
+						>
+							<ProgressDonut.Indicator />
+						</ProgressDonut.Root>
+						<ProgressDonut.Root
+							className="size-10"
+							value="indeterminate"
+							indeterminateRotationSpeed="animation-duration-[2s]"
 							strokeWidth="0.375rem"
 						>
 							<ProgressDonut.Indicator />
@@ -176,6 +188,15 @@ export default function Page() {
 									import { ProgressDonut } from "@ngrok/mantle/progress";
 
 									<ProgressDonut.Root className="size-10" value="indeterminate" strokeWidth="0.375rem">
+										<ProgressDonut.Indicator />
+									</ProgressDonut.Root>
+
+									<ProgressDonut.Root
+										className="size-10"
+										value="indeterminate"
+										indeterminateRotationSpeed="animation-duration-[2s]"
+										strokeWidth="0.375rem"
+									>
 										<ProgressDonut.Indicator />
 									</ProgressDonut.Root>
 								`}

--- a/packages/mantle/src/components/progress/progress-donut.tsx
+++ b/packages/mantle/src/components/progress/progress-donut.tsx
@@ -70,6 +70,15 @@ type Props = SvgAttributes & {
 	 * @default 0
 	 */
 	value?: ValueType | undefined;
+	/**
+	 * Controls the rotation speed of the indeterminate spinner state.
+	 *
+	 * Accepts a Tailwind `animation-duration-*` utility (e.g. `animation-duration-[2s]`).
+	 *
+	 * This prop is applied in addition to `animate-spin` to control the speed of the indeterminate spinner.
+	 * @default `animation-duration-[15s]`
+	 */
+	indeterminateRotationSpeed?: `animation-duration-${string}`;
 };
 
 /**
@@ -97,6 +106,7 @@ const Root = ({
 	max: _max = defaultMax,
 	strokeWidth: _strokeWidth = 4,
 	value: _value,
+	indeterminateRotationSpeed,
 	...props
 }: Props) => {
 	const max = isValidMaxNumber(_max) ? _max : defaultMax;
@@ -129,9 +139,18 @@ const Root = ({
 				aria-valuemax={max}
 				aria-valuemin={0}
 				aria-valuenow={valueNow}
-				className={clsx(
-					value === "indeterminate" && "animation-duration-[15s] animate-spin",
-					cx("size-6 text-gray-200 dark:text-gray-300", className),
+				className={cx(
+					"size-6 text-gray-200 dark:text-gray-300",
+					value === "indeterminate" && [
+						"animate-spin",
+						// Default duration only if consumer hasn't set one.
+						// Without this guard, both our `[15s]` and consumer overrides (e.g. `[2s]`)
+						// end up in the DOM. Since tw-animate-css utilities aren't currently deduped by
+						// tailwind-merge, whichever class Tailwind happened to emit last wins,
+						// which isn't reliable.
+						indeterminateRotationSpeed ?? "animation-duration-[15s]",
+					],
+					className,
 				)}
 				data-max={max}
 				data-min={0}


### PR DESCRIPTION
- Added new `indeterminateRotationSpeed` prop to let consumers control spin speed in indeterminate state.
- Fixed default `animation-duration-[15s]` so it no longer conflicts with consumer-provided values. 
  - `tailwind-merge` does not currently dedupe `animation-duration-*` utilities (from [tw-animate-css](https://github.com/Wombosvideo/tw-animate-css)), which previously caused the default to override consumer input.
  - This happened to work in Tailwind 3 by chance, due to CSS generation order, but is not reliable in Tailwind 4.