### PR TITLE
fix(table): continuous sticky column indicator and vertical scroll passthrough

### DIFF
--- a/.changeset/fix-sticky-col-indicator.md
+++ b/.changeset/fix-sticky-col-indicator.md
@@ -1,0 +1,9 @@
+---
+"@ngrok/mantle": patch
+---
+
+fix(table): switch to border-separate for continuous sticky column indicator
+
+Replaced `border-collapse` with `border-separate border-spacing-0` on `Table.Element` and moved row dividers from group-level borders (`divide-y` on `<thead>`/`<tbody>`/`<tfoot>`) to cell-level borders. This prevents table cells from clipping overflow content, allowing the `StickyColIndicator` shadow strip to extend across row boundaries and render as one continuous vertical line instead of per-row segments with visible gaps.
+
+Also changed `overscroll-none` to `overscroll-x-none` on the table scroll container so vertical page scrolling is no longer blocked when hovering over a table.

--- a/apps/www/app/docs/components/data-table.mdx
+++ b/apps/www/app/docs/components/data-table.mdx
@@ -4,7 +4,7 @@ description: Tables purposefully designed for dynamic, application data with fea
 ---
 
 import { Example } from "~/components/example";
-import { EmptyPaymentsDemo, PaymentsDemo } from "~/features/data-table-demo";
+import { EmptyPaymentsDemo, EndpointsDemo, PaymentsDemo } from "~/features/data-table-demo";
 
 # Data Table
 
@@ -13,6 +13,9 @@ Tables purposefully designed for dynamic, application data with features like so
 <Example className="flex-col gap-6">
 	<div className="w-full">
 		<PaymentsDemo />
+	</div>
+	<div className="w-full">
+		<EndpointsDemo />
 	</div>
 	<div className="w-full">
 		<EmptyPaymentsDemo />

--- a/apps/www/app/features/data-table-demo.tsx
+++ b/apps/www/app/features/data-table-demo.tsx
@@ -95,7 +95,7 @@ const columns = [
 					<DropdownMenu.Trigger asChild>
 						<IconButton
 							appearance="ghost"
-							className="max-w rounded"
+							className="rounded"
 							type="button"
 							size="sm"
 							label="Open actions"
@@ -327,7 +327,7 @@ const endpointColumns = [
 					<DropdownMenu.Trigger asChild>
 						<IconButton
 							appearance="ghost"
-							className="max-w rounded"
+							className="rounded"
 							type="button"
 							size="sm"
 							label="Open actions"

--- a/apps/www/app/features/data-table-demo.tsx
+++ b/apps/www/app/features/data-table-demo.tsx
@@ -160,6 +160,230 @@ export function PaymentsDemo() {
 	);
 }
 
+type Endpoint = {
+	id: string;
+	region: string;
+	url: string;
+	type: string;
+	binding: string;
+	created: string;
+	updated: string;
+};
+
+const exampleEndpoints: Endpoint[] = [
+	{
+		id: "ep_abc123",
+		region: "us-east-1",
+		url: "https://2c3aq93ca44p6y1pper381em.ngrok.stage-ngrok.com",
+		type: "Edge",
+		binding: "1st app",
+		created: "2025-03-01",
+		updated: "2025-04-10",
+	},
+	{
+		id: "ep_def456",
+		region: "eu-west-1",
+		url: "https://api-gateway.eu-west.example.internal",
+		type: "Edge",
+		binding: "1st app",
+		created: "2025-02-15",
+		updated: "2025-04-09",
+	},
+	{
+		id: "ep_ghi789",
+		region: "ap-southeast-1",
+		url: "https://j2c3aqq93ca1p6y1lopper381em.ngrok.stage-ngrok.com",
+		type: "Edge",
+		binding: "",
+		created: "2025-01-20",
+		updated: "2025-04-08",
+	},
+	{
+		id: "ep_jkl012",
+		region: "us-west-2",
+		url: "https://dashboard-frontend-us-west.example.internal",
+		type: "Edge",
+		binding: "1st app",
+		created: "2025-03-10",
+		updated: "2025-04-07",
+	},
+	{
+		id: "ep_mno345",
+		region: "us-east-1",
+		url: "https://7jsteel.stage-ngrok.io",
+		type: "Edge",
+		binding: "",
+		created: "2025-02-28",
+		updated: "2025-04-06",
+	},
+	{
+		id: "ep_pqr678",
+		region: "eu-west-1",
+		url: "https://j9be2-dash-controller-80.internal",
+		type: "Edge",
+		binding: "1st app",
+		created: "2025-01-15",
+		updated: "2025-04-05",
+	},
+	{
+		id: "ep_stu901",
+		region: "ap-southeast-1",
+		url: "https://41b5af-a1-dashboard-frontend-controlplane-k1s1.internal",
+		type: "Edge",
+		binding: "",
+		created: "2025-03-05",
+		updated: "2025-04-04",
+	},
+	{
+		id: "ep_vwx234",
+		region: "us-west-2",
+		url: "https://41b5af-a1-dashboard-frontend.internal",
+		type: "Edge",
+		binding: "1st app",
+		created: "2025-02-01",
+		updated: "2025-04-03",
+	},
+];
+
+const endpointColumnHelper = createColumnHelper<Endpoint>();
+
+const endpointColumns = [
+	endpointColumnHelper.accessor("region", {
+		id: "region",
+		header: (props) => (
+			<DataTable.Header className="min-w-28">
+				<DataTable.HeaderSortButton column={props.column} sortingMode="alphanumeric">
+					Region
+				</DataTable.HeaderSortButton>
+			</DataTable.Header>
+		),
+		cell: (props) => <DataTable.Cell key={props.cell.id}>{props.getValue()}</DataTable.Cell>,
+	}),
+	endpointColumnHelper.accessor("url", {
+		id: "url",
+		header: (props) => (
+			<DataTable.Header className="min-w-100">
+				<DataTable.HeaderSortButton column={props.column} sortingMode="alphanumeric">
+					URL
+				</DataTable.HeaderSortButton>
+			</DataTable.Header>
+		),
+		cell: (props) => (
+			<DataTable.Cell key={props.cell.id} className="truncate max-w-100">
+				{props.getValue()}
+			</DataTable.Cell>
+		),
+	}),
+	endpointColumnHelper.accessor("type", {
+		id: "type",
+		header: (props) => (
+			<DataTable.Header className="min-w-20">
+				<DataTable.HeaderSortButton column={props.column} sortingMode="alphanumeric">
+					Type
+				</DataTable.HeaderSortButton>
+			</DataTable.Header>
+		),
+		cell: (props) => <DataTable.Cell key={props.cell.id}>{props.getValue()}</DataTable.Cell>,
+	}),
+	endpointColumnHelper.accessor("binding", {
+		id: "binding",
+		header: (props) => (
+			<DataTable.Header className="min-w-24">
+				<DataTable.HeaderSortButton column={props.column} sortingMode="alphanumeric">
+					Binding
+				</DataTable.HeaderSortButton>
+			</DataTable.Header>
+		),
+		cell: (props) => <DataTable.Cell key={props.cell.id}>{props.getValue()}</DataTable.Cell>,
+	}),
+	endpointColumnHelper.accessor("created", {
+		id: "created",
+		header: (props) => (
+			<DataTable.Header className="min-w-28">
+				<DataTable.HeaderSortButton column={props.column} sortingMode="alphanumeric">
+					Created
+				</DataTable.HeaderSortButton>
+			</DataTable.Header>
+		),
+		cell: (props) => <DataTable.Cell key={props.cell.id}>{props.getValue()}</DataTable.Cell>,
+	}),
+	endpointColumnHelper.accessor("updated", {
+		id: "updated",
+		header: (props) => (
+			<DataTable.Header className="min-w-28">
+				<DataTable.HeaderSortButton column={props.column} sortingMode="alphanumeric">
+					Updated
+				</DataTable.HeaderSortButton>
+			</DataTable.Header>
+		),
+		cell: (props) => <DataTable.Cell key={props.cell.id}>{props.getValue()}</DataTable.Cell>,
+	}),
+	endpointColumnHelper.display({
+		id: "actions",
+		header: () => <DataTable.ActionHeader />,
+		cell: () => (
+			<DataTable.ActionCell>
+				<DropdownMenu.Root>
+					<DropdownMenu.Trigger asChild>
+						<IconButton
+							appearance="ghost"
+							className="max-w rounded"
+							type="button"
+							size="sm"
+							label="Open actions"
+							icon={<DotsThreeIcon weight="bold" />}
+						/>
+					</DropdownMenu.Trigger>
+					<DropdownMenu.Content align="end">
+						<DropdownMenu.Item className="flex items-center gap-2">
+							<Icon svg={<PencilSimpleIcon />} /> Edit
+						</DropdownMenu.Item>
+						<DropdownMenu.Item className="text-danger-600 flex items-center gap-2">
+							<Icon svg={<TrashIcon />} />
+							Delete
+						</DropdownMenu.Item>
+					</DropdownMenu.Content>
+				</DropdownMenu.Root>
+			</DataTable.ActionCell>
+		),
+	}),
+];
+
+/**
+ * Demo of a wide data table with many columns to demonstrate horizontal overflow
+ * and the sticky action column indicator.
+ */
+export function EndpointsDemo() {
+	const data = useMemo(() => exampleEndpoints, []);
+	const table = useReactTable({
+		data,
+		columns: endpointColumns,
+		getCoreRowModel: getCoreRowModel(),
+		getPaginationRowModel: getPaginationRowModel(),
+		getSortedRowModel: getSortedRowModel(),
+		getFilteredRowModel: getFilteredRowModel(),
+		initialState: {
+			sorting: [{ id: "region", desc: false }],
+			pagination: { pageSize: 100 },
+		},
+	});
+	const rows = table.getRowModel().rows;
+	return (
+		<DataTable.Root table={table}>
+			<DataTable.Head />
+			<DataTable.Body>
+				{rows.length > 0 ? (
+					rows.map((row) => <DataTable.Row key={row.id} row={row} />)
+				) : (
+					<DataTable.EmptyRow>
+						<p className="flex items-center justify-center min-h-20">No results.</p>
+					</DataTable.EmptyRow>
+				)}
+			</DataTable.Body>
+		</DataTable.Root>
+	);
+}
+
 /**
  * Demo of a data table in an empty state.
  */

--- a/packages/mantle/src/components/data-table/data-table.tsx
+++ b/packages/mantle/src/components/data-table/data-table.tsx
@@ -216,7 +216,6 @@ function Header({ children, className, ...props }: DataTableHeaderProps) {
 }
 
 const Body = Table.Body;
-Body.displayName = "DataTableBody";
 
 type DataTableHeadProps = Omit<ComponentProps<typeof Table.Head>, "children">;
 
@@ -279,8 +278,8 @@ function EmptyRow<TData>({ children, ...props }: DataTableEmptyRowProps) {
  * adjacent rows' strips overlap at row dividers so the effect reads as one
  * continuous column instead of per-row blobs.
  *
- * Rendered as a child `<span>` because `border-collapse` on the table
- * suppresses box-shadow on `<td>`/`<th>`.
+ * Rendered as a child `<span>` because box-shadow on `<td>`/`<th>` is
+ * unreliable across table layout modes.
  */
 function StickyColIndicator() {
 	return (
@@ -312,7 +311,10 @@ function ActionCell({ children, className, ...props }: DataTableActionCellProps)
 			className={cx(
 				// `bg-inherit` keeps the sticky cell opaque with the row's current bg
 				// (including hover state) so scrolling cells don't show through.
-				"sticky z-10 right-0 flex items-center justify-end bg-inherit p-2",
+				// Avoid `display: flex` here — it overrides `display: table-cell`,
+				// preventing the cell from stretching to the full row height in
+				// `border-separate` mode.
+				"sticky z-10 right-0 text-end align-middle bg-inherit p-2",
 				className,
 			)}
 			{...props}

--- a/packages/mantle/src/components/table/table.tsx
+++ b/packages/mantle/src/components/table/table.tsx
@@ -67,7 +67,7 @@ const Root = forwardRef<ComponentRef<"div">, ComponentProps<"div">>(
 			>
 				<div
 					className={cx(
-						"scrollbar scroll-fade-x overflow-x-auto overflow-y-clip overscroll-none",
+						"scrollbar scroll-fade-x overflow-x-auto overflow-y-clip overscroll-x-none",
 						// When the table contains a sticky right column (e.g., DataTable.ActionCell
 						// / DataTable.ActionHeader), suppress the container's right-side fade so the
 						// pinned column stays fully opaque. The pinned column provides its own
@@ -163,7 +163,7 @@ const Element = forwardRef<ComponentRef<"table">, ComponentProps<"table">>(
 			<table
 				ref={ref}
 				className={cx(
-					"table-auto border-collapse caption-bottom w-full min-w-full text-left",
+					"table-auto border-separate border-spacing-0 caption-bottom w-full min-w-full text-left",
 					className,
 				)}
 				{...props}
@@ -228,8 +228,10 @@ const Head = forwardRef<ComponentRef<"thead">, ComponentProps<"thead">>(
 			ref={ref}
 			className={cx(
 				//,
-				"border-b border-card-muted",
-				"divide-y divide-card-muted",
+				// In border-separate, <tr>/<thead> borders don't render, so apply
+				// dividers directly to cells.
+				"[&>tr:last-child>*]:border-b [&>tr:last-child>*]:border-card-muted",
+				"[&>tr+tr>*]:border-t [&>tr+tr>*]:border-card-muted",
 				"text-muted bg-base",
 				"[&>tr]:bg-base", // Row styling
 				className,
@@ -292,9 +294,10 @@ const Body = forwardRef<ComponentRef<"tbody">, ComponentProps<"tbody">>(
 		<tbody
 			className={cx(
 				//,
-				"divide-y divide-card-muted",
+				// In border-separate, <tr>/<tbody> borders don't render, so apply
+				// dividers directly to cells.
+				"[&>tr+tr>*]:border-t [&>tr+tr>*]:border-card-muted",
 				"text-body",
-				"[thead+&]:border-t [thead+&]:border-card-muted",
 				"[&>tr]:bg-card [&>tr]:not-only:hover:bg-card-hover", // Body row styling
 				className,
 			)}
@@ -361,8 +364,10 @@ const Foot = forwardRef<ComponentRef<"tfoot">, ComponentProps<"tfoot">>(
 			className={cx(
 				//,
 				"font-medium text-body",
-				"border-t border-card-muted",
-				"divide-y divide-card-muted",
+				// In border-separate, <tr>/<tfoot> borders don't render, so apply
+				// dividers directly to cells.
+				"[&>tr:first-child>*]:border-t [&>tr:first-child>*]:border-card-muted",
+				"[&>tr+tr>*]:border-t [&>tr+tr>*]:border-card-muted",
 				"[&>tr]:bg-gray-50/50 [&>tr]:hover:bg-card-hover", // Row styling
 				className,
 			)}


### PR DESCRIPTION
Switch Table.Element from border-collapse to border-separate border-spacing-0 and move row dividers from group-level borders (divide-y on thead/tbody/tfoot) to cell-level borders. This prevents table cells from clipping overflow content, allowing the StickyColIndicator shadow strip to extend across row boundaries as one continuous vertical line instead of per-row segments with visible gaps.

Also change overscroll-none to overscroll-x-none on the table scroll container so vertical page scrolling is no longer blocked when hovering over a table.

Remove display:flex from DataTable.ActionCell in favor of text-end align-middle so the cell retains table-cell display and stretches to full row height.

Add EndpointsDemo to data-table docs page to demonstrate horizontal overflow with the sticky action column.