### PR TITLE
fix(input): fix black focus ring on PasswordInput toggle click and add blink animation

### DIFF
--- a/.changeset/fix-input-focus-ring-and-password-blink.md
+++ b/.changeset/fix-input-focus-ring-and-password-blink.md
@@ -1,0 +1,5 @@
+---
+"@ngrok/mantle": patch
+---
+
+Fix Input focus ring showing as black when clicking the PasswordInput visibility toggle by using `focus-within` for both ring size and color. Add a blink animation to the PasswordInput eye icon toggle that respects `prefers-reduced-motion`.

--- a/packages/mantle/src/components/input/input.tsx
+++ b/packages/mantle/src/components/input/input.tsx
@@ -196,13 +196,13 @@ const InputContainer = ({
 				data-validation={validation || undefined}
 				className={cx(
 					"pointer-coarse:text-base h-9 text-sm",
-					"bg-form relative flex w-full items-center gap-1.5 rounded-md border px-3 py-2 file:border-0 file:bg-transparent file:text-sm file:font-medium focus-within:outline-hidden focus-within:ring-4 focus-visible:outline-hidden focus-visible:ring-4",
+					"bg-form relative flex w-full items-center gap-1.5 rounded-md border px-3 py-2 file:border-0 file:bg-transparent file:text-sm file:font-medium focus-within:outline-hidden focus-within:ring-4 focus-visible:outline-hidden",
 					"data-disabled:opacity-50",
 					"has-[input:not(:first-child)]:ps-2.5 has-[input:not(:last-child)]:pe-2.5 [&>:not(input)]:shrink-0 [&_svg]:size-5",
-					"border-form text-strong has-focus-visible:border-accent-600 has-focus-visible:ring-focus-accent",
-					"data-validation-success:border-success-600 has-focus-visible:data-validation-success:border-success-600 has-focus-visible:data-validation-success:ring-focus-success",
-					"data-validation-warning:border-warning-600 has-focus-visible:data-validation-warning:border-warning-600 has-focus-visible:data-validation-warning:ring-focus-warning",
-					"data-validation-error:border-danger-600 has-focus-visible:data-validation-error:border-danger-600 has-focus-visible:data-validation-error:ring-focus-danger",
+					"border-form text-strong focus-within:border-accent-600 focus-within:ring-focus-accent",
+					"data-validation-success:border-success-600 focus-within:data-validation-success:border-success-600 focus-within:data-validation-success:ring-focus-success",
+					"data-validation-warning:border-warning-600 focus-within:data-validation-warning:border-warning-600 focus-within:data-validation-warning:ring-focus-warning",
+					"data-validation-error:border-danger-600 focus-within:data-validation-error:border-danger-600 focus-within:data-validation-error:ring-focus-danger",
 					"autofill:shadow-[inset_0_0_0px_1000px_var(--color-blue-50)] has-autofill:bg-blue-50 has-autofill:[-webkit-text-fill-color:var(--text-color-strong)]", // Autofill styling on the input itself and any children with autofill styling
 					className,
 				)}

--- a/packages/mantle/src/components/input/input.tsx
+++ b/packages/mantle/src/components/input/input.tsx
@@ -196,7 +196,7 @@ const InputContainer = ({
 				data-validation={validation || undefined}
 				className={cx(
 					"pointer-coarse:text-base h-9 text-sm",
-					"bg-form relative flex w-full items-center gap-1.5 rounded-md border px-3 py-2 file:border-0 file:bg-transparent file:text-sm file:font-medium focus-within:outline-hidden focus-within:ring-4 focus-visible:outline-hidden",
+					"bg-form relative flex w-full items-center gap-1.5 rounded-md border px-3 py-2 file:border-0 file:bg-transparent file:text-sm file:font-medium focus-within:outline-hidden focus-within:ring-4",
 					"data-disabled:opacity-50",
 					"has-[input:not(:first-child)]:ps-2.5 has-[input:not(:last-child)]:pe-2.5 [&>:not(input)]:shrink-0 [&_svg]:size-5",
 					"border-form text-strong focus-within:border-accent-600 focus-within:ring-focus-accent",

--- a/packages/mantle/src/components/input/password-input.browser.test.tsx
+++ b/packages/mantle/src/components/input/password-input.browser.test.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { render, screen } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import { describe, expect, test, vi } from "vitest";
+import { PasswordInput } from "./password-input.js";
+
+describe("PasswordInput (browser)", () => {
+	test("clicking the visibility toggle switches the input type between password and text", async () => {
+		const user = userEvent.setup();
+		render(<PasswordInput placeholder="test" />);
+
+		const input = screen.getByPlaceholderText("test");
+		const toggle = screen.getByRole("button", { name: /turn password visibility/i });
+
+		expect(input).toHaveAttribute("type", "password");
+
+		await user.click(toggle);
+		expect(input).toHaveAttribute("type", "text");
+
+		await user.click(toggle);
+		expect(input).toHaveAttribute("type", "password");
+	});
+
+	test("clicking the toggle fires onValueVisibilityChange with the new visibility", async () => {
+		const user = userEvent.setup();
+		const handleChange = vi.fn();
+		render(<PasswordInput placeholder="test" onValueVisibilityChange={handleChange} />);
+
+		const toggle = screen.getByRole("button", { name: /turn password visibility/i });
+
+		await user.click(toggle);
+		expect(handleChange).toHaveBeenCalledWith(true);
+
+		await user.click(toggle);
+		expect(handleChange).toHaveBeenCalledWith(false);
+	});
+
+	test("does not call Element.animate when prefers-reduced-motion is enabled", async () => {
+		const user = userEvent.setup();
+		// Simulate prefers-reduced-motion: reduce
+		const matchMediaSpy = vi.spyOn(window, "matchMedia").mockImplementation((query) => ({
+			matches: false, // "(prefers-reduced-motion: no-preference)" → false means reduced motion
+			media: query,
+			onchange: null,
+			addListener: vi.fn(),
+			removeListener: vi.fn(),
+			addEventListener: vi.fn(),
+			removeEventListener: vi.fn(),
+			dispatchEvent: vi.fn(),
+		}));
+
+		render(<PasswordInput placeholder="test" />);
+		const toggle = screen.getByRole("button", { name: /turn password visibility/i });
+		const animateSpy = vi.spyOn(toggle, "animate");
+
+		await user.click(toggle);
+
+		expect(screen.getByPlaceholderText("test")).toHaveAttribute("type", "text");
+		expect(animateSpy).not.toHaveBeenCalled();
+
+		matchMediaSpy.mockRestore();
+		animateSpy.mockRestore();
+	});
+});

--- a/packages/mantle/src/components/input/password-input.tsx
+++ b/packages/mantle/src/components/input/password-input.tsx
@@ -68,10 +68,9 @@ const PasswordInput = forwardRef<HTMLInputElement, PasswordInputProps>(
 						}
 
 						// Toggle immediately so the state is always correct
-						setShowPassword((prev) => {
-							onValueVisibilityChange?.(!prev);
-							return !prev;
-						});
+						const nextShowPassword = !showPassword;
+						setShowPassword(nextShowPassword);
+						onValueVisibilityChange?.(nextShowPassword);
 
 						const button = buttonRef.current;
 						if (button && !getPrefersReducedMotion()) {

--- a/packages/mantle/src/components/input/password-input.tsx
+++ b/packages/mantle/src/components/input/password-input.tsx
@@ -2,8 +2,9 @@
 
 import { EyeIcon } from "@phosphor-icons/react/Eye";
 import { EyeClosedIcon } from "@phosphor-icons/react/EyeClosed";
-import { forwardRef, useEffect, useState } from "react";
+import { forwardRef, useEffect, useRef, useState } from "react";
 import type { InputHTMLAttributes } from "react";
+import { getPrefersReducedMotion } from "../../hooks/use-prefers-reduced-motion.js";
 import { Icon } from "../icon/icon.js";
 import { Input, InputCapture } from "./input.js";
 import type { InputType, WithAutoComplete, WithValidation } from "./types.js";
@@ -44,6 +45,8 @@ const PasswordInput = forwardRef<HTMLInputElement, PasswordInputProps>(
 		const [showPassword, setShowPassword] = useState<boolean>(showValue);
 		const type: PasswordInputType = showPassword ? "text" : "password";
 		const EyeCon = showPassword ? EyeIcon : EyeClosedIcon;
+		const buttonRef = useRef<HTMLButtonElement>(null);
+		const animationRef = useRef<Animation | null>(null);
 
 		useEffect(() => {
 			setShowPassword(showValue);
@@ -53,12 +56,34 @@ const PasswordInput = forwardRef<HTMLInputElement, PasswordInputProps>(
 			<Input type={type} ref={ref} {...props}>
 				<InputCapture />
 				<button
+					ref={buttonRef}
 					type="button"
 					tabIndex={-1}
 					className="text-body hover:text-strong ml-1 cursor-pointer bg-inherit p-0"
 					onClick={() => {
-						setShowPassword(!showPassword);
-						onValueVisibilityChange?.(!showPassword);
+						// Cancel any in-flight animation so rapid clicks are never blocked
+						if (animationRef.current) {
+							animationRef.current.cancel();
+							animationRef.current = null;
+						}
+
+						// Toggle immediately so the state is always correct
+						setShowPassword((prev) => {
+							onValueVisibilityChange?.(!prev);
+							return !prev;
+						});
+
+						const button = buttonRef.current;
+						if (button && !getPrefersReducedMotion()) {
+							const duration = 200;
+							animationRef.current = button.animate(
+								[{ transform: "scaleY(0)" }, { transform: "scaleY(1)" }],
+								{ duration, easing: "ease-out" },
+							);
+							animationRef.current.onfinish = () => {
+								animationRef.current = null;
+							};
+						}
 					}}
 				>
 					<span className="sr-only">Turn password visibility {showPassword ? "off" : "on"}</span>


### PR DESCRIPTION
- Change InputContainer focus ring and border styles from `has-focus-visible:` to `focus-within:` so the ring color is always applied when any child has focus, fixing the black ring when clicking the eye toggle button
- Add a scaleY blink animation to the PasswordInput visibility toggle using the Web Animations API, with support for interruption on rapid clicks
- Respect `prefers-reduced-motion` by skipping the animation entirely