### PR TITLE
fix(table): improve scroll fade masking, perf, and add DataTable.ActionHeader

### DIFF
--- a/.changeset/table-scroll-mask-and-action-header.md
+++ b/.changeset/table-scroll-mask-and-action-header.md
@@ -1,0 +1,12 @@
+---
+"@ngrok/mantle": patch
+---
+
+Fix horizontal scroll masking on `Table` and `DataTable` and add `DataTable.ActionHeader`.
+
+- `Table.Root` now keeps its border and rounded corners crisp at every scroll position by splitting into an outer wrapper (border, rounded, background) and an inner scroll container (mask + scrolling). The scroll container uses `overflow-x: auto; overflow-y: clip; overscroll-behavior: none` so tables only scroll horizontally and no longer bounce.
+- The scroll fade now applies to the scrolling table content (not the container chrome), with both left and right edges fading based on scroll position. When the table contains a sticky right column (`DataTable.ActionCell` / `DataTable.ActionHeader`), the container's right-side fade is suppressed so the pinned column stays fully opaque.
+- `DataTable.ActionCell` renders a left-side gradient `::before` so scrolling content appears to fade underneath the pinned action column, with per-row gradients that connect across row dividers. The cell now uses `bg-inherit` to track its row's background (including hover state) and cover scrolling content that would otherwise bleed through.
+- New `DataTable.ActionHeader` component — a sticky `<th>` that pairs with `DataTable.ActionCell` so the pinned action column stays visually aligned across the header row and every body row during horizontal scroll.
+
+See `migrations/data-table-action-header-migration.md` for guidance on updating existing data tables to use `DataTable.ActionHeader`.

--- a/.changeset/table-scroll-mask-and-action-header.md
+++ b/.changeset/table-scroll-mask-and-action-header.md
@@ -2,11 +2,12 @@
 "@ngrok/mantle": patch
 ---
 
-Fix horizontal scroll masking on `Table` and `DataTable` and add `DataTable.ActionHeader`.
+Fix table horizontal scroll masking, improve scroll perf, and add `DataTable.ActionHeader`.
 
-- `Table.Root` now keeps its border and rounded corners crisp at every scroll position by splitting into an outer wrapper (border, rounded, background) and an inner scroll container (mask + scrolling). The scroll container uses `overflow-x: auto; overflow-y: clip; overscroll-behavior: none` so tables only scroll horizontally and no longer bounce.
-- The scroll fade now applies to the scrolling table content (not the container chrome), with both left and right edges fading based on scroll position. When the table contains a sticky right column (`DataTable.ActionCell` / `DataTable.ActionHeader`), the container's right-side fade is suppressed so the pinned column stays fully opaque.
-- `DataTable.ActionCell` renders a left-side gradient `::before` so scrolling content appears to fade underneath the pinned action column, with per-row gradients that connect across row dividers. The cell now uses `bg-inherit` to track its row's background (including hover state) and cover scrolling content that would otherwise bleed through.
-- New `DataTable.ActionHeader` component — a sticky `<th>` that pairs with `DataTable.ActionCell` so the pinned action column stays visually aligned across the header row and every body row during horizontal scroll.
+- **`Table.Root`**: Split into outer wrapper (border, rounded corners, background) and inner scroll container (`scroll-fade-x` mask, `overflow-x: auto`, `overflow-y: clip`, `overscroll-behavior: none`). Tables only scroll horizontally and no longer bounce.
+- **Scroll fade**: Left and right edge fades driven by scroll position. Right-side fade correctly suppressed when a sticky right column is present (`DataTable.ActionCell` / `DataTable.ActionHeader`).
+- **`DataTable.ActionCell`**: Replaced per-cell `box-shadow` with `bg-inherit` and a `StickyColIndicator` child span (1px divider + soft leftward gradient). Tracks the row's background including hover state.
+- **`DataTable.ActionHeader`** (new): Sticky `<th>` that pairs with `DataTable.ActionCell` so the pinned action column aligns across header and body rows during horizontal scroll.
+- **`useHorizontalOverflowObserver`**: Now tracks `scrolledToStart`, coalesces rapid-fire scroll/resize/mutation events via `requestAnimationFrame`, and uses `useLayoutEffect` so corrections apply before the browser paints.
 
-See `migrations/data-table-action-header-migration.md` for guidance on updating existing data tables to use `DataTable.ActionHeader`.
+See `migrations/data-table-action-header-migration.md` for migration guidance.

--- a/apps/www/app/docs/components/data-table.mdx
+++ b/apps/www/app/docs/components/data-table.mdx
@@ -170,3 +170,11 @@ All props from [Table.Cell](/components/table).
 A sticky action cell positioned at the end of each row for action buttons.
 
 All props from [Table.Cell](/components/table).
+
+### DataTable.ActionHeader
+
+A sticky header cell that pairs with `DataTable.ActionCell`. Use this as the
+header for the action column so the pinned column stays visually aligned
+across the header and every body row when the table scrolls horizontally.
+
+All props from [Table.Header](/components/table).

--- a/apps/www/app/features/data-table-demo.tsx
+++ b/apps/www/app/features/data-table-demo.tsx
@@ -88,7 +88,7 @@ const columns = [
 	}),
 	columnHelper.display({
 		id: "actions",
-		header: () => <DataTable.Header />,
+		header: () => <DataTable.ActionHeader />,
 		cell: () => (
 			<DataTable.ActionCell>
 				<DropdownMenu.Root>

--- a/migrations/data-table-action-header-migration.md
+++ b/migrations/data-table-action-header-migration.md
@@ -223,7 +223,8 @@ const columns = [
 This is a purely additive change to the `DataTable` API:
 
 - `DataTable.Header` still works as before for non-action columns.
-- `DataTable.ActionCell` behavior is unchanged from the consumer's perspective — it is still a sticky `<td>` positioned at the right of the row. Internally it now renders a left-side fade `::before` pseudo-element and uses `bg-inherit` for an opaque background that tracks the row's hover state.
+- `DataTable.ActionCell` behavior is unchanged from the consumer's perspective — it is still a sticky `<td>` positioned at the right of the row. Internally it now renders a left-side indicator span (1px divider + soft shadow gradient) and uses `bg-inherit` for an opaque background that tracks the row's hover state.
+- `DataTable.ActionHeader` is empty-state aware — when the table body has no rows, it renders as a plain `<th>` (no sticky positioning, no indicator, no right-side fade suppression) so the empty state looks natural.
 - Tables without an action column need no changes.
 - Tables with an action column that keep using the old `DataTable.Header` for the header will continue to render correctly — they just won't get the aligned sticky header or the matching fade indicator on the header row.
 
@@ -236,9 +237,10 @@ Migrating every data table that has a `DataTable.ActionCell` is recommended for 
 Alongside `DataTable.ActionHeader`, `Table.Root` (and therefore every `DataTable.Root`) received the following internal behavior changes. Consumers typically do not need to do anything — they are listed here for completeness:
 
 - **Scroll fade mask is now applied inside the border.** `Table.Root` now renders an outer wrapper (border, rounded corners, background) and an inner scroll container (mask + horizontal scrolling). The border and rounded corners stay crisp at every scroll position; the fade only affects the scrolling table content.
-- **Left-edge scroll fade via `scroll-fade-x`.** When the table has overflowed horizontally and has been scrolled past the start, the left edge of the content fades to the container background. The right edge no longer uses a mask — the pinned action column (`DataTable.ActionCell` + `DataTable.ActionHeader`) provides the right-side fade instead, so the sticky column remains fully opaque.
+- **Bidirectional scroll fade via `scroll-fade-x`.** Both left and right edges fade based on scroll position. When the table contains a sticky right column (`DataTable.ActionCell` / `DataTable.ActionHeader`), the right-side fade is suppressed so the pinned column stays fully opaque — the pinned column provides its own left-side indicator instead.
 - **Y-scroll is disabled on the scroll container.** The inner scroll container uses `overflow-x: auto; overflow-y: clip` so the table only scrolls horizontally. Tall tables grow the container; page-level scrolling handles vertical overflow as before.
 - **Overscroll bounce is disabled on both axes** via `overscroll-behavior: none`.
 - **Sticky cells are opaque.** `DataTable.ActionCell` and `DataTable.ActionHeader` use `background-color: inherit` so they pick up the row's current background (including hover state) and cover scrolling content behind them.
+- **Scroll detection uses `useLayoutEffect` and `requestAnimationFrame` coalescing.** The horizontal overflow observer now corrects state before the browser paints (avoiding flash-of-incorrect-state) and batches rapid-fire scroll, resize, and mutation events into a single layout read per frame.
 
 No consumer code change is required for any of the above.

--- a/migrations/data-table-action-header-migration.md
+++ b/migrations/data-table-action-header-migration.md
@@ -1,0 +1,244 @@
+# Mantle DataTable Action Column Migration Guide
+
+This document describes how to migrate existing `DataTable` usages to take advantage of the new `DataTable.ActionHeader` component, which keeps the pinned action column visually aligned across the header and every body row when the table scrolls horizontally.
+
+**TL;DR:** If your data table has an action column whose cells use `DataTable.ActionCell`, change that column's header from `DataTable.Header` (or `<Table.Header />`, or an empty cell) to `DataTable.ActionHeader`. That's it.
+
+---
+
+## Why this change
+
+Previously, a typical action column was defined like this:
+
+```tsx
+columnHelper.display({
+	id: "actions",
+	header: () => <DataTable.Header />, // plain, non-sticky header
+	cell: () => <DataTable.ActionCell>{/* action buttons */}</DataTable.ActionCell>,
+});
+```
+
+The body's `DataTable.ActionCell` was `position: sticky` and pinned to the right of the scroll container, but the header cell was a regular `<th>` that scrolled away with the rest of the row. When the table overflowed horizontally this produced two visible problems:
+
+1. The sticky body cells stayed pinned at the right while the header's action column scrolled off, so the pinned column did not line up between the header and body.
+2. There was no consistent scroll-fade treatment between the header row and the body rows — the fade indicator only appeared on body cells.
+
+`DataTable.ActionHeader` is a sticky `<th>` that mirrors `DataTable.ActionCell`, so the action column stays pinned and aligned across the header and every body row, with a matching left-side fade that indicates content is scrolling underneath.
+
+---
+
+## What to search for (old patterns)
+
+Search your codebase for any data table column definitions that use `DataTable.ActionCell` in the `cell` function. For each such column, inspect the `header` function — it is almost always one of these:
+
+```tsx
+// OLD: empty DataTable.Header
+columnHelper.display({
+	id: "actions",
+	header: () => <DataTable.Header />,
+	cell: () => <DataTable.ActionCell>{/* ... */}</DataTable.ActionCell>,
+});
+
+// OLD: no header at all (just returns null / undefined)
+columnHelper.display({
+	id: "actions",
+	header: () => null,
+	cell: () => <DataTable.ActionCell>{/* ... */}</DataTable.ActionCell>,
+});
+
+// OLD: raw Table.Header
+columnHelper.display({
+	id: "actions",
+	header: () => <Table.Header />,
+	cell: () => <DataTable.ActionCell>{/* ... */}</DataTable.ActionCell>,
+});
+
+// OLD: DataTable.Header with a label
+columnHelper.display({
+	id: "actions",
+	header: () => <DataTable.Header>Actions</DataTable.Header>,
+	cell: () => <DataTable.ActionCell>{/* ... */}</DataTable.ActionCell>,
+});
+```
+
+Heuristics an agent can use to find these:
+
+- Any `columnHelper.display({ ... })` (or `columnHelper.accessor(...)`) whose `cell` returns a `<DataTable.ActionCell>`.
+- Any file that imports `DataTable` from `@ngrok/mantle/data-table` and also uses `DataTable.ActionCell`.
+- Any column with `id: "actions"` (common convention but not required).
+
+---
+
+## Replacement pattern (new)
+
+Change the header to `DataTable.ActionHeader`. It takes all the same props as `Table.Header` — including `children` — so you can keep labels, class names, and custom content:
+
+```tsx
+// NEW: empty sticky header (most common case)
+columnHelper.display({
+	id: "actions",
+	header: () => <DataTable.ActionHeader />,
+	cell: () => <DataTable.ActionCell>{/* ... */}</DataTable.ActionCell>,
+});
+
+// NEW: sticky header with a label
+columnHelper.display({
+	id: "actions",
+	header: () => <DataTable.ActionHeader>Actions</DataTable.ActionHeader>,
+	cell: () => <DataTable.ActionCell>{/* ... */}</DataTable.ActionCell>,
+});
+
+// NEW: sticky header with custom content (sr-only label, icon, etc.)
+columnHelper.display({
+	id: "actions",
+	header: () => (
+		<DataTable.ActionHeader>
+			<span className="sr-only">Actions</span>
+		</DataTable.ActionHeader>
+	),
+	cell: () => <DataTable.ActionCell>{/* ... */}</DataTable.ActionCell>,
+});
+```
+
+No other changes are required. The styling (sticky positioning, background, and left-side fade indicator) is applied by `DataTable.ActionHeader` itself.
+
+---
+
+## Find/replace recipe
+
+For most codebases a simple mechanical replacement works. Be conservative: only apply the substitution inside a column definition that also uses `DataTable.ActionCell` in its `cell` function.
+
+1. Search for `DataTable.ActionCell` to find all action-column definitions.
+2. In each match, locate the corresponding `header:` property in the same `columnHelper.display({ ... })` (or equivalent) object.
+3. Replace the header JSX according to the table below:
+
+| Before                                                 | After                                                              |
+| ------------------------------------------------------ | ------------------------------------------------------------------ |
+| `header: () => <DataTable.Header />`                   | `header: () => <DataTable.ActionHeader />`                         |
+| `header: () => <Table.Header />`                       | `header: () => <DataTable.ActionHeader />`                         |
+| `header: () => null`                                   | `header: () => <DataTable.ActionHeader />`                         |
+| `header: () => <DataTable.Header>X</DataTable.Header>` | `header: () => <DataTable.ActionHeader>X</DataTable.ActionHeader>` |
+| `header: () => <Table.Header>X</Table.Header>`         | `header: () => <DataTable.ActionHeader>X</DataTable.ActionHeader>` |
+
+If the existing header passes a `className` or other props to `<DataTable.Header>`/`<Table.Header>`, forward them unchanged to `<DataTable.ActionHeader>` — the component accepts all props from `Table.Header`.
+
+---
+
+## Imports
+
+No new import is required — `DataTable.ActionHeader` is exposed on the existing `DataTable` namespace object. If a file already imports `DataTable` from `@ngrok/mantle/data-table`, the migration is complete after the JSX swap:
+
+```tsx
+import { DataTable } from "@ngrok/mantle/data-table";
+```
+
+---
+
+## Example: complete before/after
+
+**Before:**
+
+```tsx
+import { IconButton } from "@ngrok/mantle/button";
+import {
+	DataTable,
+	createColumnHelper,
+	getCoreRowModel,
+	useReactTable,
+} from "@ngrok/mantle/data-table";
+import { DotsThreeIcon } from "@phosphor-icons/react/DotsThree";
+
+type Payment = { id: string; amount: number; status: string };
+
+const columnHelper = createColumnHelper<Payment>();
+
+const columns = [
+	columnHelper.accessor("id", {
+		id: "id",
+		header: () => <DataTable.Header>ID</DataTable.Header>,
+		cell: (props) => <DataTable.Cell>{props.getValue()}</DataTable.Cell>,
+	}),
+	columnHelper.display({
+		id: "actions",
+		header: () => <DataTable.Header />,
+		cell: () => (
+			<DataTable.ActionCell>
+				<IconButton
+					appearance="ghost"
+					type="button"
+					size="sm"
+					label="Open actions"
+					icon={<DotsThreeIcon weight="bold" />}
+				/>
+			</DataTable.ActionCell>
+		),
+	}),
+];
+```
+
+**After:**
+
+```tsx
+import { IconButton } from "@ngrok/mantle/button";
+import {
+	DataTable,
+	createColumnHelper,
+	getCoreRowModel,
+	useReactTable,
+} from "@ngrok/mantle/data-table";
+import { DotsThreeIcon } from "@phosphor-icons/react/DotsThree";
+
+type Payment = { id: string; amount: number; status: string };
+
+const columnHelper = createColumnHelper<Payment>();
+
+const columns = [
+	columnHelper.accessor("id", {
+		id: "id",
+		header: () => <DataTable.Header>ID</DataTable.Header>,
+		cell: (props) => <DataTable.Cell>{props.getValue()}</DataTable.Cell>,
+	}),
+	columnHelper.display({
+		id: "actions",
+		header: () => <DataTable.ActionHeader />, // <-- only change
+		cell: () => (
+			<DataTable.ActionCell>
+				<IconButton
+					appearance="ghost"
+					type="button"
+					size="sm"
+					label="Open actions"
+					icon={<DotsThreeIcon weight="bold" />}
+				/>
+			</DataTable.ActionCell>
+		),
+	}),
+];
+```
+
+---
+
+## Non-breaking context
+
+This is a purely additive change to the `DataTable` API:
+
+- `DataTable.Header` still works as before for non-action columns.
+- `DataTable.ActionCell` behavior is unchanged from the consumer's perspective — it is still a sticky `<td>` positioned at the right of the row. Internally it now renders a left-side fade `::before` pseudo-element and uses `bg-inherit` for an opaque background that tracks the row's hover state.
+- Tables without an action column need no changes.
+- Tables with an action column that keep using the old `DataTable.Header` for the header will continue to render correctly — they just won't get the aligned sticky header or the matching fade indicator on the header row.
+
+Migrating every data table that has a `DataTable.ActionCell` is recommended for visual consistency, but can be done incrementally.
+
+---
+
+## Related table behavior changes
+
+Alongside `DataTable.ActionHeader`, `Table.Root` (and therefore every `DataTable.Root`) received the following internal behavior changes. Consumers typically do not need to do anything — they are listed here for completeness:
+
+- **Scroll fade mask is now applied inside the border.** `Table.Root` now renders an outer wrapper (border, rounded corners, background) and an inner scroll container (mask + horizontal scrolling). The border and rounded corners stay crisp at every scroll position; the fade only affects the scrolling table content.
+- **Left-edge scroll fade via `scroll-fade-x`.** When the table has overflowed horizontally and has been scrolled past the start, the left edge of the content fades to the container background. The right edge no longer uses a mask — the pinned action column (`DataTable.ActionCell` + `DataTable.ActionHeader`) provides the right-side fade instead, so the sticky column remains fully opaque.
+- **Y-scroll is disabled on the scroll container.** The inner scroll container uses `overflow-x: auto; overflow-y: clip` so the table only scrolls horizontally. Tall tables grow the container; page-level scrolling handles vertical overflow as before.
+- **Overscroll bounce is disabled on both axes** via `overscroll-behavior: none`.
+- **Sticky cells are opaque.** `DataTable.ActionCell` and `DataTable.ActionHeader` use `background-color: inherit` so they pick up the row's current background (including hover state) and cover scrolling content behind them.
+
+No consumer code change is required for any of the above.

--- a/packages/mantle/src/components/data-table/data-table.tsx
+++ b/packages/mantle/src/components/data-table/data-table.tsx
@@ -277,7 +277,9 @@ function ActionCell({ children, className, ...props }: DataTableActionCellProps)
 	return (
 		<Table.Cell
 			className={cx(
-				"sticky z-10 right-0 flex items-center justify-end p-2",
+				// `bg-inherit` keeps the sticky cell opaque with the row's current bg
+				// (including hover state) so scrolling cells don't show through.
+				"sticky z-10 right-0 flex items-center justify-end bg-inherit p-2",
 				// Scroll fade indicator — rendered to the left of the sticky cell so
 				// scrolling content appears to fade underneath the pinned action column.
 				// Extends 1px beyond the cell top/bottom so per-row gradients visually
@@ -317,7 +319,8 @@ function ActionHeader({ children, className, ...props }: DataTableActionHeaderPr
 	return (
 		<Table.Header
 			className={cx(
-				"sticky z-10 right-0 bg-base",
+				// `bg-inherit` keeps the sticky header opaque with the thead's current bg.
+				"sticky z-10 right-0 bg-inherit",
 				// Match the fade indicator on ActionCell so the header aligns with body rows.
 				"before:pointer-events-none before:absolute before:-inset-y-px before:right-full before:w-6",
 				"before:bg-gradient-to-r before:from-transparent before:to-base",

--- a/packages/mantle/src/components/data-table/data-table.tsx
+++ b/packages/mantle/src/components/data-table/data-table.tsx
@@ -276,7 +276,18 @@ type DataTableActionCellProps = ComponentProps<typeof Table.Cell>;
 function ActionCell({ children, className, ...props }: DataTableActionCellProps) {
 	return (
 		<Table.Cell
-			className={cx("sticky z-10 right-0 flex items-center justify-end p-2", className)}
+			className={cx(
+				"sticky z-10 right-0 flex items-center justify-end p-2",
+				// Scroll fade indicator — rendered to the left of the sticky cell so
+				// scrolling content appears to fade underneath the pinned action column.
+				// Extends 1px beyond the cell top/bottom so per-row gradients visually
+				// connect across row dividers with no gaps.
+				"before:pointer-events-none before:absolute before:-inset-y-px before:right-full before:w-6",
+				"before:bg-gradient-to-r before:from-transparent before:to-card",
+				"before:opacity-0 before:transition-opacity",
+				"group-data-sticky-active/table:before:opacity-100",
+				className,
+			)}
 			{...props}
 		>
 			{children}
@@ -284,9 +295,47 @@ function ActionCell({ children, className, ...props }: DataTableActionCellProps)
 	);
 }
 
+type DataTableActionHeaderProps = ComponentProps<typeof Table.Header>;
+
+/**
+ * A sticky header cell that pairs with `DataTable.ActionCell`. Use this as the
+ * header for the action column so the pinned column visually aligns across the
+ * header and every body row when the table scrolls horizontally.
+ *
+ * @see https://mantle.ngrok.com/components/data-table#datatableactionheader
+ *
+ * @example
+ * ```tsx
+ * columnHelper.display({
+ *   id: "actions",
+ *   header: () => <DataTable.ActionHeader />,
+ *   cell: () => <DataTable.ActionCell>{...}</DataTable.ActionCell>,
+ * })
+ * ```
+ */
+function ActionHeader({ children, className, ...props }: DataTableActionHeaderProps) {
+	return (
+		<Table.Header
+			className={cx(
+				"sticky z-10 right-0 bg-base",
+				// Match the fade indicator on ActionCell so the header aligns with body rows.
+				"before:pointer-events-none before:absolute before:-inset-y-px before:right-full before:w-6",
+				"before:bg-gradient-to-r before:from-transparent before:to-base",
+				"before:opacity-0 before:transition-opacity",
+				"group-data-sticky-active/table:before:opacity-100",
+				className,
+			)}
+			{...props}
+		>
+			{children}
+		</Table.Header>
+	);
+}
+
 // Set display names to preserve original component names for debugging
 Root.displayName = "DataTable";
 ActionCell.displayName = "DataTableActionCell";
+ActionHeader.displayName = "DataTableActionHeader";
 Body.displayName = "DataTableBody";
 EmptyRow.displayName = "DataTableEmptyRow";
 Head.displayName = "DataTableHead";
@@ -341,6 +390,22 @@ const DataTable = {
 	 * ```
 	 */
 	ActionCell,
+	/**
+	 * A sticky header cell that pairs with `DataTable.ActionCell`, keeping the
+	 * action column aligned across the header and body when scrolling horizontally.
+	 *
+	 * @see https://mantle.ngrok.com/components/data-table#datatableactionheader
+	 *
+	 * @example
+	 * ```tsx
+	 * columnHelper.display({
+	 *   id: "actions",
+	 *   header: () => <DataTable.ActionHeader />,
+	 *   cell: () => <DataTable.ActionCell>{...}</DataTable.ActionCell>,
+	 * })
+	 * ```
+	 */
+	ActionHeader,
 	/**
 	 * A table cell component for rendering individual data cells.
 	 *

--- a/packages/mantle/src/components/data-table/data-table.tsx
+++ b/packages/mantle/src/components/data-table/data-table.tsx
@@ -276,10 +276,7 @@ type DataTableActionCellProps = ComponentProps<typeof Table.Cell>;
 function ActionCell({ children, className, ...props }: DataTableActionCellProps) {
 	return (
 		<Table.Cell
-			className={cx(
-				"sticky z-10 right-0 top-px -bottom-px flex items-center justify-end p-2 group-data-sticky-active/table:[box-shadow:inset_10px_0_8px_-8px_oklch(0_0_0/15%)]",
-				className,
-			)}
+			className={cx("sticky z-10 right-0 flex items-center justify-end p-2", className)}
 			{...props}
 		>
 			{children}

--- a/packages/mantle/src/components/data-table/data-table.tsx
+++ b/packages/mantle/src/components/data-table/data-table.tsx
@@ -271,6 +271,36 @@ function EmptyRow<TData>({ children, ...props }: DataTableEmptyRowProps) {
 	);
 }
 
+/**
+ * Internal: renders the visual indicator on the left edge of the sticky action
+ * column — a 1px divider plus a soft shadow gradient that reads as content
+ * sliding under the pinned column. Positioned as a 6px strip sitting
+ * immediately to the left of its sticky parent cell; `-inset-y-px` lets
+ * adjacent rows' strips overlap at row dividers so the effect reads as one
+ * continuous column instead of per-row blobs.
+ *
+ * Rendered as a child `<span>` because `border-collapse` on the table
+ * suppresses box-shadow on `<td>`/`<th>`.
+ */
+function StickyColIndicator() {
+	return (
+		<span
+			aria-hidden
+			className={cx(
+				"pointer-events-none absolute -inset-y-px -left-1.5 w-1.5",
+				"opacity-0 transition-opacity group-data-sticky-active/table:opacity-100",
+				// 1px divider painted at the strip's right edge (= the pinned
+				// cell's left edge).
+				"shadow-[1px_0_0_0_var(--border-color-card-muted)]",
+				// Soft shadow gradient fading leftward. Uses mantle's shadow
+				// tokens so the alpha adapts to light/dark themes.
+				"bg-linear-to-l to-transparent",
+				"from-[color-mix(in_oklab,var(--shadow-color)_var(--shadow-second-opacity),transparent)]",
+			)}
+		/>
+	);
+}
+
 type DataTableActionCellProps = ComponentProps<typeof Table.Cell>;
 
 function ActionCell({ children, className, ...props }: DataTableActionCellProps) {
@@ -283,18 +313,11 @@ function ActionCell({ children, className, ...props }: DataTableActionCellProps)
 				// `bg-inherit` keeps the sticky cell opaque with the row's current bg
 				// (including hover state) so scrolling cells don't show through.
 				"sticky z-10 right-0 flex items-center justify-end bg-inherit p-2",
-				// Scroll fade indicator — rendered to the left of the sticky cell so
-				// scrolling content appears to fade underneath the pinned action column.
-				// Extends 1px beyond the cell top/bottom so per-row gradients visually
-				// connect across row dividers with no gaps.
-				"before:pointer-events-none before:absolute before:-inset-y-px before:right-full before:w-6",
-				"before:bg-gradient-to-r before:from-transparent before:to-card",
-				"before:opacity-0 before:transition-opacity",
-				"group-data-sticky-active/table:before:opacity-100",
 				className,
 			)}
 			{...props}
 		>
+			<StickyColIndicator />
 			{children}
 		</Table.Cell>
 	);
@@ -327,15 +350,11 @@ function ActionHeader({ children, className, ...props }: DataTableActionHeaderPr
 			className={cx(
 				// `bg-inherit` keeps the sticky header opaque with the thead's current bg.
 				"sticky z-10 right-0 bg-inherit",
-				// Match the fade indicator on ActionCell so the header aligns with body rows.
-				"before:pointer-events-none before:absolute before:-inset-y-px before:right-full before:w-6",
-				"before:bg-gradient-to-r before:from-transparent before:to-base",
-				"before:opacity-0 before:transition-opacity",
-				"group-data-sticky-active/table:before:opacity-100",
 				className,
 			)}
 			{...props}
 		>
+			<StickyColIndicator />
 			{children}
 		</Table.Header>
 	);

--- a/packages/mantle/src/components/data-table/data-table.tsx
+++ b/packages/mantle/src/components/data-table/data-table.tsx
@@ -342,19 +342,22 @@ type DataTableActionHeaderProps = ComponentProps<typeof Table.Header>;
  * ```
  */
 function ActionHeader({ children, className, ...props }: DataTableActionHeaderProps) {
+	const { table } = useDataTableContext();
+	const hasRows = table.getRowModel().rows.length > 0;
+
 	return (
 		<Table.Header
-			// Marks this header as a sticky right-edge column so Table.Root can suppress
-			// its container-level right-side scroll fade (keeping this header opaque).
-			data-mantle-table-sticky-right
+			// Only mark as sticky-right when body rows exist so the empty state
+			// doesn't suppress the container's right-side scroll fade.
+			{...(hasRows ? { "data-mantle-table-sticky-right": true } : {})}
 			className={cx(
 				// `bg-inherit` keeps the sticky header opaque with the thead's current bg.
-				"sticky z-10 right-0 bg-inherit",
+				hasRows && "sticky z-10 right-0 bg-inherit",
 				className,
 			)}
 			{...props}
 		>
-			<StickyColIndicator />
+			{hasRows && <StickyColIndicator />}
 			{children}
 		</Table.Header>
 	);

--- a/packages/mantle/src/components/data-table/data-table.tsx
+++ b/packages/mantle/src/components/data-table/data-table.tsx
@@ -276,6 +276,9 @@ type DataTableActionCellProps = ComponentProps<typeof Table.Cell>;
 function ActionCell({ children, className, ...props }: DataTableActionCellProps) {
 	return (
 		<Table.Cell
+			// Marks this cell as a sticky right-edge column so Table.Root can suppress
+			// its container-level right-side scroll fade (keeping this cell opaque).
+			data-mantle-table-sticky-right
 			className={cx(
 				// `bg-inherit` keeps the sticky cell opaque with the row's current bg
 				// (including hover state) so scrolling cells don't show through.
@@ -318,6 +321,9 @@ type DataTableActionHeaderProps = ComponentProps<typeof Table.Header>;
 function ActionHeader({ children, className, ...props }: DataTableActionHeaderProps) {
 	return (
 		<Table.Header
+			// Marks this header as a sticky right-edge column so Table.Root can suppress
+			// its container-level right-side scroll fade (keeping this header opaque).
+			data-mantle-table-sticky-right
 			className={cx(
 				// `bg-inherit` keeps the sticky header opaque with the thead's current bg.
 				"sticky z-10 right-0 bg-inherit",

--- a/packages/mantle/src/components/table/table.tsx
+++ b/packages/mantle/src/components/table/table.tsx
@@ -52,9 +52,17 @@ const Root = forwardRef<ComponentRef<"div">, ComponentProps<"div">>(
 		return (
 			<div
 				className={cx(
-					"group/table scrollbar overflow-x-auto overscroll-x-none rounded-lg border border-card bg-white dark:bg-gray-100 relative w-full",
+					"group/table scrollbar scroll-fade-x overflow-x-auto overscroll-x-none rounded-lg border border-card bg-white dark:bg-gray-100 relative w-full",
 					className,
 				)}
+				data-scroll-left={
+					(horizontalOverflow.state.hasOverflow && !horizontalOverflow.state.scrolledToStart) ||
+					undefined
+				}
+				data-scroll-right={
+					(horizontalOverflow.state.hasOverflow && !horizontalOverflow.state.scrolledToEnd) ||
+					undefined
+				}
 				data-sticky-active={
 					(horizontalOverflow.state.hasOverflow && !horizontalOverflow.state.scrolledToEnd) ||
 					undefined
@@ -1002,6 +1010,7 @@ function useHorizontalOverflowObserver<T extends HTMLElement>() {
 	const ref = useRef<T | null>(null);
 	const [state, setState] = useState({
 		hasOverflow: false,
+		scrolledToStart: true,
 		scrolledToEnd: false,
 	});
 
@@ -1013,12 +1022,17 @@ function useHorizontalOverflowObserver<T extends HTMLElement>() {
 
 		const checkState = () => {
 			const hasOverflow = element.scrollWidth > element.clientWidth;
+			const scrolledToStart = element.scrollLeft < 1;
 			const scrolledToEnd =
 				Math.abs(element.scrollWidth - element.scrollLeft - element.clientWidth) < 1;
 
 			setState((previous) => {
-				if (previous.hasOverflow !== hasOverflow || previous.scrolledToEnd !== scrolledToEnd) {
-					return { hasOverflow, scrolledToEnd };
+				if (
+					previous.hasOverflow !== hasOverflow ||
+					previous.scrolledToStart !== scrolledToStart ||
+					previous.scrolledToEnd !== scrolledToEnd
+				) {
+					return { hasOverflow, scrolledToStart, scrolledToEnd };
 				}
 				return previous; // No state change
 			});

--- a/packages/mantle/src/components/table/table.tsx
+++ b/packages/mantle/src/components/table/table.tsx
@@ -1,6 +1,5 @@
 import type { ComponentProps, ComponentRef } from "react";
 import { forwardRef, useEffect, useMemo, useRef, useState } from "react";
-import { composeRefs } from "../../utils/compose-refs/compose-refs.js";
 import { cx } from "../../utils/cx/cx.js";
 
 /**
@@ -52,17 +51,9 @@ const Root = forwardRef<ComponentRef<"div">, ComponentProps<"div">>(
 		return (
 			<div
 				className={cx(
-					"group/table scrollbar scroll-fade-x overflow-x-auto overscroll-x-none rounded-lg border border-card bg-white dark:bg-gray-100 relative w-full",
+					"group/table relative w-full overflow-hidden rounded-lg border border-card bg-white dark:bg-gray-100",
 					className,
 				)}
-				data-scroll-left={
-					(horizontalOverflow.state.hasOverflow && !horizontalOverflow.state.scrolledToStart) ||
-					undefined
-				}
-				data-scroll-right={
-					(horizontalOverflow.state.hasOverflow && !horizontalOverflow.state.scrolledToEnd) ||
-					undefined
-				}
 				data-sticky-active={
 					(horizontalOverflow.state.hasOverflow && !horizontalOverflow.state.scrolledToEnd) ||
 					undefined
@@ -71,10 +62,23 @@ const Root = forwardRef<ComponentRef<"div">, ComponentProps<"div">>(
 				data-x-scroll-end={
 					horizontalOverflow.state.hasOverflow && horizontalOverflow.state.scrolledToEnd
 				}
-				ref={composeRefs(horizontalOverflow.ref, ref)}
+				ref={ref}
 				{...props}
 			>
-				{children}
+				<div
+					className="scrollbar scroll-fade-x overflow-x-auto overscroll-x-none"
+					data-scroll-left={
+						(horizontalOverflow.state.hasOverflow && !horizontalOverflow.state.scrolledToStart) ||
+						undefined
+					}
+					data-scroll-right={
+						(horizontalOverflow.state.hasOverflow && !horizontalOverflow.state.scrolledToEnd) ||
+						undefined
+					}
+					ref={horizontalOverflow.ref}
+				>
+					{children}
+				</div>
 			</div>
 		);
 	},

--- a/packages/mantle/src/components/table/table.tsx
+++ b/packages/mantle/src/components/table/table.tsx
@@ -66,7 +66,7 @@ const Root = forwardRef<ComponentRef<"div">, ComponentProps<"div">>(
 				{...props}
 			>
 				<div
-					className="scrollbar scroll-fade-x overflow-x-auto overscroll-x-none"
+					className="scrollbar scroll-fade-x overflow-x-auto overflow-y-clip overscroll-none"
 					data-scroll-left={
 						(horizontalOverflow.state.hasOverflow && !horizontalOverflow.state.scrolledToStart) ||
 						undefined

--- a/packages/mantle/src/components/table/table.tsx
+++ b/packages/mantle/src/components/table/table.tsx
@@ -1,5 +1,6 @@
 import type { ComponentProps, ComponentRef } from "react";
 import { forwardRef, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { composeRefs } from "../../utils/compose-refs/compose-refs.js";
 import { cx } from "../../utils/cx/cx.js";
 
 /**
@@ -62,7 +63,6 @@ const Root = forwardRef<ComponentRef<"div">, ComponentProps<"div">>(
 				data-x-scroll-end={
 					horizontalOverflow.state.hasOverflow && horizontalOverflow.state.scrolledToEnd
 				}
-				ref={ref}
 				{...props}
 			>
 				<div
@@ -82,7 +82,7 @@ const Root = forwardRef<ComponentRef<"div">, ComponentProps<"div">>(
 						(horizontalOverflow.state.hasOverflow && !horizontalOverflow.state.scrolledToEnd) ||
 						undefined
 					}
-					ref={horizontalOverflow.ref}
+					ref={composeRefs(horizontalOverflow.ref, ref)}
 				>
 					{children}
 				</div>

--- a/packages/mantle/src/components/table/table.tsx
+++ b/packages/mantle/src/components/table/table.tsx
@@ -66,9 +66,20 @@ const Root = forwardRef<ComponentRef<"div">, ComponentProps<"div">>(
 				{...props}
 			>
 				<div
-					className="scrollbar scroll-fade-x overflow-x-auto overflow-y-clip overscroll-none"
+					className={cx(
+						"scrollbar scroll-fade-x overflow-x-auto overflow-y-clip overscroll-none",
+						// When the table contains a sticky right column (e.g., DataTable.ActionCell
+						// / DataTable.ActionHeader), suppress the container's right-side fade so the
+						// pinned column stays fully opaque. The pinned column provides its own
+						// left-side gradient for the scroll-under effect.
+						"has-[[data-mantle-table-sticky-right]]:[--_fade-right:black]!",
+					)}
 					data-scroll-left={
 						(horizontalOverflow.state.hasOverflow && !horizontalOverflow.state.scrolledToStart) ||
+						undefined
+					}
+					data-scroll-right={
+						(horizontalOverflow.state.hasOverflow && !horizontalOverflow.state.scrolledToEnd) ||
 						undefined
 					}
 					ref={horizontalOverflow.ref}

--- a/packages/mantle/src/components/table/table.tsx
+++ b/packages/mantle/src/components/table/table.tsx
@@ -71,10 +71,6 @@ const Root = forwardRef<ComponentRef<"div">, ComponentProps<"div">>(
 						(horizontalOverflow.state.hasOverflow && !horizontalOverflow.state.scrolledToStart) ||
 						undefined
 					}
-					data-scroll-right={
-						(horizontalOverflow.state.hasOverflow && !horizontalOverflow.state.scrolledToEnd) ||
-						undefined
-					}
 					ref={horizontalOverflow.ref}
 				>
 					{children}

--- a/packages/mantle/src/components/table/table.tsx
+++ b/packages/mantle/src/components/table/table.tsx
@@ -1,5 +1,5 @@
 import type { ComponentProps, ComponentRef } from "react";
-import { forwardRef, useEffect, useMemo, useRef, useState } from "react";
+import { forwardRef, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { cx } from "../../utils/cx/cx.js";
 
 /**
@@ -72,7 +72,7 @@ const Root = forwardRef<ComponentRef<"div">, ComponentProps<"div">>(
 						// / DataTable.ActionHeader), suppress the container's right-side fade so the
 						// pinned column stays fully opaque. The pinned column provides its own
 						// left-side gradient for the scroll-under effect.
-						"has-[[data-mantle-table-sticky-right]]:[--_fade-right:black]!",
+						"has-data-mantle-table-sticky-right:[--_fade-right:black]",
 					)}
 					data-scroll-left={
 						(horizontalOverflow.state.hasOverflow && !horizontalOverflow.state.scrolledToStart) ||
@@ -1025,11 +1025,13 @@ function useHorizontalOverflowObserver<T extends HTMLElement>() {
 		scrolledToEnd: false,
 	});
 
-	useEffect(() => {
+	useLayoutEffect(() => {
 		const element = ref.current;
 		if (!element) {
 			return;
 		}
+
+		let frameId = 0;
 
 		const checkState = () => {
 			const hasOverflow = element.scrollWidth > element.clientWidth;
@@ -1049,20 +1051,32 @@ function useHorizontalOverflowObserver<T extends HTMLElement>() {
 			});
 		};
 
-		const resizeObserver = new ResizeObserver(checkState);
+		// Coalesce rapid-fire events (scroll, mutation, resize) into a single
+		// layout read per animation frame to avoid redundant work.
+		const scheduleCheck = () => {
+			if (frameId === 0) {
+				frameId = requestAnimationFrame(() => {
+					frameId = 0;
+					checkState();
+				});
+			}
+		};
+
+		const resizeObserver = new ResizeObserver(scheduleCheck);
 		resizeObserver.observe(element);
 
-		const mutationObserver = new MutationObserver(checkState);
+		const mutationObserver = new MutationObserver(scheduleCheck);
 		mutationObserver.observe(element, { childList: true, subtree: true });
 
-		element.addEventListener("scroll", checkState, { passive: true });
+		element.addEventListener("scroll", scheduleCheck, { passive: true });
 
 		checkState();
 
 		return () => {
+			cancelAnimationFrame(frameId);
 			resizeObserver.disconnect();
 			mutationObserver.disconnect();
-			element.removeEventListener("scroll", checkState);
+			element.removeEventListener("scroll", scheduleCheck);
 		};
 	}, []);
 


### PR DESCRIPTION
## Summary

- **`Table.Root`** split into outer wrapper (border, rounded corners, background) and inner scroll container (`scroll-fade-x` mask, `overflow-x: auto`, `overflow-y: clip`, `overscroll-behavior: none`). Tables only scroll horizontally and no longer bounce.
- **Scroll fade** left and right edge fades driven by scroll position. Right-side fade correctly suppressed when a sticky right column is present (`DataTable.ActionCell` / `DataTable.ActionHeader`).
- **`DataTable.ActionCell`** replaced per-cell `box-shadow` with `bg-inherit` and a `StickyColIndicator` child span (1px divider + soft leftward gradient). Tracks the row's background including hover state.
- **`DataTable.ActionHeader`** (new) — sticky `<th>` that pairs with `DataTable.ActionCell` so the pinned action column aligns across header and body rows during horizontal scroll.
- **`useHorizontalOverflowObserver`** now tracks `scrolledToStart`, coalesces rapid-fire scroll/resize/mutation events via `requestAnimationFrame`, and uses `useLayoutEffect` so corrections apply before the browser paints.

## Test plan

- [ ] Verify left/right scroll fades appear and disappear at correct scroll positions on a plain `Table`
- [ ] Verify right-side fade is suppressed on a `DataTable` with `ActionCell` / `ActionHeader`
- [ ] Verify sticky column indicator (divider + shadow) appears when scrolling and hides at scroll end
- [ ] Verify sticky column tracks row hover background
- [ ] Verify no vertical scroll or overscroll bounce on tables
- [ ] Verify no layout jank during rapid horizontal scrolling
- [ ] Check light and dark mode