### PR TITLE
pnpm: enable "minimumReleaseAge: 1440" to provide some more protection against compromised npm packages

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,3 +2,10 @@ packages:
   - "apps/*"
   - "config/*"
   - "packages/*"
+
+# Don't install packages that are less than 1 day old
+# This reduces the risk of installing compromised packages.
+# In most cases, malicious releases are discovered and removed from the registry
+# within an hour.
+# see: https://pnpm.io/settings#minimumreleaseage
+minimumReleaseAge: 1440


### PR DESCRIPTION
this, combined with https://pnpm.io/settings#onlybuiltdependencies gives us some solid defense against the recent waves of malicious npm package takeovers