### PR TITLE
fix(input): prevent focus flicker and simplify PasswordInput animation

### DIFF
--- a/.changeset/fix-input-mousedown-and-password-animation.md
+++ b/.changeset/fix-input-mousedown-and-password-animation.md
@@ -2,4 +2,4 @@
 "@ngrok/mantle": patch
 ---
 
-Fix InputContainer focus ring flicker by preventing mousedown default on non-input children. Animate the PasswordInput eye icon (instead of the button) after React commits the new icon to the DOM. Remove `pointer-events-none` from validation feedback icons.
+Fix InputContainer focus ring flicker by preventing mousedown default on non-input children. Use `flushSync` in PasswordInput to animate the eye icon inline in the click handler after React commits the new icon to the DOM. Remove `pointer-events-none` from validation feedback icons.

--- a/.changeset/fix-input-mousedown-and-password-animation.md
+++ b/.changeset/fix-input-mousedown-and-password-animation.md
@@ -1,0 +1,5 @@
+---
+"@ngrok/mantle": patch
+---
+
+Fix InputContainer focus ring flicker by preventing mousedown default on non-input children. Animate the PasswordInput eye icon (instead of the button) after React commits the new icon to the DOM. Remove `pointer-events-none` from validation feedback icons.

--- a/packages/mantle/src/components/input/input.tsx
+++ b/packages/mantle/src/components/input/input.tsx
@@ -206,6 +206,13 @@ const InputContainer = ({
 					"autofill:shadow-[inset_0_0_0px_1000px_var(--color-blue-50)] has-autofill:bg-blue-50 has-autofill:[-webkit-text-fill-color:var(--text-color-strong)]", // Autofill styling on the input itself and any children with autofill styling
 					className,
 				)}
+				onMouseDown={(event) => {
+					// Prevent mousedown on non-input children (icons, buttons, etc.) from
+					// blurring the input, which would cause the focus ring to flicker.
+					if (event.target !== innerRef?.current) {
+						event.preventDefault();
+					}
+				}}
 				onClick={() => {
 					innerRef?.current?.focus();
 				}}
@@ -237,7 +244,7 @@ const ValidationFeedback = ({
 	switch (validation) {
 		case "error":
 			return (
-				<div className="text-danger-600 pointer-events-none order-last select-none">
+				<div className="text-danger-600 order-last select-none">
 					<span className="sr-only">
 						{clsx("The value entered for the", name, "input has failed validation.")}
 					</span>
@@ -246,13 +253,13 @@ const ValidationFeedback = ({
 			);
 		case "success":
 			return (
-				<div className="text-success-600 pointer-events-none order-last select-none">
+				<div className="text-success-600 order-last select-none">
 					<Icon svg={<CheckCircleIcon weight="fill" />} />
 				</div>
 			);
 		case "warning":
 			return (
-				<div className="text-warning-600 pointer-events-none order-last select-none">
+				<div className="text-warning-600 order-last select-none">
 					<Icon svg={<WarningDiamondIcon weight="fill" />} />
 				</div>
 			);

--- a/packages/mantle/src/components/input/password-input.browser.test.tsx
+++ b/packages/mantle/src/components/input/password-input.browser.test.tsx
@@ -52,7 +52,10 @@ describe("PasswordInput (browser)", () => {
 
 		render(<PasswordInput placeholder="test" />);
 		const toggle = screen.getByRole("button", { name: /turn password visibility/i });
-		const animateSpy = vi.spyOn(toggle, "animate");
+		const icon = toggle.querySelector("svg");
+		expect(icon).toBeInTheDocument();
+
+		const animateSpy = vi.spyOn(SVGSVGElement.prototype, "animate");
 
 		await user.click(toggle);
 

--- a/packages/mantle/src/components/input/password-input.tsx
+++ b/packages/mantle/src/components/input/password-input.tsx
@@ -45,18 +45,37 @@ const PasswordInput = forwardRef<HTMLInputElement, PasswordInputProps>(
 		const [showPassword, setShowPassword] = useState<boolean>(showValue);
 		const type: PasswordInputType = showPassword ? "text" : "password";
 		const EyeCon = showPassword ? EyeIcon : EyeClosedIcon;
-		const buttonRef = useRef<HTMLButtonElement>(null);
+		const iconRef = useRef<SVGSVGElement>(null);
 		const animationRef = useRef<Animation | null>(null);
+		const shouldAnimateRef = useRef(false);
 
 		useEffect(() => {
 			setShowPassword(showValue);
 		}, [showValue]);
 
+		// Run the blink animation after React commits the new icon to the DOM
+		useEffect(() => {
+			if (!shouldAnimateRef.current) {
+				return;
+			}
+			shouldAnimateRef.current = false;
+
+			const icon = iconRef.current;
+			if (icon) {
+				animationRef.current = icon.animate(
+					[{ transform: "scaleY(0)" }, { transform: "scaleY(1)" }],
+					{ duration: 200, easing: "ease-out" },
+				);
+				animationRef.current.onfinish = () => {
+					animationRef.current = null;
+				};
+			}
+		}, [showPassword]);
+
 		return (
 			<Input type={type} ref={ref} {...props}>
 				<InputCapture />
 				<button
-					ref={buttonRef}
 					type="button"
 					tabIndex={-1}
 					className="text-body hover:text-strong ml-1 cursor-pointer bg-inherit p-0"
@@ -67,26 +86,17 @@ const PasswordInput = forwardRef<HTMLInputElement, PasswordInputProps>(
 							animationRef.current = null;
 						}
 
+						// Flag the animation to run after React commits the new icon
+						shouldAnimateRef.current = !getPrefersReducedMotion();
+
 						// Toggle immediately so the state is always correct
 						const nextShowPassword = !showPassword;
 						setShowPassword(nextShowPassword);
 						onValueVisibilityChange?.(nextShowPassword);
-
-						const button = buttonRef.current;
-						if (button && !getPrefersReducedMotion()) {
-							const duration = 200;
-							animationRef.current = button.animate(
-								[{ transform: "scaleY(0)" }, { transform: "scaleY(1)" }],
-								{ duration, easing: "ease-out" },
-							);
-							animationRef.current.onfinish = () => {
-								animationRef.current = null;
-							};
-						}
 					}}
 				>
 					<span className="sr-only">Turn password visibility {showPassword ? "off" : "on"}</span>
-					<Icon svg={<EyeCon aria-hidden />} />
+					<Icon ref={iconRef} svg={<EyeCon aria-hidden />} />
 				</button>
 			</Input>
 		);

--- a/packages/mantle/src/components/input/password-input.tsx
+++ b/packages/mantle/src/components/input/password-input.tsx
@@ -4,6 +4,7 @@ import { EyeIcon } from "@phosphor-icons/react/Eye";
 import { EyeClosedIcon } from "@phosphor-icons/react/EyeClosed";
 import { forwardRef, useEffect, useRef, useState } from "react";
 import type { InputHTMLAttributes } from "react";
+import { flushSync } from "react-dom";
 import { getPrefersReducedMotion } from "../../hooks/use-prefers-reduced-motion.js";
 import { Icon } from "../icon/icon.js";
 import { Input, InputCapture } from "./input.js";
@@ -47,30 +48,10 @@ const PasswordInput = forwardRef<HTMLInputElement, PasswordInputProps>(
 		const EyeCon = showPassword ? EyeIcon : EyeClosedIcon;
 		const iconRef = useRef<SVGSVGElement>(null);
 		const animationRef = useRef<Animation | null>(null);
-		const shouldAnimateRef = useRef(false);
 
 		useEffect(() => {
 			setShowPassword(showValue);
 		}, [showValue]);
-
-		// Run the blink animation after React commits the new icon to the DOM
-		useEffect(() => {
-			if (!shouldAnimateRef.current) {
-				return;
-			}
-			shouldAnimateRef.current = false;
-
-			const icon = iconRef.current;
-			if (icon) {
-				animationRef.current = icon.animate(
-					[{ transform: "scaleY(0)" }, { transform: "scaleY(1)" }],
-					{ duration: 200, easing: "ease-out" },
-				);
-				animationRef.current.onfinish = () => {
-					animationRef.current = null;
-				};
-			}
-		}, [showPassword]);
 
 		return (
 			<Input type={type} ref={ref} {...props}>
@@ -86,13 +67,23 @@ const PasswordInput = forwardRef<HTMLInputElement, PasswordInputProps>(
 							animationRef.current = null;
 						}
 
-						// Flag the animation to run after React commits the new icon
-						shouldAnimateRef.current = !getPrefersReducedMotion();
-
-						// Toggle immediately so the state is always correct
+						// Flush synchronously so React commits the new icon to the DOM before we animate
 						const nextShowPassword = !showPassword;
-						setShowPassword(nextShowPassword);
+						flushSync(() => {
+							setShowPassword(nextShowPassword);
+						});
 						onValueVisibilityChange?.(nextShowPassword);
+
+						const icon = iconRef.current;
+						if (icon && !getPrefersReducedMotion()) {
+							animationRef.current = icon.animate(
+								[{ transform: "scaleY(0)" }, { transform: "scaleY(1)" }],
+								{ duration: 200, easing: "ease-out" },
+							);
+							animationRef.current.onfinish = () => {
+								animationRef.current = null;
+							};
+						}
 					}}
 				>
 					<span className="sr-only">Turn password visibility {showPassword ? "off" : "on"}</span>


### PR DESCRIPTION
- Add `onMouseDown` handler to `InputContainer` that prevents default on non-input children (icons, buttons) to stop focus ring flicker from blur/refocus cycle
- Use `flushSync` in `PasswordInput` click handler to synchronously commit the new icon to the DOM, then animate it inline — no `useEffect` or ref callbacks needed
- Remove `pointer-events-none` from `ValidationFeedback` icons
- Fix test to spy on `SVGSVGElement.prototype.animate` instead of the button