### PR TITLE
feat(code-block): default showLineNumbers to true in mantleCode()

### DIFF
--- a/.changeset/show-line-numbers-default-true.md
+++ b/.changeset/show-line-numbers-default-true.md
@@ -1,0 +1,5 @@
+---
+"@ngrok/mantle": patch
+---
+
+Default `showLineNumbers` to `true` in `mantleCode()` so code blocks show line numbers by default.

--- a/.changeset/show-line-numbers-default-true.md
+++ b/.changeset/show-line-numbers-default-true.md
@@ -1,5 +1,6 @@
 ---
 "@ngrok/mantle": patch
+"@ngrok/mantle-server-syntax-highlighter": patch
 ---
 
-Default `showLineNumbers` to `true` in `mantleCode()` so code blocks show line numbers by default.
+Default `showLineNumbers` to `true` in `mantleCode()` and `highlightWithMantleShiki()` so code blocks show line numbers by default.

--- a/.changeset/show-line-numbers-default-true.md
+++ b/.changeset/show-line-numbers-default-true.md
@@ -3,4 +3,4 @@
 "@ngrok/mantle-server-syntax-highlighter": patch
 ---
 
-Default `showLineNumbers` to `true` in `mantleCode()` and `highlightWithMantleShiki()` so code blocks show line numbers by default.
+Default `showLineNumbers` to `true` in `mantleCode()` and `highlightWithMantleShiki()` so code blocks show line numbers by default. Single-line shell snippets (`bash`, `sh`, `shell`) default to `false` since line numbers add noise to one-liners like install commands.

--- a/apps/www/app/docs/components/code-block.mdx
+++ b/apps/www/app/docs/components/code-block.mdx
@@ -10,6 +10,7 @@ import {
 	NoHeaderOrCopyButtonDemo,
 	SingleLineHorizontalScrollingDemo,
 	ServerRenderedHighlightingDemo,
+	MantleCodeOptionsDemo,
 	OverridingIndentationDemo,
 	TabbedCodeBlockDemo,
 } from "~/features/code-block-demos";
@@ -274,11 +275,90 @@ const policyJson = mantleCode("json")`…`;
 </CodeBlock.Root>;
 ```
 
-### Overriding default language indentation
+### `mantleCode()` Options
 
-By default, the code block code will detect the preferred (or required) indentation of the given language. This is important for languages that require a certain indentation style; for example, Python and YAML are space-indented languages, so the code block will use spaces for indentation. This is done to ensure that the code is displayed and copied correctly and is easy to read. However, you can override this by passing `indentation` in the `mantleCode()` options.
+The `mantleCode()` tagged template accepts an optional second argument with the following options:
+
+- **`showLineNumbers`** — Whether to show line numbers. Defaults to `true`. Pass `false` to hide them.
+- **`highlightLines`** — An array of line numbers or ranges (e.g. `[2, "4-5"]`) to visually highlight.
+- **`lineNumberStart`** — The starting line number when line numbers are displayed. Defaults to `1`.
+- **`indentation`** — Override the default indentation style (`"tabs"` or `"spaces"`).
+
+<MantleCodeOptionsDemo />
+
+```tsx
+import { CodeBlock, mantleCode } from "@ngrok/mantle/code-block";
+
+<CodeBlock.Root>
+	<CodeBlock.Header>
+		<CodeBlock.Icon preset="file" />
+		<CodeBlock.Title>all-options.ts</CodeBlock.Title>
+	</CodeBlock.Header>
+	<CodeBlock.Body>
+		<CodeBlock.CopyButton />
+		<CodeBlock.Code
+			value={mantleCode("typescript", {
+				showLineNumbers: false,
+				highlightLines: [2, "4-5"],
+				lineNumberStart: 10,
+				indentation: "spaces",
+			})`
+				import { serve } from "bun";
+
+				const server = serve({
+					port: 3000,
+					fetch(req) {
+						return new Response("Hello from Bun!");
+					},
+				});
+
+				console.log(\`Listening on \${server.url}\`);
+			`}
+		/>
+	</CodeBlock.Body>
+</CodeBlock.Root>;
+```
+
+### Overriding Defaults
+
+The `mantleCode()` options let you customize how code is displayed. By default, line numbers are shown, indentation is inferred from the language, and highlighting starts at line 1. You can override any of these per code block. The first example below uses the defaults (YAML auto-detects space indentation), while the second overrides all options: custom indentation, line number start, highlighted lines, and visible line numbers.
 
 <OverridingIndentationDemo />
+
+```tsx
+{
+	/* yaml auto-detects space indentation, all other defaults apply */
+}
+<CodeBlock.Code
+	value={mantleCode("yaml")`
+		on_http_request:
+			actions:
+				type: custom-response
+				config:
+					status_code: 200
+					content: Hello, World!
+	`}
+/>;
+
+{
+	/* override all mantleCode() options */
+}
+<CodeBlock.Code
+	value={mantleCode("javascript", {
+		indentation: "spaces",
+		showLineNumbers: true,
+		highlightLines: [1, "5-7"],
+		lineNumberStart: 42,
+	})`
+		const http = require('http');
+		const ngrok = require("@ngrok/ngrok");
+		const server = http.createServer((req, res) => {
+			res.writeHead(200);
+			res.end("Hello!");
+		});
+	`}
+/>;
+```
 
 ## API Reference
 

--- a/apps/www/app/docs/components/code-block.mdx
+++ b/apps/www/app/docs/components/code-block.mdx
@@ -279,7 +279,7 @@ const policyJson = mantleCode("json")`…`;
 
 The `mantleCode()` tagged template accepts an optional second argument with the following options:
 
-- **`showLineNumbers`** — Whether to show line numbers. Defaults to `true`. Pass `false` to hide them.
+- **`showLineNumbers`** — Whether to show line numbers. Defaults to `true` for most languages, but `false` for single-line shell snippets (`bash`, `sh`, `shell`). Pass `false` to hide them or `true` to force them on.
 - **`highlightLines`** — An array of line numbers or ranges (e.g. `[2, "4-5"]`) to visually highlight.
 - **`lineNumberStart`** — The starting line number when line numbers are displayed. Defaults to `1`.
 - **`indentation`** — Override the default indentation style (`"tabs"` or `"spaces"`).

--- a/apps/www/app/docs/components/code-block.mdx
+++ b/apps/www/app/docs/components/code-block.mdx
@@ -299,7 +299,7 @@ import { CodeBlock, mantleCode } from "@ngrok/mantle/code-block";
 		<CodeBlock.Code
 			value={mantleCode("typescript", {
 				showLineNumbers: false,
-				highlightLines: [2, "4-5"],
+				highlightLines: [11, "13-14"],
 				lineNumberStart: 10,
 				indentation: "spaces",
 			})`
@@ -321,7 +321,7 @@ import { CodeBlock, mantleCode } from "@ngrok/mantle/code-block";
 
 ### Overriding Defaults
 
-The `mantleCode()` options let you customize how code is displayed. By default, line numbers are shown, indentation is inferred from the language, and highlighting starts at line 1. You can override any of these per code block. The first example below uses the defaults (YAML auto-detects space indentation), while the second overrides all options: custom indentation, line number start, highlighted lines, and visible line numbers.
+The `mantleCode()` options let you customize how code is displayed. By default, line numbers are shown starting at 1 and indentation is inferred from the language. You can also specify highlighted lines per code block. The first example below uses the defaults (YAML auto-detects space indentation), while the second overrides all options: custom indentation, line number start, highlighted lines, and visible line numbers.
 
 <OverridingIndentationDemo />
 
@@ -347,7 +347,7 @@ The `mantleCode()` options let you customize how code is displayed. By default, 
 	value={mantleCode("javascript", {
 		indentation: "spaces",
 		showLineNumbers: true,
-		highlightLines: [1, "5-7"],
+		highlightLines: [42, "46-48"],
 		lineNumberStart: 42,
 	})`
 		const http = require('http');

--- a/apps/www/app/features/code-block-demos.tsx
+++ b/apps/www/app/features/code-block-demos.tsx
@@ -475,7 +475,48 @@ export function TabbedCodeBlockDemo() {
 }
 
 /**
- * Code block demonstrating overriding default language indentation.
+ * Code block demonstrating all `mantleCode()` options: `showLineNumbers`, `highlightLines`,
+ * `lineNumberStart`, and `indentation`.
+ */
+export function MantleCodeOptionsDemo() {
+	return (
+		<Example>
+			<CodeBlock.Root>
+				<CodeBlock.Header>
+					<CodeBlock.Icon preset="file" />
+					<CodeBlock.Title>all-options.ts</CodeBlock.Title>
+				</CodeBlock.Header>
+				<CodeBlock.Body>
+					<CodeBlock.CopyButton />
+					<CodeBlock.Code
+						value={mantleCode("typescript", {
+							showLineNumbers: false,
+							highlightLines: [2, "4-5"],
+							lineNumberStart: 10,
+							indentation: "spaces",
+						})`
+							import { serve } from "bun";
+
+							const server = serve({
+								port: 3000,
+								fetch(req) {
+									return new Response("Hello from Bun!");
+								},
+							});
+
+							console.log(\`Listening on \${server.url}\`);
+						`}
+					/>
+				</CodeBlock.Body>
+			</CodeBlock.Root>
+		</Example>
+	);
+}
+
+/**
+ * Code block demonstrating overriding `mantleCode()` defaults: indentation, line numbers,
+ * highlighted lines, and line number start. The first block uses language-inferred defaults,
+ * the second overrides all options.
  */
 export function OverridingIndentationDemo() {
 	return (
@@ -503,12 +544,17 @@ export function OverridingIndentationDemo() {
 			<CodeBlock.Root>
 				<CodeBlock.Header>
 					<CodeBlock.Icon preset="file" />
-					<CodeBlock.Title>ngrok-example.js (using space indentation)</CodeBlock.Title>
+					<CodeBlock.Title>ngrok-example.js (all options overridden)</CodeBlock.Title>
 				</CodeBlock.Header>
 				<CodeBlock.Body>
 					<CodeBlock.CopyButton />
 					<CodeBlock.Code
-						value={mantleCode("javascript", { indentation: "spaces" })`
+						value={mantleCode("javascript", {
+							indentation: "spaces",
+							showLineNumbers: true,
+							highlightLines: [1, "5-7"],
+							lineNumberStart: 42,
+						})`
 							// by default, mantle decides that javascript uses tabs,
 							// but this example uses spaces for indentation
 							const http = require('http');

--- a/apps/www/app/features/code-block-demos.tsx
+++ b/apps/www/app/features/code-block-demos.tsx
@@ -491,7 +491,7 @@ export function MantleCodeOptionsDemo() {
 					<CodeBlock.Code
 						value={mantleCode("typescript", {
 							showLineNumbers: false,
-							highlightLines: [2, "4-5"],
+							highlightLines: [11, "13-14"],
 							lineNumberStart: 10,
 							indentation: "spaces",
 						})`
@@ -552,7 +552,7 @@ export function OverridingIndentationDemo() {
 						value={mantleCode("javascript", {
 							indentation: "spaces",
 							showLineNumbers: true,
-							highlightLines: [1, "5-7"],
+							highlightLines: [42, "46-48"],
 							lineNumberStart: 42,
 						})`
 							// by default, mantle decides that javascript uses tabs,

--- a/packages/mantle-server-syntax-highlighter/src/engine.ts
+++ b/packages/mantle-server-syntax-highlighter/src/engine.ts
@@ -58,7 +58,7 @@ type MantleHighlightInput = {
 	indentation?: Indentation;
 	/**
 	 * Whether to render line numbers into the returned HTML.
-	 * @default false
+	 * @default true
 	 */
 	showLineNumbers?: boolean;
 	/**
@@ -195,7 +195,7 @@ async function highlightWithMantleShiki(
 	const normalizedCode = normalizeIndentation(input.code, {
 		indentation,
 	});
-	const showLineNumbers = input.showLineNumbers ?? false;
+	const showLineNumbers = input.showLineNumbers ?? true;
 	const highlightLines = input.highlightLines ?? [];
 	const lineNumberStart = input.lineNumberStart ?? 1;
 	const cacheKey = createHash("sha1")

--- a/packages/mantle-vite-plugins/src/mantle-code-rehype-plugin.test.ts
+++ b/packages/mantle-vite-plugins/src/mantle-code-rehype-plugin.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, test } from "vitest";
+import { mantleCodeRehypePlugin } from "./mantle-code-rehype-plugin.js";
+
+/**
+ * Creates a minimal HAST tree representing a fenced code block:
+ * ```<language> <meta>
+ * <code>
+ * ```
+ */
+function createCodeFenceTree(language: string, code: string, meta?: string) {
+	return {
+		type: "root" as const,
+		children: [
+			{
+				type: "element" as const,
+				tagName: "pre",
+				properties: {} as Record<string, unknown>,
+				children: [
+					{
+						type: "element" as const,
+						tagName: "code",
+						properties: {
+							className: [`language-${language}`],
+						},
+						data: meta ? { meta } : undefined,
+						children: [{ type: "text" as const, value: code }],
+					},
+				],
+			},
+		],
+	};
+}
+
+function getPreNode(tree: ReturnType<typeof createCodeFenceTree>) {
+	const node = tree.children[0];
+	if (node == null) {
+		throw new Error("expected a <pre> node in the tree");
+	}
+	return node;
+}
+
+describe("mantleCodeRehypePlugin", () => {
+	test("defaults showLineNumbers to true for non-shell multi-line code", async () => {
+		const tree = createCodeFenceTree("typescript", "const a = 1;\nconst b = 2;");
+		await mantleCodeRehypePlugin()(tree);
+
+		const pre = getPreNode(tree);
+		expect(pre.properties.mantleShowLineNumbers).toBe(true);
+		expect(pre.properties.mantlePreHtml).toContain("mantle-code-line-number");
+	});
+
+	test("defaults showLineNumbers to false for single-line bash", async () => {
+		const tree = createCodeFenceTree("bash", "npm install @ngrok/mantle");
+		await mantleCodeRehypePlugin()(tree);
+
+		const pre = getPreNode(tree);
+		expect(pre.properties.mantleShowLineNumbers).toBe(false);
+		expect(pre.properties.mantlePreHtml).not.toContain("mantle-code-line-number");
+	});
+
+	test("defaults showLineNumbers to false for single-line sh", async () => {
+		const tree = createCodeFenceTree("sh", "curl -s https://example.com");
+		await mantleCodeRehypePlugin()(tree);
+
+		const pre = getPreNode(tree);
+		expect(pre.properties.mantleShowLineNumbers).toBe(false);
+	});
+
+	test("defaults showLineNumbers to false for single-line shell", async () => {
+		const tree = createCodeFenceTree("shell", "echo hello");
+		await mantleCodeRehypePlugin()(tree);
+
+		const pre = getPreNode(tree);
+		expect(pre.properties.mantleShowLineNumbers).toBe(false);
+	});
+
+	test("defaults showLineNumbers to true for multi-line bash", async () => {
+		const tree = createCodeFenceTree("bash", "echo hello\necho world");
+		await mantleCodeRehypePlugin()(tree);
+
+		const pre = getPreNode(tree);
+		expect(pre.properties.mantleShowLineNumbers).toBe(true);
+		expect(pre.properties.mantlePreHtml).toContain("mantle-code-line-number");
+	});
+
+	test("meta showLineNumbers=true overrides single-line shell default", async () => {
+		const tree = createCodeFenceTree("bash", "npm install @ngrok/mantle", "showLineNumbers=true");
+		await mantleCodeRehypePlugin()(tree);
+
+		const pre = getPreNode(tree);
+		expect(pre.properties.mantleShowLineNumbers).toBe(true);
+		expect(pre.properties.mantlePreHtml).toContain("mantle-code-line-number");
+	});
+
+	test("meta showLineNumbers=false overrides multi-line default", async () => {
+		const tree = createCodeFenceTree(
+			"typescript",
+			"const a = 1;\nconst b = 2;",
+			"showLineNumbers=false",
+		);
+		await mantleCodeRehypePlugin()(tree);
+
+		const pre = getPreNode(tree);
+		expect(pre.properties.mantleShowLineNumbers).toBe(false);
+		expect(pre.properties.mantlePreHtml).not.toContain("mantle-code-line-number");
+	});
+
+	test("property showLineNumbers overrides single-line shell default", async () => {
+		const tree = createCodeFenceTree("bash", "npm install @ngrok/mantle");
+		getPreNode(tree).properties.showLineNumbers = "true";
+		await mantleCodeRehypePlugin()(tree);
+
+		const pre = getPreNode(tree);
+		expect(pre.properties.mantleShowLineNumbers).toBe(true);
+	});
+});

--- a/packages/mantle-vite-plugins/src/mantle-code-rehype-plugin.ts
+++ b/packages/mantle-vite-plugins/src/mantle-code-rehype-plugin.ts
@@ -1,4 +1,5 @@
 import {
+	defaultShowLineNumbers,
 	isSupportedLanguage,
 	normalizeValue,
 	parseCodeBlockHighlightLines,
@@ -156,7 +157,7 @@ function mantleCodeRehypePlugin() {
 				const showLineNumbers =
 					parseCodeBlockShowLineNumbers(preNode.properties?.showLineNumbers) ??
 					parseCodeBlockShowLineNumbers(getMetaValue(meta, "showLineNumbers")) ??
-					true;
+					defaultShowLineNumbers(language, rawCode);
 				const lineNumberStart =
 					parseCodeBlockLineNumberStart(preNode.properties?.lineNumberStart) ??
 					parseCodeBlockLineNumberStart(getMetaValue(meta, "lineNumberStart"));

--- a/packages/mantle-vite-plugins/src/mantle-code-vite-plugin.test.ts
+++ b/packages/mantle-vite-plugins/src/mantle-code-vite-plugin.test.ts
@@ -94,16 +94,17 @@ describe("mantleCodeVitePlugin", () => {
 		expect(result.code).not.toContain('indentation="spaces"');
 	});
 
-	test("defaults showLineNumbers to true when not specified", async () => {
+	test("defaults showLineNumbers to true for non-shell languages and emits line-number HTML", async () => {
 		const result = await runTransform(
 			mantleImport + 'const snippet = mantleCode("typescript")`const value = 1;`;',
 		);
 
 		expect(result.warn).not.toHaveBeenCalled();
 		expect(result.code).toContain('"~showLineNumbers":true');
+		expect(result.code).toContain("mantle-code-line-number");
 	});
 
-	test("preserves showLineNumbers false when explicitly set", async () => {
+	test("preserves showLineNumbers false when explicitly set and omits line-number HTML", async () => {
 		const result = await runTransform(
 			mantleImport +
 				'const snippet = mantleCode("typescript", { showLineNumbers: false })`const value = 1;`;',
@@ -111,6 +112,111 @@ describe("mantleCodeVitePlugin", () => {
 
 		expect(result.warn).not.toHaveBeenCalled();
 		expect(result.code).toContain('"~showLineNumbers":false');
+		expect(result.code).not.toContain("mantle-code-line-number");
+	});
+
+	test("defaults showLineNumbers to false for single-line bash and omits line-number HTML", async () => {
+		const result = await runTransform(
+			mantleImport + 'const snippet = mantleCode("bash")`npm install @ngrok/mantle`;',
+		);
+
+		expect(result.warn).not.toHaveBeenCalled();
+		expect(result.code).toContain('"~showLineNumbers":false');
+		expect(result.code).not.toContain("mantle-code-line-number");
+	});
+
+	test("defaults showLineNumbers to false for single-line sh", async () => {
+		const result = await runTransform(
+			mantleImport + 'const snippet = mantleCode("sh")`curl -s https://example.com`;',
+		);
+
+		expect(result.warn).not.toHaveBeenCalled();
+		expect(result.code).toContain('"~showLineNumbers":false');
+		expect(result.code).not.toContain("mantle-code-line-number");
+	});
+
+	test("defaults showLineNumbers to false for single-line shell", async () => {
+		const result = await runTransform(
+			mantleImport + 'const snippet = mantleCode("shell")`echo hello`;',
+		);
+
+		expect(result.warn).not.toHaveBeenCalled();
+		expect(result.code).toContain('"~showLineNumbers":false');
+		expect(result.code).not.toContain("mantle-code-line-number");
+	});
+
+	test("defaults showLineNumbers to true for multi-line shell code and emits line-number HTML", async () => {
+		const result = await runTransform(
+			mantleImport + 'const snippet = mantleCode("bash")`echo hello\necho world`;',
+		);
+
+		expect(result.warn).not.toHaveBeenCalled();
+		expect(result.code).toContain('"~showLineNumbers":true');
+		expect(result.code).toContain("mantle-code-line-number");
+	});
+
+	test("single-line shell code respects explicit showLineNumbers true and emits line-number HTML", async () => {
+		const result = await runTransform(
+			mantleImport +
+				'const snippet = mantleCode("bash", { showLineNumbers: true })`npm install @ngrok/mantle`;',
+		);
+
+		expect(result.warn).not.toHaveBeenCalled();
+		expect(result.code).toContain('"~showLineNumbers":true');
+		expect(result.code).toContain("mantle-code-line-number");
+	});
+
+	test("highlightLines with lineNumberStart produces highlighted lines at correct offsets", async () => {
+		const result = await runTransform(
+			mantleImport +
+				'const snippet = mantleCode("typescript", { lineNumberStart: 10, highlightLines: [11] })`const a = 1;\nconst b = 2;`;',
+		);
+
+		expect(result.warn).not.toHaveBeenCalled();
+		expect(result.code).toContain('"~lineNumberStart":10');
+		expect(result.code).toContain('"~highlightLines":[11]');
+		expect(result.code).toContain("mantle-code-line-highlighted");
+	});
+
+	test("indented single-line shell template defaults showLineNumbers to false", async () => {
+		const source = [
+			mantleImport + 'const snippet = mantleCode("bash")`',
+			"\t\tnpm install @ngrok/mantle",
+			"\t`;",
+		].join("\n");
+		const result = await runTransform(source);
+
+		expect(result.warn).not.toHaveBeenCalled();
+		expect(result.code).toContain('"~showLineNumbers":false');
+		expect(result.code).not.toContain("mantle-code-line-number");
+	});
+
+	test("JSX showLineNumbers prop overrides mantleCode option", async () => {
+		const source = [
+			mantleImport + "<CodeBlock.Code",
+			"\tshowLineNumbers={false}",
+			'\tvalue={mantleCode("typescript", { showLineNumbers: true })`const x = 1;`}',
+			"/>;",
+		].join("\n");
+		const result = await runTransform(source);
+
+		expect(result.warn).not.toHaveBeenCalled();
+		expect(result.code).toContain('"~showLineNumbers":false');
+		expect(result.code).not.toContain("mantle-code-line-number");
+	});
+
+	test("JSX showLineNumbers prop overrides shell single-line default", async () => {
+		const source = [
+			mantleImport + "<CodeBlock.Code",
+			"\tshowLineNumbers",
+			'\tvalue={mantleCode("bash")`npm install @ngrok/mantle`}',
+			"/>;",
+		].join("\n");
+		const result = await runTransform(source);
+
+		expect(result.warn).not.toHaveBeenCalled();
+		expect(result.code).toContain('"~showLineNumbers":true');
+		expect(result.code).toContain("mantle-code-line-number");
 	});
 
 	test("normalizes numeric highlightLines entries to integers", async () => {

--- a/packages/mantle-vite-plugins/src/mantle-code-vite-plugin.test.ts
+++ b/packages/mantle-vite-plugins/src/mantle-code-vite-plugin.test.ts
@@ -94,6 +94,25 @@ describe("mantleCodeVitePlugin", () => {
 		expect(result.code).not.toContain('indentation="spaces"');
 	});
 
+	test("defaults showLineNumbers to true when not specified", async () => {
+		const result = await runTransform(
+			mantleImport + 'const snippet = mantleCode("typescript")`const value = 1;`;',
+		);
+
+		expect(result.warn).not.toHaveBeenCalled();
+		expect(result.code).toContain('"~showLineNumbers":true');
+	});
+
+	test("preserves showLineNumbers false when explicitly set", async () => {
+		const result = await runTransform(
+			mantleImport +
+				'const snippet = mantleCode("typescript", { showLineNumbers: false })`const value = 1;`;',
+		);
+
+		expect(result.warn).not.toHaveBeenCalled();
+		expect(result.code).toContain('"~showLineNumbers":false');
+	});
+
 	test("normalizes numeric highlightLines entries to integers", async () => {
 		const result = await runTransform(
 			mantleImport +

--- a/packages/mantle-vite-plugins/src/mantle-code-vite-plugin.ts
+++ b/packages/mantle-vite-plugins/src/mantle-code-vite-plugin.ts
@@ -1,5 +1,6 @@
 import MagicString from "magic-string";
 import {
+	defaultShowLineNumbers,
 	inferIndentation,
 	isIndentation,
 	isSupportedLanguage,
@@ -702,6 +703,9 @@ function mantleCodeVitePlugin(): Plugin {
 			// Highlight all code blocks in parallel
 			const results = await Promise.all(
 				jobs.map(async (job) => {
+					const resolvedShowLineNumbers =
+						job.effectiveOptions.showLineNumbers ??
+						defaultShowLineNumbers(job.language, job.placeholderCode);
 					try {
 						const highlighted = await highlightWithMantleShiki({
 							code: job.placeholderCode,
@@ -709,9 +713,9 @@ function mantleCodeVitePlugin(): Plugin {
 							indentation: inferIndentation(job.language, job.effectiveOptions.indentation),
 							language: job.language,
 							lineNumberStart: job.effectiveOptions.lineNumberStart,
-							showLineNumbers: job.effectiveOptions.showLineNumbers,
+							showLineNumbers: resolvedShowLineNumbers,
 						});
-						return { ...job, highlighted } as const;
+						return { ...job, highlighted, resolvedShowLineNumbers } as const;
 					} catch (error) {
 						return { ...job, error } as const;
 					}
@@ -729,8 +733,15 @@ function mantleCodeVitePlugin(): Plugin {
 					continue;
 				}
 
-				const { componentProps, effectiveOptions, highlighted, language, node, preValToken } =
-					result;
+				const {
+					componentProps,
+					effectiveOptions,
+					highlighted,
+					language,
+					node,
+					preValToken,
+					resolvedShowLineNumbers,
+				} = result;
 
 				for (const range of [...componentProps.attributeRemovalRanges].sort(
 					(a, b) => b.start - a.start,
@@ -750,7 +761,7 @@ function mantleCodeVitePlugin(): Plugin {
 					`"~preHtml":\`${escapedHtml}\``,
 					`"~preValToken":${JSON.stringify(node.quasi.expressions.length === 0 ? undefined : preValToken)}`,
 					`"~preVals":${preValsArray}`,
-					`"~showLineNumbers":${JSON.stringify(effectiveOptions.showLineNumbers ?? true)}`,
+					`"~showLineNumbers":${JSON.stringify(resolvedShowLineNumbers)}`,
 					`"~highlightLines":${JSON.stringify(effectiveOptions.highlightLines)}`,
 					`"~lineNumberStart":${JSON.stringify(effectiveOptions.lineNumberStart)}`,
 				];

--- a/packages/mantle-vite-plugins/src/mantle-code-vite-plugin.ts
+++ b/packages/mantle-vite-plugins/src/mantle-code-vite-plugin.ts
@@ -744,7 +744,17 @@ function mantleCodeVitePlugin(): Plugin {
 					node.quasi.expressions.length === 0
 						? "undefined"
 						: `[${node.quasi.expressions.map((expression) => code.slice(expression.start, expression.end)).join(",")}]`;
-				const replacement = `({language:${JSON.stringify(language)},code:\`${escapedCode}\`,"~preHtml":\`${escapedHtml}\`,"~preValToken":${JSON.stringify(node.quasi.expressions.length === 0 ? undefined : preValToken)},"~preVals":${preValsArray},"~showLineNumbers":${JSON.stringify(effectiveOptions.showLineNumbers)},"~highlightLines":${JSON.stringify(effectiveOptions.highlightLines)},"~lineNumberStart":${JSON.stringify(effectiveOptions.lineNumberStart)}})`;
+				const replacementEntries = [
+					`language:${JSON.stringify(language)}`,
+					`code:\`${escapedCode}\``,
+					`"~preHtml":\`${escapedHtml}\``,
+					`"~preValToken":${JSON.stringify(node.quasi.expressions.length === 0 ? undefined : preValToken)}`,
+					`"~preVals":${preValsArray}`,
+					`"~showLineNumbers":${JSON.stringify(effectiveOptions.showLineNumbers ?? true)}`,
+					`"~highlightLines":${JSON.stringify(effectiveOptions.highlightLines)}`,
+					`"~lineNumberStart":${JSON.stringify(effectiveOptions.lineNumberStart)}`,
+				];
+				const replacement = `({${replacementEntries.join(",")}})`;
 
 				ms.overwrite(node.start, node.end, replacement);
 				didTransform = true;

--- a/packages/mantle/src/components/code-block/highlight-utils.ts
+++ b/packages/mantle/src/components/code-block/highlight-utils.ts
@@ -37,6 +37,11 @@ export {
 
 export {
 	//,
+	defaultShowLineNumbers,
+} from "./mantle-code.js";
+
+export {
+	//,
 	isSupportedLanguage,
 	parseLanguage,
 	supportedLanguages,

--- a/packages/mantle/src/components/code-block/mantle-code.test.ts
+++ b/packages/mantle/src/components/code-block/mantle-code.test.ts
@@ -49,4 +49,35 @@ describe("mantleCode", () => {
 		const value = mantleCode("typescript", { lineNumberStart: 5 })`const x = 1;`;
 		expect(value["~lineNumberStart"]).toBe(5);
 	});
+
+	test("single-line shell code defaults showLineNumbers to false", () => {
+		const bashValue = mantleCode("bash")`npm install @ngrok/mantle`;
+		expect(bashValue["~showLineNumbers"]).toBe(false);
+
+		const shValue = mantleCode("sh")`curl -s https://example.com`;
+		expect(shValue["~showLineNumbers"]).toBe(false);
+
+		const shellValue = mantleCode("shell")`echo hello`;
+		expect(shellValue["~showLineNumbers"]).toBe(false);
+	});
+
+	test("multi-line shell code defaults showLineNumbers to true", () => {
+		const value = mantleCode("bash")`
+			npm install @ngrok/mantle
+			npm run build
+		`;
+		expect(value["~showLineNumbers"]).toBe(true);
+	});
+
+	test("indented single-line shell template defaults showLineNumbers to false", () => {
+		const value = mantleCode("bash")`
+			npm install @ngrok/mantle
+		`;
+		expect(value["~showLineNumbers"]).toBe(false);
+	});
+
+	test("single-line shell code respects explicit showLineNumbers true", () => {
+		const value = mantleCode("bash", { showLineNumbers: true })`npm install @ngrok/mantle`;
+		expect(value["~showLineNumbers"]).toBe(true);
+	});
 });

--- a/packages/mantle/src/components/code-block/mantle-code.test.ts
+++ b/packages/mantle/src/components/code-block/mantle-code.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "vitest";
+import { mantleCode } from "./mantle-code.js";
+
+describe("mantleCode", () => {
+	test("returns a MantleCodeBlockValue with the correct language and code", () => {
+		const value = mantleCode("typescript")`const x = 1;`;
+		expect(value.language).toBe("typescript");
+		expect(value.code).toBe("const x = 1;");
+	});
+
+	test("showLineNumbers defaults to true", () => {
+		const value = mantleCode("typescript")`const x = 1;`;
+		expect(value["~showLineNumbers"]).toBe(true);
+	});
+
+	test("showLineNumbers can be explicitly set to false", () => {
+		const value = mantleCode("typescript", { showLineNumbers: false })`const x = 1;`;
+		expect(value["~showLineNumbers"]).toBe(false);
+	});
+
+	test("showLineNumbers can be explicitly set to true", () => {
+		const value = mantleCode("typescript", { showLineNumbers: true })`const x = 1;`;
+		expect(value["~showLineNumbers"]).toBe(true);
+	});
+
+	test("interpolated template expressions are included in the code string", () => {
+		const name = "world";
+		const value = mantleCode("typescript")`const greeting = "Hello, ${name}!";`;
+		expect(value.code).toBe('const greeting = "Hello, world!";');
+	});
+
+	test("interpolated values are captured in ~preVals", () => {
+		const name = "world";
+		const value = mantleCode("typescript")`Hello, ${name}!`;
+		expect(value["~preVals"]).toEqual(["world"]);
+	});
+
+	test("~preVals is undefined when there are no interpolated values", () => {
+		const value = mantleCode("typescript")`const x = 1;`;
+		expect(value["~preVals"]).toBeUndefined();
+	});
+
+	test("passes through highlightLines option", () => {
+		const value = mantleCode("typescript", { highlightLines: [1, 3] })`const x = 1;`;
+		expect(value["~highlightLines"]).toEqual([1, 3]);
+	});
+
+	test("passes through lineNumberStart option", () => {
+		const value = mantleCode("typescript", { lineNumberStart: 5 })`const x = 1;`;
+		expect(value["~lineNumberStart"]).toBe(5);
+	});
+});

--- a/packages/mantle/src/components/code-block/mantle-code.ts
+++ b/packages/mantle/src/components/code-block/mantle-code.ts
@@ -72,9 +72,19 @@ type MantleCodeBlockValueInput = ReplacePrefix<
 
 /** Options for configuring line numbers, highlights, and indentation in `mantleCode()`. */
 type MantleCodeOptions = {
+	/** Line numbers or ranges to visually highlight in the code block. */
 	highlightLines?: (LineRange | number)[] | undefined;
+	/** The indentation style to use when normalizing the code string. */
 	indentation?: Indentation | undefined;
+	/**
+	 * The starting line number when line numbers are displayed.
+	 * @default 1
+	 */
 	lineNumberStart?: number | undefined;
+	/**
+	 * Whether to show line numbers in the code block.
+	 * @default true
+	 */
 	showLineNumbers?: boolean | undefined;
 };
 
@@ -130,18 +140,25 @@ function buildCodeFromTemplate(strings: TemplateStringsArray, values: unknown[])
  *
  * Interpolated template expressions are supported via placeholder substitution.
  *
+ * Line numbers are shown by default (`showLineNumbers` defaults to `true`).
+ * Pass `{ showLineNumbers: false }` to disable them.
+ *
  * @example
  * ```tsx
- * // Static string
+ * // Static string (line numbers shown by default)
  * mantleCode("typescript")`const x: string = "hello";`
  * // Interpolated string
  * mantleCode("typescript")`const greeting = "Hello, ${name}!";`
+ * // Disable line numbers
+ * mantleCode("typescript", { showLineNumbers: false })`const x = 1;`
  * ```
  */
 function mantleCode(
 	language: SupportedLanguage,
 	options: MantleCodeOptions = {},
 ): (strings: TemplateStringsArray, ...values: unknown[]) => MantleCodeBlockValue {
+	const { showLineNumbers = true, highlightLines, lineNumberStart } = options;
+
 	return (strings, ...values) => {
 		const code = buildCodeFromTemplate(strings, values);
 
@@ -150,9 +167,9 @@ function mantleCode(
 			code,
 			preHtml: undefined,
 			preVals: values.length > 0 ? values : undefined,
-			highlightLines: options.highlightLines,
-			lineNumberStart: options.lineNumberStart,
-			showLineNumbers: options.showLineNumbers,
+			highlightLines,
+			lineNumberStart,
+			showLineNumbers,
 		});
 	};
 }

--- a/packages/mantle/src/components/code-block/mantle-code.ts
+++ b/packages/mantle/src/components/code-block/mantle-code.ts
@@ -2,6 +2,17 @@ import type { SupportedLanguage } from "../code-block/supported-languages.js";
 import type { LineRange } from "../code-block/line-numbers.js";
 import type { Indentation } from "../code-block/indentation.js";
 
+/** Languages that represent shell/terminal commands. */
+const shellLanguages = new Set<SupportedLanguage>(["bash", "sh", "shell"]);
+
+/** Returns the default `showLineNumbers` value for a given language and code string. Single-line shell snippets default to `false`; everything else defaults to `true`. */
+function defaultShowLineNumbers(language: SupportedLanguage, code: string): boolean {
+	if (shellLanguages.has(language) && !code.trim().includes("\n")) {
+		return false;
+	}
+	return true;
+}
+
 const mantleCodeBlockValueBrand: unique symbol = Symbol("MantleCodeBlockValue");
 
 /**
@@ -82,8 +93,8 @@ type MantleCodeOptions = {
 	 */
 	lineNumberStart?: number | undefined;
 	/**
-	 * Whether to show line numbers in the code block.
-	 * @default true
+	 * Whether to show line numbers in the code block. Defaults to `true` for most
+	 * languages, but `false` for single-line shell snippets (`bash`, `sh`, `shell`).
 	 */
 	showLineNumbers?: boolean | undefined;
 };
@@ -140,8 +151,8 @@ function buildCodeFromTemplate(strings: TemplateStringsArray, values: unknown[])
  *
  * Interpolated template expressions are supported via placeholder substitution.
  *
- * Line numbers are shown by default (`showLineNumbers` defaults to `true`).
- * Pass `{ showLineNumbers: false }` to disable them.
+ * Line numbers are shown by default (`showLineNumbers` defaults to `true`),
+ * except for single-line shell snippets (`bash`, `sh`, `shell`) where they default to `false`.
  *
  * @example
  * ```tsx
@@ -151,13 +162,15 @@ function buildCodeFromTemplate(strings: TemplateStringsArray, values: unknown[])
  * mantleCode("typescript")`const greeting = "Hello, ${name}!";`
  * // Disable line numbers
  * mantleCode("typescript", { showLineNumbers: false })`const x = 1;`
+ * // Single-line shell — line numbers hidden by default
+ * mantleCode("bash")`npm install @ngrok/mantle`
  * ```
  */
 function mantleCode(
 	language: SupportedLanguage,
 	options: MantleCodeOptions = {},
 ): (strings: TemplateStringsArray, ...values: unknown[]) => MantleCodeBlockValue {
-	const { showLineNumbers = true, highlightLines, lineNumberStart } = options;
+	const { showLineNumbers, highlightLines, lineNumberStart } = options;
 
 	return (strings, ...values) => {
 		const code = buildCodeFromTemplate(strings, values);
@@ -169,11 +182,11 @@ function mantleCode(
 			preVals: values.length > 0 ? values : undefined,
 			highlightLines,
 			lineNumberStart,
-			showLineNumbers,
+			showLineNumbers: showLineNumbers ?? defaultShowLineNumbers(language, code),
 		});
 	};
 }
 
-export { mantleCode };
+export { defaultShowLineNumbers, mantleCode };
 export { createMantleCodeBlockValue };
 export type { MantleCodeBlockValue, MantleCodeOptions };


### PR DESCRIPTION
Line numbers are now shown by default when using mantleCode(). Callers can still opt out with { showLineNumbers: false }. Adds JSDoc to all MantleCodeOptions properties, unit tests for mantleCode(), a new "mantleCode() Options" docs section with a live demo, and updates the "Overriding Defaults" section to demonstrate all options.