### PR TITLE
feat(mantle): add data-slot attributes and expand asChild support across components

### DIFF
--- a/.changeset/add-data-slot-attributes.md
+++ b/.changeset/add-data-slot-attributes.md
@@ -1,0 +1,9 @@
+---
+"@ngrok/mantle": patch
+---
+
+Add missing `data-slot` attributes across the component library so every exported component and compound sub-part exposes a stable `data-slot="<name>"` (or `data-slot="<name>-<part>"`) styling hook. Also adds `asChild` support (via `Slot`) to `Empty.Root`, `Empty.Actions`, `Code`, `ButtonGroup`, and `Table.Root` (which `DataTable` inherits automatically).
+
+Components updated include (non-exhaustive): `Main`, `SkipToMainLink`, `Empty`, `CodeBlock`, `Tabs`, `TextArea`, `Toast`/`Toaster`, `Separator`, `HorizontalSeparatorGroup`, `Sheet`, `Skeleton`, `Switch`, `Table`, `Label`, `MediaObject`, `Popover`, `RadioGroup`, `Select`, `Flag`, `HoverCard`, `Icon`, `SvgOnly`, `Input`/`PasswordInput`, `Kbd`, `DescriptionList`, `Dialog`, `DropdownMenu`, `DataTable`, `MetaKey`, `CursorPagination`, `ProgressBar`, and `ProgressDonut`. `HoverCard.Trigger`, `Dialog.Trigger`/`Dialog.Close`, and `DropdownMenu.Trigger` are now thin wrappers around their underlying Radix primitives so they can carry a `data-slot` attribute.
+
+Note: `ProgressBar`'s existing `data-slot` values were renamed to follow the compound-component naming convention — `data-slot="progress"` → `data-slot="progress-bar"` and `data-slot="progress-indicator"` → `data-slot="progress-bar-indicator"`. Consumers styling against those specific values will need to update their selectors.

--- a/.changeset/add-data-slot-attributes.md
+++ b/.changeset/add-data-slot-attributes.md
@@ -2,7 +2,7 @@
 "@ngrok/mantle": patch
 ---
 
-Add missing `data-slot` attributes across the component library so every exported component and compound sub-part exposes a stable `data-slot="<name>"` (or `data-slot="<name>-<part>"`) styling hook. Also adds `asChild` support (via `Slot`) to `Empty.Root`, `Empty.Actions`, `Code`, `ButtonGroup`, and `Table.Root` (which `DataTable` inherits automatically).
+Add missing `data-slot` attributes across the component library so every exported component and compound sub-part exposes a stable `data-slot="<name>"` (or `data-slot="<name>-<part>"`) styling hook. Also adds `asChild` support (via `Slot`) to `Empty.Root`, `Empty.Actions`, `Code`, and `ButtonGroup`.
 
 Components updated include (non-exhaustive): `Main`, `SkipToMainLink`, `Empty`, `CodeBlock`, `Tabs`, `TextArea`, `Toast`/`Toaster`, `Separator`, `HorizontalSeparatorGroup`, `Sheet`, `Skeleton`, `Switch`, `Table`, `Label`, `MediaObject`, `Popover`, `RadioGroup`, `Select`, `Flag`, `HoverCard`, `Icon`, `SvgOnly`, `Input`/`PasswordInput`, `Kbd`, `DescriptionList`, `Dialog`, `DropdownMenu`, `DataTable`, `MetaKey`, `CursorPagination`, `ProgressBar`, and `ProgressDonut`. `HoverCard.Trigger`, `Dialog.Trigger`/`Dialog.Close`, and `DropdownMenu.Trigger` are now thin wrappers around their underlying Radix primitives so they can carry a `data-slot` attribute.
 

--- a/.claude/commands/scaffold-component.md
+++ b/.claude/commands/scaffold-component.md
@@ -66,6 +66,12 @@ Create `packages/mantle/src/components/<component-name>/` with:
 - Use `ComponentProps` from React for prop types (no `interface`, use `type`)
 - Add JSDoc comments on all exported components with `@see` linking to `https://mantle.ngrok.com/components/<component-name>` and `@example` blocks
 - Use named exports (no default exports)
+- **Add a `data-slot` attribute to the rendered root element of every component** (applies to both simple and compound components, and to every sub-part of a compound component). Use kebab-case:
+  - Simple component: `data-slot="<component-name>"` (e.g., `data-slot="main"`)
+  - Compound root: `data-slot="<component-name>"` (e.g., `data-slot="code-block"`)
+  - Compound sub-part: `data-slot="<component-name>-<sub-part>"` (e.g., `data-slot="code-block-header"`, `data-slot="empty-title"`)
+
+  `data-slot` attributes give consumers a stable, styling-friendly hook that survives className overrides and `asChild` swaps. See `multi-select.tsx`, `empty.tsx`, and `code-block.tsx` for examples.
 
 #### Compound component pattern (POJO namespace)
 
@@ -156,13 +162,28 @@ If the component has sub-parts, follow the POJO namespace pattern from `decision
 
 #### `asChild` support
 
-Sub-components that render a semantic HTML element (headings, paragraphs, etc.) where consumers may need element-level flexibility should support the `asChild` prop:
+**All components and compound sub-parts should support the `asChild` prop by default.** Every component has an ideal default DOM element it renders as, but consumers must also be able to swap that element for their own component or a different tag when composition requires it — that's what `asChild` is for. Only skip `asChild` when there is a concrete reason the polymorphism doesn't apply (examples below).
+
+To add `asChild` support:
 
 - Import `WithAsChild` from `../../types/as-child.js` and `Slot` from `../slot/index.js`
-- Add `asChild` to the props type: `HTMLAttributes<HTMLElement> & WithAsChild`
-- Swap the rendered element: `const Comp = asChild ? Slot : "h3";`
+- Add `asChild` to the props type: `ComponentProps<"div"> & WithAsChild` (or the appropriate element)
+- Swap the rendered element:
+  ```tsx
+  const Comp = asChild ? Slot : "div";
+  return <Comp data-slot="my-component" className={cx(...)} {...props} />;
+  ```
+- Document the polymorphism in the docs page under a `## Polymorphism` section (see step 3).
 
-See the `Empty.Title` and `Empty.Description` components for a real example.
+**Exceptions — when NOT to add `asChild`:**
+
+- The component accepts an element via a prop rather than children and clones it internally (e.g., `Empty.Icon` takes an `svg` prop and uses `SvgOnly` to clone it — polymorphism is already handled via the prop).
+- The component is a pure utility that does not render a DOM element (e.g., `BrowserOnly`, `Slot` itself, `SandboxedOnClick`).
+- The component wraps a third-party primitive (Radix, Ariakit) that already exposes its own `asChild` / `render` mechanism, in which case forward to that primitive's escape hatch instead of re-implementing with `Slot`.
+
+If you skip `asChild`, document why in a short comment at the component declaration so future maintainers know it was a deliberate exception, not an oversight.
+
+See `alert.tsx`, `empty.tsx`, and `code-block.tsx` for canonical examples.
 
 #### Simple (non-compound) components
 

--- a/apps/www/app/docs/components/empty.mdx
+++ b/apps/www/app/docs/components/empty.mdx
@@ -164,7 +164,11 @@ Empty.Root
 
 The root container for an empty state. Centers content horizontally with consistent vertical padding and max-width.
 
-All props from [div](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div#attributes).
+All props from [div](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div#attributes), plus:
+
+| Prop       | Type      | Default | Description                                       |
+| ---------- | --------- | ------- | ------------------------------------------------- |
+| `asChild?` | `boolean` | `false` | Render as a different element by passing a child. |
 
 ### Empty.Icon
 
@@ -200,4 +204,8 @@ All props from [div](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/d
 
 A flex container for action buttons or links.
 
-All props from [div](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div#attributes).
+All props from [div](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div#attributes), plus:
+
+| Prop       | Type      | Default | Description                                       |
+| ---------- | --------- | ------- | ------------------------------------------------- |
+| `asChild?` | `boolean` | `false` | Render as a different element by passing a child. |

--- a/apps/www/app/docs/components/table.mdx
+++ b/apps/www/app/docs/components/table.mdx
@@ -152,7 +152,11 @@ The `Table` is a structured way to display data in rows and columns. The API mat
 
 Root container for all `Table` sub-components. Should be the parent of all other table sub-components. It provides styling and additional functionality, such as horizontal overflow detection.
 
-All props from [div](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div#attributes).
+All props from [div](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div#attributes), plus:
+
+| Prop       | Type      | Default | Description                                       |
+| ---------- | --------- | ------- | ------------------------------------------------- |
+| `asChild?` | `boolean` | `false` | Render as a different element by passing a child. |
 
 ### Table.Element
 

--- a/apps/www/app/docs/components/table.mdx
+++ b/apps/www/app/docs/components/table.mdx
@@ -152,11 +152,7 @@ The `Table` is a structured way to display data in rows and columns. The API mat
 
 Root container for all `Table` sub-components. Should be the parent of all other table sub-components. It provides styling and additional functionality, such as horizontal overflow detection.
 
-All props from [div](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div#attributes), plus:
-
-| Prop       | Type      | Default | Description                                       |
-| ---------- | --------- | ------- | ------------------------------------------------- |
-| `asChild?` | `boolean` | `false` | Render as a different element by passing a child. |
+All props from [div](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div#attributes).
 
 ### Table.Element
 

--- a/packages/mantle/src/components/accordion/accordion.tsx
+++ b/packages/mantle/src/components/accordion/accordion.tsx
@@ -33,7 +33,12 @@ const Root = forwardRef<
 	ComponentRef<"div">,
 	ComponentPropsWithoutRef<typeof AccordionPrimitive.Root>
 >(({ className, ...props }, ref) => (
-	<AccordionPrimitive.Root ref={ref} className={cx("w-full space-y-2.5", className)} {...props} />
+	<AccordionPrimitive.Root
+		ref={ref}
+		data-slot="accordion"
+		className={cx("w-full space-y-2.5", className)}
+		{...props}
+	/>
 ));
 Root.displayName = "Accordion";
 
@@ -60,7 +65,12 @@ Root.displayName = "Accordion";
  * </Accordion.Root>
  * ```
  */
-const Item = AccordionPrimitive.Item;
+const Item = forwardRef<
+	ComponentRef<typeof AccordionPrimitive.Item>,
+	ComponentPropsWithoutRef<typeof AccordionPrimitive.Item>
+>(({ ...props }, ref) => (
+	<AccordionPrimitive.Item ref={ref} data-slot="accordion-item" {...props} />
+));
 Item.displayName = "AccordionItem";
 
 /**
@@ -92,6 +102,7 @@ const Heading = forwardRef<
 >(({ className, ...props }, ref) => (
 	<AccordionPrimitive.Header
 		ref={ref}
+		data-slot="accordion-heading"
 		className={cx("flex items-center gap-2", className)}
 		{...props}
 	/>
@@ -127,6 +138,7 @@ const Trigger = forwardRef<
 >(({ className, children, ...props }, ref) => (
 	<AccordionPrimitive.Trigger
 		ref={ref}
+		data-slot="accordion-trigger"
 		className={cx("group flex items-center gap-1.5", className)}
 		{...props}
 	>
@@ -161,6 +173,7 @@ Trigger.displayName = "AccordionTrigger";
 const TriggerIcon = ({ className, ...props }: Omit<IconProps, "svg">) => (
 	<Icon
 		{...props}
+		data-slot="accordion-trigger-icon"
 		svg={<CaretDownIcon weight="fill" />}
 		className={cx("group-data-[state=open]:rotate-0 -rotate-90", className)}
 	/>
@@ -196,6 +209,7 @@ const Content = forwardRef<
 >(({ className, children, ...props }, ref) => (
 	<AccordionPrimitive.Content
 		ref={ref}
+		data-slot="accordion-content"
 		className={cx(
 			"data-state-closed:animate-accordion-up data-state-open:animate-accordion-down overflow-hidden *:first:mt-4",
 			className,

--- a/packages/mantle/src/components/alert-dialog/alert-dialog.tsx
+++ b/packages/mantle/src/components/alert-dialog/alert-dialog.tsx
@@ -127,7 +127,12 @@ Root.displayName = "AlertDialog";
  * </AlertDialog.Root>
  * ```
  */
-const Trigger = AlertDialogPrimitive.Trigger;
+const Trigger = forwardRef<
+	ComponentRef<typeof AlertDialogPrimitive.Trigger>,
+	ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Trigger>
+>(({ ...props }, ref) => (
+	<AlertDialogPrimitive.Trigger ref={ref} data-slot="alert-dialog-trigger" {...props} />
+));
 Trigger.displayName = "AlertDialogTrigger";
 
 /**
@@ -148,6 +153,7 @@ const AlertDialogOverlay = forwardRef<
 	ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Overlay>
 >(({ className, ...props }, ref) => (
 	<AlertDialogPrimitive.Overlay
+		data-slot="alert-dialog-overlay"
 		className={cx(
 			"data-state-open:animate-in data-state-closed:animate-out data-state-closed:fade-out-0 data-state-open:fade-in-0 bg-overlay fixed inset-0 z-50 backdrop-blur-xs",
 			className,
@@ -215,6 +221,7 @@ const Content = forwardRef<
 		<AlertDialogOverlay />
 		<div className="fixed inset-4 z-50 flex items-center justify-center">
 			<AlertDialogPrimitive.Content
+				data-slot="alert-dialog-content"
 				data-mantle-modal-content
 				ref={ref}
 				className={cx(
@@ -272,7 +279,14 @@ const Body = forwardRef<ComponentRef<"div">, ComponentProps<"div"> & WithAsChild
 	({ asChild = false, className, ...props }, ref) => {
 		const Component = asChild ? Slot : "div";
 
-		return <Component className={cx("flex-1 space-y-4", className)} ref={ref} {...props} />;
+		return (
+			<Component
+				data-slot="alert-dialog-body"
+				className={cx("flex-1 space-y-4", className)}
+				ref={ref}
+				{...props}
+			/>
+		);
 	},
 );
 Body.displayName = "AlertDialogBody";
@@ -318,6 +332,7 @@ const Header = forwardRef<ComponentRef<"div">, ComponentProps<"div"> & WithAsChi
 
 		return (
 			<Component
+				data-slot="alert-dialog-header"
 				className={cx("flex flex-col space-y-2 text-center sm:text-start", className)}
 				ref={ref}
 				{...props}
@@ -368,6 +383,7 @@ const Footer = forwardRef<ComponentRef<"div">, ComponentProps<"div"> & WithAsChi
 
 		return (
 			<Component
+				data-slot="alert-dialog-footer"
 				className={cx("flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2", className)}
 				ref={ref}
 				{...props}
@@ -421,6 +437,7 @@ const Title = forwardRef<
 >(({ className, ...props }, ref) => (
 	<AlertDialogPrimitive.Title
 		ref={ref}
+		data-slot="alert-dialog-title"
 		className={cx("text-strong text-center text-lg font-medium sm:text-start", className)}
 		{...props}
 	/>
@@ -473,6 +490,7 @@ const Description = forwardRef<
 >(({ className, ...props }, ref) => (
 	<AlertDialogPrimitive.Description
 		ref={ref}
+		data-slot="alert-dialog-description"
 		className={cx("text-body text-center text-sm font-normal sm:text-start", className)}
 		{...props}
 	/>
@@ -539,6 +557,7 @@ const Action = forwardRef<ComponentRef<"button">, ButtonProps>(
 			<Button
 				//
 				appearance={appearance}
+				data-slot="alert-dialog-action"
 				priority={buttonPriority}
 				ref={ref}
 				{...props}
@@ -602,6 +621,7 @@ const Cancel = forwardRef<ComponentRef<"button">, ButtonProps>(
 		<AlertDialogPrimitive.Close asChild>
 			<Button
 				appearance={appearance}
+				data-slot="alert-dialog-cancel"
 				className={cx("mt-2 sm:mt-0", className)}
 				priority={priority}
 				ref={ref}
@@ -665,6 +685,7 @@ const Icon = forwardRef<ComponentRef<"svg">, AlertDialogIconProps>(
 		return (
 			<SvgOnly
 				ref={ref}
+				data-slot="alert-dialog-icon"
 				className={cx("size-12 sm:size-7", defaultColor, className)}
 				svg={svg ?? defaultIcon}
 				{...props}
@@ -690,7 +711,12 @@ Icon.displayName = "AlertDialogIcon";
  *   </AlertDialog.Action>
  * </AlertDialog.Close>
  */
-const Close = AlertDialogPrimitive.Close;
+const Close = forwardRef<
+	ComponentRef<typeof AlertDialogPrimitive.Close>,
+	ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Close>
+>(({ ...props }, ref) => (
+	<AlertDialogPrimitive.Close ref={ref} data-slot="alert-dialog-close" {...props} />
+));
 Close.displayName = "AlertDialogClose";
 
 /**

--- a/packages/mantle/src/components/alert/alert.tsx
+++ b/packages/mantle/src/components/alert/alert.tsx
@@ -146,6 +146,7 @@ const Root = forwardRef<ComponentRef<"div">, AlertProps>(
 			<AlertContext.Provider value={context}>
 				<div
 					ref={ref}
+					data-slot="alert"
 					className={cx(alertVariants({ appearance, priority }), className)}
 					{...props}
 				/>
@@ -201,7 +202,13 @@ const Icon = forwardRef<ComponentRef<"svg">, AlertIconProps>(
 		const defaultIcon = defaultIcons[ctx.priority];
 
 		return (
-			<SvgOnly ref={ref} className={cx("size-5", className)} svg={svg ?? defaultIcon} {...props} />
+			<SvgOnly
+				ref={ref}
+				data-slot="alert-icon"
+				className={cx("size-5", className)}
+				svg={svg ?? defaultIcon}
+				{...props}
+			/>
 		);
 	},
 );
@@ -230,6 +237,7 @@ const Content = forwardRef<ComponentRef<"div">, ComponentProps<"div">>(
 	({ className, ...props }, ref) => (
 		<div
 			ref={ref}
+			data-slot="alert-content"
 			className={cx("min-w-0 flex-1 has-data-alert-dismiss:pr-6", className)}
 			{...props}
 		/>
@@ -262,7 +270,14 @@ const Title = forwardRef<HTMLHeadingElement, AlertTitleProps>(
 	({ asChild = false, className, ...props }, ref) => {
 		const Component = asChild ? Slot : "h5";
 
-		return <Component ref={ref} className={cx("font-medium", className)} {...props} />;
+		return (
+			<Component
+				ref={ref}
+				data-slot="alert-title"
+				className={cx("font-medium", className)}
+				{...props}
+			/>
+		);
 	},
 );
 Title.displayName = "AlertTitle";
@@ -294,7 +309,14 @@ const Description = forwardRef<ComponentRef<"div">, AlertDescriptionProps>(
 	({ asChild = false, className, ...props }, ref) => {
 		const Component = asChild ? Slot : "div";
 
-		return <Component ref={ref} className={cx("text-sm", className)} {...props} />;
+		return (
+			<Component
+				ref={ref}
+				data-slot="alert-description"
+				className={cx("text-sm", className)}
+				{...props}
+			/>
+		);
 	},
 );
 Description.displayName = "AlertDescription";
@@ -332,6 +354,7 @@ const DismissIconButton = ({
 			icon={icon}
 			label={label}
 			size={size}
+			data-slot="alert-dismiss-icon-button"
 			data-alert-dismiss
 			className={cx(
 				"right-1.5 top-1.5 absolute",

--- a/packages/mantle/src/components/anchor/anchor.tsx
+++ b/packages/mantle/src/components/anchor/anchor.tsx
@@ -64,6 +64,7 @@ const Anchor = forwardRef<ComponentRef<"a">, AnchorProps>(
 	) => {
 		const rel = resolveRel(propRel);
 		const componentProps = {
+			"data-slot": "anchor",
 			className: anchorClassNames(className),
 			ref,
 			rel,

--- a/packages/mantle/src/components/badge/badge.tsx
+++ b/packages/mantle/src/components/badge/badge.tsx
@@ -67,7 +67,7 @@ const Badge = ({
 		const grandchildren = singleChild.props?.children;
 
 		return (
-			<Slot className={badgeClasses} {...props}>
+			<Slot data-slot="badge" className={badgeClasses} {...props}>
 				{cloneElement(
 					singleChild,
 					{},
@@ -81,7 +81,7 @@ const Badge = ({
 	}
 
 	return (
-		<span className={badgeClasses} {...props}>
+		<span data-slot="badge" className={badgeClasses} {...props}>
 			{icon && <SvgOnly className="size-4" svg={icon} />}
 			{children}
 		</span>

--- a/packages/mantle/src/components/button/button-group.tsx
+++ b/packages/mantle/src/components/button/button-group.tsx
@@ -1,7 +1,9 @@
 import { cva } from "class-variance-authority";
 import { type ComponentProps, type ComponentRef, forwardRef } from "react";
 import type { VariantProps } from "../../types/index.js";
+import type { WithAsChild } from "../../types/as-child.js";
 import { cx } from "../../utils/cx/cx.js";
+import { Slot } from "../slot/index.js";
 
 const buttonGroupVariants = cva("border-form inline-flex items-center rounded-md", {
 	variants: {
@@ -19,7 +21,7 @@ const buttonGroupVariants = cva("border-form inline-flex items-center rounded-md
 
 type ButtonGroupVariants = VariantProps<typeof buttonGroupVariants>;
 
-type ButtonGroupProps = ComponentProps<"div"> & ButtonGroupVariants;
+type ButtonGroupProps = ComponentProps<"div"> & ButtonGroupVariants & WithAsChild;
 
 /**
  * A contained group of related buttons.
@@ -36,11 +38,17 @@ type ButtonGroupProps = ComponentProps<"div"> & ButtonGroupVariants;
  * ```
  */
 const ButtonGroup = forwardRef<ComponentRef<"div">, ButtonGroupProps>(
-	({ appearance, className, children, ...props }, ref) => {
+	({ appearance, asChild, className, children, ...props }, ref) => {
+		const Comp = asChild ? Slot : "div";
 		return (
-			<div className={cx(buttonGroupVariants({ appearance }), className)} ref={ref} {...props}>
+			<Comp
+				data-slot="button-group"
+				className={cx(buttonGroupVariants({ appearance }), className)}
+				ref={ref}
+				{...props}
+			>
 				{children}
-			</div>
+			</Comp>
 		);
 	},
 );

--- a/packages/mantle/src/components/button/button.tsx
+++ b/packages/mantle/src/components/button/button.tsx
@@ -214,6 +214,7 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
 
 		const buttonProps = {
 			"aria-disabled": disabled,
+			"data-slot": "button",
 			className: cx(
 				"inline-flex items-center justify-center gap-1.5 whitespace-nowrap rounded-md",
 				"focus:outline-hidden focus-visible:ring-4",

--- a/packages/mantle/src/components/button/icon-button.tsx
+++ b/packages/mantle/src/components/button/icon-button.tsx
@@ -164,6 +164,7 @@ const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(
 
 		const buttonProps = {
 			"aria-disabled": disabled,
+			"data-slot": "icon-button",
 			className: cx(iconButtonVariants({ appearance, isLoading, size }), className),
 			"data-appearance": appearance,
 			"data-disabled": disabled,

--- a/packages/mantle/src/components/calendar/calendar.tsx
+++ b/packages/mantle/src/components/calendar/calendar.tsx
@@ -38,6 +38,7 @@ type CalendarProps = ComponentProps<typeof DayPicker>;
 function Calendar({ className, classNames, showOutsideDays = false, ...props }: CalendarProps) {
 	return (
 		<DayPicker
+			data-slot="calendar"
 			animate={false}
 			components={{
 				Chevron: (iconProps) => {

--- a/packages/mantle/src/components/card/card.tsx
+++ b/packages/mantle/src/components/card/card.tsx
@@ -40,6 +40,7 @@ const Root = forwardRef<ComponentRef<"div">, CardProps>(
 		return (
 			<Component
 				ref={ref}
+				data-slot="card"
 				className={cx("border-card bg-card relative rounded-md border", className)}
 				{...rest}
 			>
@@ -83,6 +84,7 @@ const Body = forwardRef<ComponentRef<"div">, CardProps>(
 		return (
 			<Component
 				ref={ref}
+				data-slot="card-body"
 				className={cx("p-6 border-t border-card-muted first:border-t-0", className)}
 				{...rest}
 			>
@@ -120,6 +122,7 @@ const Footer = forwardRef<ComponentRef<"div">, CardProps>(
 		return (
 			<Component
 				ref={ref}
+				data-slot="card-footer"
 				className={cx("px-6 py-3 border-t border-card-muted first:border-t-0", className)}
 				{...rest}
 			>
@@ -157,6 +160,7 @@ const Header = forwardRef<ComponentRef<"div">, CardProps>(
 		return (
 			<Component
 				ref={ref}
+				data-slot="card-header"
 				className={cx("px-6 py-3 border-t border-card-muted first:border-t-0", className)}
 				{...rest}
 			>
@@ -197,7 +201,12 @@ const Title = forwardRef<HTMLHeadingElement, CardTitleProps>(
 	({ className, asChild, ...props }, ref) => {
 		const Comp = asChild ? Slot : "h3";
 		return (
-			<Comp ref={ref} className={cx("text-strong text-base font-medium", className)} {...props} />
+			<Comp
+				ref={ref}
+				data-slot="card-title"
+				className={cx("text-strong text-base font-medium", className)}
+				{...props}
+			/>
 		);
 	},
 );

--- a/packages/mantle/src/components/checkbox/checkbox.tsx
+++ b/packages/mantle/src/components/checkbox/checkbox.tsx
@@ -80,6 +80,7 @@ const Checkbox = forwardRef<ComponentRef<"input">, Props>(
 			<input
 				aria-checked={isIndeterminate(_checked) ? "mixed" : _checked}
 				aria-invalid={ariaInvalid}
+				data-slot="checkbox"
 				className={clsx(
 					"border-form bg-form shrink-0 cursor-pointer select-none appearance-none rounded border disabled:cursor-default disabled:opacity-50",
 					"bg-center bg-no-repeat focus:outline-hidden",

--- a/packages/mantle/src/components/code-block/code-block.tsx
+++ b/packages/mantle/src/components/code-block/code-block.tsx
@@ -199,7 +199,14 @@ Root.displayName = "CodeBlock";
 const Body = forwardRef<ComponentRef<"div">, ComponentProps<"div"> & WithAsChild>(
 	({ asChild = false, className, ...props }, ref) => {
 		const Component = asChild ? Slot : "div";
-		return <Component className={cx("relative", className)} ref={ref} {...props} />;
+		return (
+			<Component
+				data-slot="code-block-body"
+				className={cx("relative", className)}
+				ref={ref}
+				{...props}
+			/>
+		);
 	},
 );
 Body.displayName = "CodeBlockBody";
@@ -364,6 +371,7 @@ const Code = forwardRef<ComponentRef<"pre">, CodeBlockCodeProps>(
 
 		return (
 			<pre
+				data-slot="code-block-code"
 				aria-expanded={hasCodeExpander ? isCodeExpanded : undefined}
 				className={cx(
 					"scrollbar overflow-x-auto overflow-y-hidden py-4",
@@ -431,6 +439,7 @@ const Header = forwardRef<ComponentRef<"div">, ComponentProps<"div"> & WithAsChi
 		const Component = asChild ? Slot : "div";
 		return (
 			<Component
+				data-slot="code-block-header"
 				className={cx(
 					"flex items-center gap-1 border-b border-gray-300 bg-base px-4 py-2 text-gray-700",
 					className,
@@ -469,6 +478,7 @@ const Title = forwardRef<
 	const Component = asChild ? Slot : "h3";
 	return (
 		<Component
+			data-slot="code-block-title"
 			ref={ref}
 			className={cx("text-mono m-0 font-mono font-normal", className)}
 			{...props}
@@ -523,7 +533,7 @@ const CopyButton = forwardRef<ComponentRef<"button">, CodeBlockCopyButtonProps>(
 		}, []);
 
 		return (
-			<span className="absolute right-2.5 top-2.5 z-10 bg-card">
+			<span data-slot="code-block-copy-button" className="absolute right-2.5 top-2.5 z-10 bg-card">
 				<IconButton
 					type="button"
 					appearance="ghost"
@@ -604,6 +614,7 @@ const ExpanderButton = forwardRef<ComponentRef<"button">, CodeBlockExpanderButto
 		return (
 			<Component
 				{...props}
+				data-slot="code-block-expander-button"
 				aria-controls={codeId}
 				aria-expanded={isCodeExpanded}
 				className={cx(
@@ -695,7 +706,7 @@ function CodeBlockIconComponent({
 				break;
 		}
 	}
-	return <MantleIcon className={className} svg={svg} {...props} />;
+	return <MantleIcon data-slot="code-block-icon" className={className} svg={svg} {...props} />;
 }
 CodeBlockIconComponent.displayName = "CodeBlockIcon";
 
@@ -732,7 +743,12 @@ type CodeBlockTabListProps = Omit<ComponentProps<typeof RadixTabsList>, "asChild
  */
 const TabList = forwardRef<ComponentRef<typeof RadixTabsList>, CodeBlockTabListProps>(
 	({ className, ...props }, ref) => (
-		<RadixTabsList className={cx("flex items-center gap-1", className)} ref={ref} {...props} />
+		<RadixTabsList
+			data-slot="code-block-tab-list"
+			className={cx("flex items-center gap-1", className)}
+			ref={ref}
+			{...props}
+		/>
 	),
 );
 TabList.displayName = "CodeBlockTabList";
@@ -754,6 +770,7 @@ type CodeBlockTabTriggerProps = Omit<ComponentProps<typeof RadixTabsTrigger>, "a
 const TabTrigger = forwardRef<ComponentRef<typeof RadixTabsTrigger>, CodeBlockTabTriggerProps>(
 	({ className, ...props }, ref) => (
 		<RadixTabsTrigger
+			data-slot="code-block-tab-trigger"
 			className={cx(
 				"cursor-pointer rounded px-1.5 py-0.5 text-xs font-medium",
 				"text-gray-600 outline-hidden",
@@ -793,7 +810,7 @@ type CodeBlockTabContentProps = Omit<
  * ```
  */
 const TabContent = forwardRef<ComponentRef<typeof RadixTabsContent>, CodeBlockTabContentProps>(
-	(props, ref) => <RadixTabsContent ref={ref} {...props} />,
+	(props, ref) => <RadixTabsContent data-slot="code-block-tab-content" ref={ref} {...props} />,
 );
 TabContent.displayName = "CodeBlockTabContent";
 

--- a/packages/mantle/src/components/code/code.tsx
+++ b/packages/mantle/src/components/code/code.tsx
@@ -1,6 +1,8 @@
 import { forwardRef } from "react";
 import type { HTMLAttributes } from "react";
+import type { WithAsChild } from "../../types/as-child.js";
 import { cx } from "../../utils/cx/cx.js";
+import { Slot } from "../slot/index.js";
 
 /**
  * Marks text to signify a short fragment of inline computer code.
@@ -14,17 +16,21 @@ import { cx } from "../../utils/cx/cx.js";
  * </p>
  * ```
  */
-const Code = forwardRef<HTMLSpanElement, HTMLAttributes<HTMLSpanElement>>(
-	({ className, ...props }, ref) => (
-		<code
-			ref={ref}
-			className={cx(
-				"border-gray-500/15 rounded-md border bg-gray-500/5 px-1 font-mono text-[0.8em]",
-				className,
-			)}
-			{...props}
-		/>
-	),
+const Code = forwardRef<HTMLSpanElement, HTMLAttributes<HTMLSpanElement> & WithAsChild>(
+	({ asChild, className, ...props }, ref) => {
+		const Comp = asChild ? Slot : "code";
+		return (
+			<Comp
+				ref={ref}
+				data-slot="code"
+				className={cx(
+					"border-gray-500/15 rounded-md border bg-gray-500/5 px-1 font-mono text-[0.8em]",
+					className,
+				)}
+				{...props}
+			/>
+		);
+	},
 );
 Code.displayName = "Code";
 

--- a/packages/mantle/src/components/code/code.tsx
+++ b/packages/mantle/src/components/code/code.tsx
@@ -1,5 +1,5 @@
 import { forwardRef } from "react";
-import type { HTMLAttributes } from "react";
+import type { ComponentProps, ComponentRef } from "react";
 import type { WithAsChild } from "../../types/as-child.js";
 import { cx } from "../../utils/cx/cx.js";
 import { Slot } from "../slot/index.js";
@@ -16,7 +16,7 @@ import { Slot } from "../slot/index.js";
  * </p>
  * ```
  */
-const Code = forwardRef<HTMLSpanElement, HTMLAttributes<HTMLSpanElement> & WithAsChild>(
+const Code = forwardRef<ComponentRef<"code">, ComponentProps<"code"> & WithAsChild>(
 	({ asChild, className, ...props }, ref) => {
 		const Comp = asChild ? Slot : "code";
 		return (

--- a/packages/mantle/src/components/combobox/combobox.tsx
+++ b/packages/mantle/src/components/combobox/combobox.tsx
@@ -70,6 +70,7 @@ const Input = forwardRef<ComponentRef<"input">, ComboboxInputProps>(
 				aria-invalid={ariaInvalid}
 				autoComplete={autoComplete}
 				autoSelect={autoSelect}
+				data-slot="combobox-input"
 				className={cx(
 					"pointer-coarse:text-base h-9 text-sm",
 					"bg-form relative block w-full rounded-md border px-3 py-2 border-form text-strong font-sans",
@@ -114,6 +115,7 @@ const Content = forwardRef<ComponentRef<typeof Primitive.ComboboxPopover>, Combo
 	) => {
 		return (
 			<Primitive.ComboboxPopover
+				data-slot="combobox-content"
 				className={cx(
 					"border-popover bg-popover relative z-50 max-h-96 min-w-32 scrollbar overflow-y-scroll overflow-x-hidden rounded-md border shadow-md p-1 my-2 space-y-px font-sans focus:outline-hidden",
 					className,
@@ -155,6 +157,7 @@ const Item = forwardRef<ComponentRef<typeof Primitive.ComboboxItem>, ComboboxIte
 		return (
 			<ComboboxItemValueContext.Provider value={value}>
 				<Primitive.ComboboxItem
+					data-slot="combobox-item"
 					className={cx(
 						"cursor-pointer rounded-md px-2 py-1.5 text-strong text-sm flex min-w-0 gap-2 items-center [&>svg]:size-5 [&_svg]:shrink-0",
 						"data-active-item:bg-active-menu-item",
@@ -202,6 +205,7 @@ const Group = forwardRef<ComponentRef<typeof Primitive.ComboboxGroup>, ComboboxG
 	({ asChild = false, children, className, ...props }, ref) => {
 		return (
 			<Primitive.ComboboxGroup
+				data-slot="combobox-group"
 				className={cx("space-y-px", className)}
 				ref={ref}
 				render={
@@ -243,6 +247,7 @@ const GroupLabel = forwardRef<
 >(({ asChild = false, children, className, ...props }, ref) => {
 	return (
 		<Primitive.ComboboxGroupLabel
+			data-slot="combobox-group-label"
 			className={cx("text-muted px-2 py-1 text-xs font-medium", className)}
 			ref={ref}
 			render={asChild ? ({ ref, ...childProps }) => <Slot ref={ref} {...childProps} /> : undefined}
@@ -290,6 +295,7 @@ const ItemValue = forwardRef<
 >(({ asChild = false, className, ...props }, ref) => {
 	return (
 		<Primitive.ComboboxItemValue
+			data-slot="combobox-item-value"
 			className={cx(
 				"*:data-user-value:font-medium flex-1 shrink-0 text-strong font-normal",
 				className,
@@ -324,7 +330,12 @@ const ComboboxSeparatorComponent = forwardRef<
 	ComponentRef<typeof Separator>,
 	ComponentPropsWithoutRef<typeof Separator>
 >(({ className, ...props }, ref) => (
-	<Separator ref={ref} className={cx("-mx-1.25 my-1 w-auto", className)} {...props} />
+	<Separator
+		ref={ref}
+		data-slot="combobox-separator"
+		className={cx("-mx-1.25 my-1 w-auto", className)}
+		{...props}
+	/>
 ));
 ComboboxSeparatorComponent.displayName = "ComboboxSeparator";
 

--- a/packages/mantle/src/components/command/meta-key.tsx
+++ b/packages/mantle/src/components/command/meta-key.tsx
@@ -25,6 +25,7 @@ function MetaKey({ className, ...props }: Props) {
 		<Kbd
 			{...props}
 			suppressHydrationWarning
+			data-slot="meta-key"
 			className={cx(glyph === "⌃" && "font-medium", className)}
 		>
 			<span className="sr-only">{label}</span>

--- a/packages/mantle/src/components/data-table/data-table.tsx
+++ b/packages/mantle/src/components/data-table/data-table.tsx
@@ -7,9 +7,12 @@ import {
 } from "@tanstack/react-table";
 import {
 	type ComponentProps,
+	type ComponentPropsWithoutRef,
+	type ComponentRef,
 	Fragment,
 	type ReactNode,
 	createContext,
+	forwardRef,
 	useContext,
 	useMemo,
 } from "react";
@@ -220,9 +223,11 @@ function Header({ children, className, ...props }: DataTableHeaderProps) {
 	);
 }
 
-const Body = ({ ...props }: ComponentProps<typeof Table.Body>) => (
-	<Table.Body data-slot="data-table-body" {...props} />
-);
+const Body = forwardRef<
+	ComponentRef<typeof Table.Body>,
+	ComponentPropsWithoutRef<typeof Table.Body>
+>((props, ref) => <Table.Body ref={ref} data-slot="data-table-body" {...props} />);
+Body.displayName = "DataTableBody";
 
 type DataTableHeadProps = Omit<ComponentProps<typeof Table.Head>, "children">;
 

--- a/packages/mantle/src/components/data-table/data-table.tsx
+++ b/packages/mantle/src/components/data-table/data-table.tsx
@@ -66,7 +66,7 @@ function Root<TData>({ children, table, ...props }: DataTableProps<TData>) {
 
 	return (
 		<DataTableContext.Provider value={context}>
-			<Table.Root {...props}>
+			<Table.Root data-slot="data-table" {...props}>
 				<Table.Element>{children}</Table.Element>
 			</Table.Root>
 		</DataTableContext.Provider>
@@ -152,6 +152,7 @@ function HeaderSortButton<TData, TValue>({
 	return (
 		<Button
 			appearance="ghost"
+			data-slot="data-table-header-sort-button"
 			className={cx(
 				"flex justify-start w-full h-full rounded-none not-disabled:active:scale-none text-muted",
 				className,
@@ -209,13 +210,19 @@ type DataTableHeaderProps = ComponentProps<typeof Table.Header>;
  */
 function Header({ children, className, ...props }: DataTableHeaderProps) {
 	return (
-		<Table.Header className={cx("has-data-table-header-action:px-0", className)} {...props}>
+		<Table.Header
+			data-slot="data-table-header"
+			className={cx("has-data-table-header-action:px-0", className)}
+			{...props}
+		>
 			{children}
 		</Table.Header>
 	);
 }
 
-const Body = Table.Body;
+const Body = ({ ...props }: ComponentProps<typeof Table.Body>) => (
+	<Table.Body data-slot="data-table-body" {...props} />
+);
 
 type DataTableHeadProps = Omit<ComponentProps<typeof Table.Head>, "children">;
 
@@ -223,7 +230,7 @@ function Head<TData>(props: DataTableHeadProps) {
 	const { table } = useDataTableContext<TData>();
 
 	return (
-		<Table.Head {...props}>
+		<Table.Head data-slot="data-table-head" {...props}>
 			{table.getHeaderGroups().map((headerGroup) => (
 				<Table.Row key={headerGroup.id}>
 					{headerGroup.headers.map((header) => (
@@ -247,7 +254,7 @@ type DataTableRowProps<TData> = Omit<ComponentProps<typeof Table.Row>, "children
 
 function Row<TData>({ row, ...props }: DataTableRowProps<TData>) {
 	return (
-		<Table.Row {...props}>
+		<Table.Row data-slot="data-table-row" {...props}>
 			{row.getVisibleCells().map((cell) => (
 				<Fragment key={cell.id}>
 					{flexRender(cell.column.columnDef.cell, cell.getContext())}
@@ -264,7 +271,7 @@ function EmptyRow<TData>({ children, ...props }: DataTableEmptyRowProps) {
 	const numberOfColumns = table.getAllColumns().length;
 
 	return (
-		<Table.Row {...props}>
+		<Table.Row data-slot="data-table-empty-row" {...props}>
 			<Table.Cell colSpan={numberOfColumns}>{children}</Table.Cell>
 		</Table.Row>
 	);
@@ -308,6 +315,7 @@ function ActionCell({ children, className, ...props }: DataTableActionCellProps)
 			// Marks this cell as a sticky right-edge column so Table.Root can suppress
 			// its container-level right-side scroll fade (keeping this cell opaque).
 			data-mantle-table-sticky-right
+			data-slot="data-table-action-cell"
 			className={cx(
 				// `bg-inherit` keeps the sticky cell opaque with the row's current bg
 				// (including hover state) so scrolling cells don't show through.
@@ -352,6 +360,7 @@ function ActionHeader({ children, className, ...props }: DataTableActionHeaderPr
 			// Only mark as sticky-right when body rows exist so the empty state
 			// doesn't suppress the container's right-side scroll fade.
 			{...(hasRows ? { "data-mantle-table-sticky-right": true } : {})}
+			data-slot="data-table-action-header"
 			className={cx(
 				// `bg-inherit` keeps the sticky header opaque with the thead's current bg.
 				hasRows && "sticky z-10 right-0 bg-inherit",

--- a/packages/mantle/src/components/description-list/description-list.tsx
+++ b/packages/mantle/src/components/description-list/description-list.tsx
@@ -31,6 +31,7 @@ const Root = forwardRef<ComponentRef<"dl">, DescriptionListProps>(
 		return (
 			<Component
 				ref={ref}
+				data-slot="description-list"
 				className={cx(
 					"relative scrollbar overflow-x-auto overscroll-x-none rounded-lg border border-card grid grid-cols-[auto_1fr] gap-x-4 [&>*:nth-child(odd)]:bg-neutral-500/5 p-1",
 					className,
@@ -68,6 +69,7 @@ const Item = forwardRef<ComponentRef<"div">, DescriptionListItemProps>(
 		return (
 			<Component
 				ref={ref}
+				data-slot="description-list-item"
 				className={cx("rounded-sm col-span-full grid grid-cols-subgrid items-center", className)}
 				{...rest}
 			>
@@ -97,6 +99,7 @@ const Label = forwardRef<ComponentRef<"dt">, DescriptionListLabelProps>(
 		return (
 			<Component
 				ref={ref}
+				data-slot="description-list-label"
 				className={cx("text-muted text-sm font-sans font-medium min-w-36 p-2", className)}
 				{...rest}
 			>
@@ -130,6 +133,7 @@ const Value = forwardRef<ComponentRef<"dd">, DescriptionListValueProps>(
 		return (
 			<Component
 				ref={ref}
+				data-slot="description-list-value"
 				className={cx("text-body font-mono text-mono py-2 px-3", className)}
 				{...rest}
 			>

--- a/packages/mantle/src/components/dialog/dialog.tsx
+++ b/packages/mantle/src/components/dialog/dialog.tsx
@@ -69,13 +69,19 @@ Root.displayName = "Dialog";
  * </Dialog.Root>
  * ```
  */
-const Trigger = DialogPrimitive.Trigger;
+const Trigger = forwardRef<
+	ComponentRef<typeof DialogPrimitive.Trigger>,
+	ComponentPropsWithoutRef<typeof DialogPrimitive.Trigger>
+>((props, ref) => <DialogPrimitive.Trigger ref={ref} data-slot="dialog-trigger" {...props} />);
 Trigger.displayName = "DialogTrigger";
 
 const Portal = DialogPrimitive.Portal;
 Portal.displayName = "DialogPortal";
 
-const Close = DialogPrimitive.Close;
+const Close = forwardRef<
+	ComponentRef<typeof DialogPrimitive.Close>,
+	ComponentPropsWithoutRef<typeof DialogPrimitive.Close>
+>((props, ref) => <DialogPrimitive.Close ref={ref} data-slot="dialog-close" {...props} />);
 Close.displayName = "DialogClose";
 
 const Overlay = forwardRef<
@@ -84,6 +90,7 @@ const Overlay = forwardRef<
 >(({ className, ...props }, ref) => (
 	<DialogPrimitive.Overlay
 		ref={ref}
+		data-slot="dialog-overlay"
 		className={cx(
 			"bg-overlay data-state-closed:animate-out data-state-closed:fade-out-0 data-state-open:animate-in data-state-open:fade-in-0 fixed inset-0 z-50 backdrop-blur-xs",
 			className,
@@ -143,6 +150,7 @@ const Content = forwardRef<ComponentRef<"div">, ContentProps>(
 			<div className="fixed inset-4 z-50 flex items-center justify-center">
 				<DialogPrimitive.Content
 					data-mantle-modal-content
+					data-slot="dialog-content"
 					className={cx(
 						"flex max-h-full w-full flex-1 flex-col",
 						"outline-hidden focus-within:outline-hidden",
@@ -194,6 +202,7 @@ Content.displayName = "DialogContent";
  */
 const Header = ({ className, children, ...props }: ComponentProps<"div">) => (
 	<div
+		data-slot="dialog-header"
 		className={cx(
 			"border-dialog-muted text-strong relative flex shrink-0 items-center justify-between gap-2 border-b px-6 py-4",
 			"has-[.icon-button]:pr-4", // when there are actions in the header, shorten the padding
@@ -248,6 +257,7 @@ const CloseIconButton = ({
 	<DialogPrimitive.Close asChild>
 		<IconButton
 			appearance={appearance}
+			data-slot="dialog-close-icon-button"
 			icon={<XIcon />}
 			label={label}
 			size={size}
@@ -289,7 +299,11 @@ CloseIconButton.displayName = "DialogCloseIconButton";
  * ```
  */
 const Body = ({ className, ...props }: ComponentProps<"div">) => (
-	<div className={cx("scrollbar text-body flex-1 overflow-y-auto p-6", className)} {...props} />
+	<div
+		data-slot="dialog-body"
+		className={cx("scrollbar text-body flex-1 overflow-y-auto p-6", className)}
+		{...props}
+	/>
 );
 Body.displayName = "DialogBody";
 
@@ -325,6 +339,7 @@ Body.displayName = "DialogBody";
  */
 const Footer = ({ className, ...props }: ComponentProps<"div">) => (
 	<div
+		data-slot="dialog-footer"
 		className={cx(
 			"border-dialog-muted flex shrink-0 flex-row-reverse gap-2 border-t px-6 py-4",
 			className,
@@ -370,6 +385,7 @@ const Title = forwardRef<
 >(({ className, ...props }, ref) => (
 	<DialogPrimitive.Title
 		ref={ref}
+		data-slot="dialog-title"
 		className={cx("text-strong truncate text-lg font-medium", className)}
 		{...props}
 	/>
@@ -412,7 +428,12 @@ const Description = forwardRef<
 	ComponentRef<typeof DialogPrimitive.Description>,
 	ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
 >(({ className, ...props }, ref) => (
-	<DialogPrimitive.Description ref={ref} className={cx("text-muted", className)} {...props} />
+	<DialogPrimitive.Description
+		ref={ref}
+		data-slot="dialog-description"
+		className={cx("text-muted", className)}
+		{...props}
+	/>
 ));
 Description.displayName = "DialogDescription";
 

--- a/packages/mantle/src/components/dropdown-menu/dropdown-menu.tsx
+++ b/packages/mantle/src/components/dropdown-menu/dropdown-menu.tsx
@@ -50,14 +50,24 @@ Root.displayName = "DropdownMenu";
  * </DropdownMenu.Root>
  * ```
  */
-const Trigger = DropdownMenuPrimitive.Trigger;
+const Trigger = forwardRef<
+	ComponentRef<typeof DropdownMenuPrimitive.Trigger>,
+	ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Trigger>
+>((props, ref) => (
+	<DropdownMenuPrimitive.Trigger ref={ref} data-slot="dropdown-menu-trigger" {...props} />
+));
 Trigger.displayName = "DropdownMenuTrigger";
 
 const Group = forwardRef<
 	ComponentRef<typeof DropdownMenuPrimitive.Group>,
 	ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Group>
 >(({ className, ...props }, ref) => (
-	<DropdownMenuPrimitive.Group ref={ref} className={cx("space-y-px", className)} {...props} />
+	<DropdownMenuPrimitive.Group
+		ref={ref}
+		data-slot="dropdown-menu-group"
+		className={cx("space-y-px", className)}
+		{...props}
+	/>
 ));
 Group.displayName = "DropdownMenuGroup";
 
@@ -74,7 +84,12 @@ const RadioGroup = forwardRef<
 	ComponentRef<typeof DropdownMenuPrimitive.RadioGroup>,
 	ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.RadioGroup>
 >(({ className, ...props }, ref) => (
-	<DropdownMenuPrimitive.RadioGroup ref={ref} className={cx("space-y-px", className)} {...props} />
+	<DropdownMenuPrimitive.RadioGroup
+		ref={ref}
+		data-slot="dropdown-menu-radio-group"
+		className={cx("space-y-px", className)}
+		{...props}
+	/>
 ));
 RadioGroup.displayName = "DropdownMenuRadioGroup";
 
@@ -90,6 +105,7 @@ const SubTrigger = forwardRef<
 	}
 >(({ className, inset, children, ...props }, ref) => (
 	<DropdownMenuPrimitive.SubTrigger
+		data-slot="dropdown-menu-sub-trigger"
 		className={cx(
 			"focus:bg-accent data-state-open:bg-accent relative flex select-none items-center rounded-md py-1.5 pl-2 pr-9 text-sm outline-hidden",
 			"data-highlighted:bg-active-menu-item data-state-open:bg-active-menu-item",
@@ -119,6 +135,7 @@ const SubContent = forwardRef<
 >(({ className, loop = true, ...props }, ref) => (
 	<Portal>
 		<DropdownMenuPrimitive.SubContent
+			data-slot="dropdown-menu-sub-content"
 			className={cx(
 				"scrollbar",
 				"text-popover-foreground border-popover bg-popover p-1.25 data-state-closed:animate-out data-state-closed:fade-out-0 data-state-closed:zoom-out-95 data-state-open:animate-in data-state-open:fade-in-0 data-state-open:zoom-in-95 data-side-bottom:slide-in-from-top-2 data-side-left:slide-in-from-right-2 data-side-right:slide-in-from-left-2 data-side-top:slide-in-from-bottom-2 z-50 min-w-32 overflow-hidden rounded-md border shadow-xl space-y-px font-sans",
@@ -167,6 +184,7 @@ const Content = forwardRef<
 	<Portal>
 		<DropdownMenuPrimitive.Content
 			ref={ref}
+			data-slot="dropdown-menu-content"
 			className={cx(
 				"scrollbar",
 				"text-popover-foreground border-popover bg-popover p-1.25 z-50 min-w-32 overflow-hidden rounded-md border shadow-xl outline-hidden space-y-px font-sans",
@@ -218,6 +236,7 @@ const Item = forwardRef<
 >(({ className, inset, ...props }, ref) => (
 	<DropdownMenuPrimitive.Item
 		ref={ref}
+		data-slot="dropdown-menu-item"
 		className={cx(
 			"relative flex cursor-pointer select-none items-center rounded-md px-2 py-1.5 text-strong text-sm font-normal outline-hidden transition-colors",
 			"data-highlighted:bg-active-menu-item",
@@ -243,6 +262,7 @@ const CheckboxItem = forwardRef<
 >(({ className, children, checked, ...props }, ref) => (
 	<DropdownMenuPrimitive.CheckboxItem
 		ref={ref}
+		data-slot="dropdown-menu-checkbox-item"
 		className={cx(
 			"text-strong data-disabled:pointer-events-none data-disabled:opacity-50 relative flex cursor-pointer select-none items-center gap-2 rounded-md py-1.5 pl-2 pr-9 text-sm font-normal outline-hidden",
 			"data-highlighted:bg-active-menu-item",
@@ -280,6 +300,7 @@ type DropdownMenuRadioItemProps = ComponentPropsWithoutRef<
 const RadioItem = forwardRef<ComponentRef<"input">, DropdownMenuRadioItemProps>(
 	({ className, children, ...props }, ref) => (
 		<DropdownMenuPrimitive.RadioItem
+			data-slot="dropdown-menu-radio-item"
 			className={cx(
 				"group/dropdown-menu-radio-item",
 				"text-strong data-disabled:pointer-events-none data-disabled:opacity-50 relative flex cursor-pointer select-none items-center gap-2 rounded-md py-1.5 px-2 text-sm font-normal outline-none",
@@ -316,6 +337,7 @@ const Label = forwardRef<
 >(({ className, inset, ...props }, ref) => (
 	<DropdownMenuPrimitive.Label
 		ref={ref}
+		data-slot="dropdown-menu-label"
 		className={cx("px-2 py-1.5 text-sm font-medium", inset && "pl-8", className)}
 		{...props}
 	/>
@@ -331,13 +353,22 @@ const DropdownSeparator = forwardRef<
 	ComponentRef<typeof Separator>,
 	ComponentPropsWithoutRef<typeof Separator>
 >(({ className, ...props }, ref) => (
-	<Separator ref={ref} className={cx("-mx-1.25 my-1 w-auto", className)} {...props} />
+	<Separator
+		ref={ref}
+		data-slot="dropdown-menu-separator"
+		className={cx("-mx-1.25 my-1 w-auto", className)}
+		{...props}
+	/>
 ));
 DropdownSeparator.displayName = "DropdownMenuSeparator";
 
 const Shortcut = ({ className, ...props }: ComponentProps<"span">) => {
 	return (
-		<span className={cx("ml-auto text-xs tracking-widest opacity-60", className)} {...props} />
+		<span
+			data-slot="dropdown-menu-shortcut"
+			className={cx("ml-auto text-xs tracking-widest opacity-60", className)}
+			{...props}
+		/>
 	);
 };
 Shortcut.displayName = "DropdownMenuShortcut";

--- a/packages/mantle/src/components/empty/empty.test.tsx
+++ b/packages/mantle/src/components/empty/empty.test.tsx
@@ -111,6 +111,49 @@ describe("Empty", () => {
 		expect(actions.tagName).toBe("DIV");
 	});
 
+	test("Root renders as child element when asChild is true", () => {
+		render(
+			<Empty.Root asChild>
+				<section data-testid="root">content</section>
+			</Empty.Root>,
+		);
+		const root = screen.getByTestId("root");
+		expect(root.tagName).toBe("SECTION");
+		expect(root).toHaveAttribute("data-slot", "empty");
+		expect(root).toHaveTextContent("content");
+	});
+
+	test("Root forwards data-slot on the default element", () => {
+		render(<Empty.Root data-testid="root">content</Empty.Root>);
+		expect(screen.getByTestId("root")).toHaveAttribute("data-slot", "empty");
+	});
+
+	test("Actions renders as child element when asChild is true", () => {
+		render(
+			<Empty.Root>
+				<Empty.Actions asChild>
+					<nav data-testid="actions">
+						<button type="button">Click</button>
+					</nav>
+				</Empty.Actions>
+			</Empty.Root>,
+		);
+		const actions = screen.getByTestId("actions");
+		expect(actions.tagName).toBe("NAV");
+		expect(actions).toHaveAttribute("data-slot", "empty-actions");
+	});
+
+	test("Actions forwards data-slot on the default element", () => {
+		render(
+			<Empty.Root>
+				<Empty.Actions data-testid="actions">
+					<button type="button">Click</button>
+				</Empty.Actions>
+			</Empty.Root>,
+		);
+		expect(screen.getByTestId("actions")).toHaveAttribute("data-slot", "empty-actions");
+	});
+
 	test("Actions merges custom className", () => {
 		render(
 			<Empty.Root>

--- a/packages/mantle/src/components/empty/empty.tsx
+++ b/packages/mantle/src/components/empty/empty.tsx
@@ -23,14 +23,17 @@ import { Slot } from "../slot/index.js";
  * </Empty.Root>
  * ```
  */
-const Root = ({ children, className, ...props }: ComponentProps<"div">) => {
+const Root = ({ asChild, children, className, ...props }: ComponentProps<"div"> & WithAsChild) => {
+	const Comp = asChild ? Slot : "div";
+
 	return (
-		<div
+		<Comp
+			data-slot="empty"
 			className={cx("mx-auto flex max-w-lg flex-col items-center py-14 text-center", className)}
 			{...props}
 		>
 			{children}
-		</div>
+		</Comp>
 	);
 };
 Root.displayName = "Empty";
@@ -61,7 +64,14 @@ type EmptyIconProps = Omit<SvgAttributes, "children"> & {
  * ```
  */
 const Icon = ({ className, svg, ...props }: EmptyIconProps) => {
-	return <SvgOnly className={cx("mb-2 size-16 text-muted", className)} svg={svg} {...props} />;
+	return (
+		<SvgOnly
+			data-slot="empty-icon"
+			className={cx("mb-2 size-16 text-muted", className)}
+			svg={svg}
+			{...props}
+		/>
+	);
 };
 Icon.displayName = "EmptyIcon";
 
@@ -96,7 +106,11 @@ const Title = ({
 	const Comp = asChild ? Slot : "h3";
 
 	return (
-		<Comp className={cx("text-strong text-xl font-medium", className)} {...props}>
+		<Comp
+			data-slot="empty-title"
+			className={cx("text-strong text-xl font-medium", className)}
+			{...props}
+		>
 			{children}
 		</Comp>
 	);
@@ -136,7 +150,11 @@ const Description = ({
 	const Comp = asChild ? Slot : "div";
 
 	return (
-		<Comp className={cx("text-body mt-1 space-y-4 text-sm", className)} {...props}>
+		<Comp
+			data-slot="empty-description"
+			className={cx("text-body mt-1 space-y-4 text-sm", className)}
+			{...props}
+		>
 			{children}
 		</Comp>
 	);
@@ -161,11 +179,22 @@ Description.displayName = "EmptyDescription";
  * </Empty.Root>
  * ```
  */
-const Actions = ({ children, className, ...props }: ComponentProps<"div">) => {
+const Actions = ({
+	asChild,
+	children,
+	className,
+	...props
+}: ComponentProps<"div"> & WithAsChild) => {
+	const Comp = asChild ? Slot : "div";
+
 	return (
-		<div className={cx("mt-4 flex items-center gap-2", className)} {...props}>
+		<Comp
+			data-slot="empty-actions"
+			className={cx("mt-4 flex items-center gap-2", className)}
+			{...props}
+		>
 			{children}
-		</div>
+		</Comp>
 	);
 };
 Actions.displayName = "EmptyActions";

--- a/packages/mantle/src/components/flag/flag.tsx
+++ b/packages/mantle/src/components/flag/flag.tsx
@@ -74,6 +74,7 @@ function Flag({
 
 	return (
 		<div
+			data-slot="flag"
 			className={cx("flag relative overflow-hidden", borderRadius, sizing, className)}
 			{...props}
 		>

--- a/packages/mantle/src/components/hover-card/hover-card.tsx
+++ b/packages/mantle/src/components/hover-card/hover-card.tsx
@@ -2,7 +2,7 @@
 
 import * as HoverCardPrimitive from "@radix-ui/react-hover-card";
 import { forwardRef } from "react";
-import type { ComponentPropsWithoutRef, ComponentRef } from "react";
+import type { ComponentProps, ComponentPropsWithoutRef, ComponentRef } from "react";
 import { cx } from "../../utils/cx/cx.js";
 
 /**
@@ -30,7 +30,12 @@ const Root = ({
 	openDelay = 100,
 	...props
 }: ComponentPropsWithoutRef<typeof HoverCardPrimitive.Root>) => (
-	<HoverCardPrimitive.Root closeDelay={closeDelay} openDelay={openDelay} {...props} />
+	<HoverCardPrimitive.Root
+		data-slot="hover-card"
+		closeDelay={closeDelay}
+		openDelay={openDelay}
+		{...props}
+	/>
 );
 Root.displayName = "HoverCard";
 
@@ -53,7 +58,9 @@ Root.displayName = "HoverCard";
  * </HoverCard.Root>
  * ```
  */
-const Trigger = HoverCardPrimitive.Trigger;
+const Trigger = (props: ComponentProps<typeof HoverCardPrimitive.Trigger>) => (
+	<HoverCardPrimitive.Trigger data-slot="hover-card-trigger" {...props} />
+);
 Trigger.displayName = "HoverCardTrigger";
 
 /**
@@ -91,6 +98,7 @@ const Content = forwardRef<
 	<Portal>
 		<HoverCardPrimitive.Content
 			ref={ref}
+			data-slot="hover-card-content"
 			align={align}
 			sideOffset={sideOffset}
 			className={cx(

--- a/packages/mantle/src/components/hover-card/hover-card.tsx
+++ b/packages/mantle/src/components/hover-card/hover-card.tsx
@@ -2,7 +2,7 @@
 
 import * as HoverCardPrimitive from "@radix-ui/react-hover-card";
 import { forwardRef } from "react";
-import type { ComponentProps, ComponentPropsWithoutRef, ComponentRef } from "react";
+import type { ComponentPropsWithoutRef, ComponentRef } from "react";
 import { cx } from "../../utils/cx/cx.js";
 
 /**
@@ -30,12 +30,7 @@ const Root = ({
 	openDelay = 100,
 	...props
 }: ComponentPropsWithoutRef<typeof HoverCardPrimitive.Root>) => (
-	<HoverCardPrimitive.Root
-		data-slot="hover-card"
-		closeDelay={closeDelay}
-		openDelay={openDelay}
-		{...props}
-	/>
+	<HoverCardPrimitive.Root closeDelay={closeDelay} openDelay={openDelay} {...props} />
 );
 Root.displayName = "HoverCard";
 
@@ -58,9 +53,12 @@ Root.displayName = "HoverCard";
  * </HoverCard.Root>
  * ```
  */
-const Trigger = (props: ComponentProps<typeof HoverCardPrimitive.Trigger>) => (
-	<HoverCardPrimitive.Trigger data-slot="hover-card-trigger" {...props} />
-);
+const Trigger = forwardRef<
+	ComponentRef<typeof HoverCardPrimitive.Trigger>,
+	ComponentPropsWithoutRef<typeof HoverCardPrimitive.Trigger>
+>((props, ref) => (
+	<HoverCardPrimitive.Trigger ref={ref} data-slot="hover-card-trigger" {...props} />
+));
 Trigger.displayName = "HoverCardTrigger";
 
 /**

--- a/packages/mantle/src/components/icon/icon.tsx
+++ b/packages/mantle/src/components/icon/icon.tsx
@@ -24,7 +24,14 @@ type IconProps = Omit<SvgAttributes, "children"> & {
  */
 const Icon = forwardRef<ComponentRef<"svg">, IconProps>(
 	({ className, style, svg, ...props }, ref) => (
-		<SvgOnly ref={ref} className={cx("size-5", className)} style={style} svg={svg} {...props} />
+		<SvgOnly
+			ref={ref}
+			data-slot="icon"
+			className={cx("size-5", className)}
+			style={style}
+			svg={svg}
+			{...props}
+		/>
 	),
 );
 Icon.displayName = "Icon";

--- a/packages/mantle/src/components/icon/svg-only.tsx
+++ b/packages/mantle/src/components/icon/svg-only.tsx
@@ -32,6 +32,7 @@ const SvgOnly = forwardRef<ComponentRef<"svg">, SvgOnlyProps>(
 		);
 
 		return cloneElement(svg, {
+			"data-slot": "svg-only",
 			...props,
 			className: cx(
 				"shrink-0", // the SvgOnly base classes

--- a/packages/mantle/src/components/icon/types.ts
+++ b/packages/mantle/src/components/icon/types.ts
@@ -1,5 +1,26 @@
 import type { ComponentProps } from "react";
 
+/**
+ * Props accepted by SVG-rendering primitives in mantle (`Icon`, `SvgOnly`, and
+ * icon-bearing parts of other components). Extends the standard React `<svg>`
+ * props with:
+ *
+ * - `focusable` narrowed to the string literals `"true"` / `"false"`, matching
+ *   the SVG spec (React's default typing allows `boolean`, which serializes
+ *   inconsistently across browsers for this attribute).
+ * - `data-slot`, so these primitives can carry mantle's standard
+ *   `data-slot="<name>"` styling hook alongside other consumer-supplied props.
+ */
 export type SvgAttributes = ComponentProps<"svg"> & {
+	/**
+	 * Whether the SVG can receive keyboard focus. Use the string form
+	 * (`"true"` / `"false"`) — the SVG attribute is serialized as a string and
+	 * React's boolean form can produce inconsistent output.
+	 */
 	focusable?: "true" | "false";
+	/**
+	 * Stable styling hook used by mantle to identify this element in the DOM
+	 * (e.g. `data-slot="icon"`). Consumers can override it via props spread.
+	 */
+	"data-slot"?: string;
 };

--- a/packages/mantle/src/components/input/input.tsx
+++ b/packages/mantle/src/components/input/input.tsx
@@ -113,6 +113,7 @@ const InputCapture = forwardRef<HTMLInputElement, InputCaptureProps>(
 		return (
 			<input
 				aria-invalid={ariaInvalid}
+				data-slot="input-capture"
 				data-validation={validationValue}
 				className={cx(
 					"placeholder:text-placeholder min-w-0 flex-1 bg-transparent text-left autofill:shadow-[inset_0_0_0px_1000px_var(--color-blue-50)] focus:outline-hidden",
@@ -161,6 +162,7 @@ type InputContainerProps = InputHTMLAttributes<HTMLInputElement> &
 const InputContainer = ({
 	"aria-invalid": _ariaInvalid,
 	"aria-disabled": _ariaDisabled,
+	"data-slot": dataSlot = "input",
 	children,
 	className,
 	disabled,
@@ -170,7 +172,7 @@ const InputContainer = ({
 	type,
 	validation: _validation,
 	...props
-}: InputContainerProps) => {
+}: InputContainerProps & { "data-slot"?: string }) => {
 	const isInvalid = _ariaInvalid != null && _ariaInvalid !== "false";
 	const validation = isInvalid
 		? "error"
@@ -192,6 +194,7 @@ const InputContainer = ({
 		>
 			<div
 				role="none"
+				data-slot={dataSlot}
 				data-disabled={(disabled ?? _ariaDisabled) || undefined}
 				data-validation={validation || undefined}
 				className={cx(

--- a/packages/mantle/src/components/input/password-input.tsx
+++ b/packages/mantle/src/components/input/password-input.tsx
@@ -54,7 +54,7 @@ const PasswordInput = forwardRef<HTMLInputElement, PasswordInputProps>(
 		}, [showValue]);
 
 		return (
-			<Input type={type} ref={ref} {...props}>
+			<Input data-slot="password-input" type={type} ref={ref} {...props}>
 				<InputCapture />
 				<button
 					type="button"

--- a/packages/mantle/src/components/kbd/kbd.tsx
+++ b/packages/mantle/src/components/kbd/kbd.tsx
@@ -17,6 +17,7 @@ import { cx } from "../../utils/cx/cx.js";
 function Kbd({ children, className, ...props }: ComponentProps<"kbd">) {
 	return (
 		<kbd
+			data-slot="kbd"
 			className={cx(
 				"[font-kerning:normal] [font-variant-ligatures:common-ligatures_contextual]",
 				"appearance-none tabular-nums inline-grid place-items-center size-5 bg-neutral-500/15 px-1 rounded text-mono leading-none font-mono",

--- a/packages/mantle/src/components/label/label.tsx
+++ b/packages/mantle/src/components/label/label.tsx
@@ -37,6 +37,7 @@ const Label = forwardRef<ComponentRef<"label">, LabelProps>(
 		// biome-ignore lint/a11y/noLabelWithoutControl: this is a composable label component
 		<label
 			aria-disabled={disabled ?? _ariaDisabled}
+			data-slot="label"
 			className={cx(
 				"text-strong cursor-pointer text-sm peer-disabled:cursor-default has-disabled:cursor-default aria-disabled:cursor-default font-sans",
 				className,

--- a/packages/mantle/src/components/main/main.tsx
+++ b/packages/mantle/src/components/main/main.tsx
@@ -22,7 +22,13 @@ import { cx } from "../../utils/cx/cx.js";
  */
 const Main = ({ className, ...props }: ComponentProps<"main">) => {
 	return (
-		<main {...props} id="main" tabIndex={-1} className={cx("focus:outline-hidden", className)} />
+		<main
+			{...props}
+			data-slot="main"
+			id="main"
+			tabIndex={-1}
+			className={cx("focus:outline-hidden", className)}
+		/>
 	);
 };
 Main.displayName = "Main";

--- a/packages/mantle/src/components/media-object/media-object.tsx
+++ b/packages/mantle/src/components/media-object/media-object.tsx
@@ -16,7 +16,12 @@ const Root = forwardRef<HTMLDivElement, Props>(
 		const Component = asChild ? Slot : "div";
 
 		return (
-			<Component ref={ref} className={cx("flex gap-4", className)} style={style}>
+			<Component
+				ref={ref}
+				data-slot="media-object"
+				className={cx("flex gap-4", className)}
+				style={style}
+			>
 				{children}
 			</Component>
 		);
@@ -32,7 +37,12 @@ const Media = forwardRef<HTMLDivElement, Props>(
 		const Component = asChild ? Slot : "div";
 
 		return (
-			<Component ref={ref} className={cx("shrink-0 leading-none", className)} style={style}>
+			<Component
+				ref={ref}
+				data-slot="media-object-media"
+				className={cx("shrink-0 leading-none", className)}
+				style={style}
+			>
 				{children}
 			</Component>
 		);
@@ -48,7 +58,12 @@ const Content = forwardRef<HTMLDivElement, Props>(
 		const Component = asChild ? Slot : "div";
 
 		return (
-			<Component ref={ref} className={cx("min-w-0 flex-1", className)} style={style}>
+			<Component
+				ref={ref}
+				data-slot="media-object-content"
+				className={cx("min-w-0 flex-1", className)}
+				style={style}
+			>
 				{children}
 			</Component>
 		);

--- a/packages/mantle/src/components/pagination/cursor-pagination.tsx
+++ b/packages/mantle/src/components/pagination/cursor-pagination.tsx
@@ -73,6 +73,7 @@ const Root = forwardRef<HTMLDivElement, CursorPaginationProps>(
 		return (
 			<CursorPaginationContext.Provider value={{ defaultPageSize, pageSize, setPageSize }}>
 				<div
+					data-slot="cursor-pagination"
 					className={cx("inline-flex items-center justify-between gap-2", className)}
 					ref={ref}
 					{...props}
@@ -124,8 +125,9 @@ const Buttons = forwardRef<ComponentRef<typeof ButtonGroup>, CursorButtonsProps>
 		// TODO(cody): this _feels_ like a good spot for left and right arrow keys to navigate between pages when focused on the buttons
 
 		return (
-			<ButtonGroup appearance="panel" ref={ref} {...props}>
+			<ButtonGroup data-slot="cursor-pagination-buttons" appearance="panel" ref={ref} {...props}>
 				<IconButton
+					data-slot="cursor-pagination-previous"
 					appearance="ghost"
 					disabled={!hasPreviousPage}
 					icon={<CaretLeftIcon />}
@@ -134,8 +136,13 @@ const Buttons = forwardRef<ComponentRef<typeof ButtonGroup>, CursorButtonsProps>
 					size="sm"
 					type="button"
 				/>
-				<Separator orientation="vertical" className="min-h-5" />
+				<Separator
+					data-slot="cursor-pagination-separator"
+					orientation="vertical"
+					className="min-h-5"
+				/>
 				<IconButton
+					data-slot="cursor-pagination-next"
 					appearance="ghost"
 					disabled={!hasNextPage}
 					icon={<CaretRightIcon />}
@@ -206,6 +213,7 @@ const PageSizeSelect = forwardRef<ComponentRef<typeof Select.Trigger>, CursorPag
 			>
 				<Select.Trigger
 					ref={ref}
+					data-slot="cursor-pagination-page-size-select"
 					className={cx("w-auto min-w-36", className)}
 					value={ctx.pageSize}
 					{...rest}
@@ -248,7 +256,11 @@ function PageSizeValue({ asChild = false, className, ...props }: CursorPageSizeV
 	const Component = asChild ? Slot : "span";
 
 	return (
-		<Component className={cx("text-muted text-sm font-normal", className)} {...props}>
+		<Component
+			data-slot="cursor-pagination-page-size-value"
+			className={cx("text-muted text-sm font-normal", className)}
+			{...props}
+		>
 			{ctx.pageSize} per page
 		</Component>
 	);

--- a/packages/mantle/src/components/popover/popover.tsx
+++ b/packages/mantle/src/components/popover/popover.tsx
@@ -145,6 +145,7 @@ const Content = forwardRef<ComponentRef<"div">, PopoverContentProps>(
 		<PopoverPrimitive.Portal>
 			<PopoverPrimitive.Content
 				align={align}
+				data-slot="popover-content"
 				className={cx(
 					"text-popover-foreground border-popover bg-popover data-side-bottom:slide-in-from-top-2 data-side-left:slide-in-from-right-2 data-side-right:slide-in-from-left-2 data-side-top:slide-in-from-bottom-2 data-state-closed:animate-out data-state-closed:fade-out-0 data-state-closed:zoom-out-95 data-state-open:animate-in data-state-open:fade-in-0 data-state-open:zoom-in-95 z-50 rounded-md border p-4 shadow-md outline-hidden",
 					preferredWidth,

--- a/packages/mantle/src/components/progress/progress-bar.tsx
+++ b/packages/mantle/src/components/progress/progress-bar.tsx
@@ -87,7 +87,7 @@ function Root({ className, children, max: _max = defaultMax, value: _value, ...p
 	return (
 		<ProgressContext.Provider value={ctx}>
 			<ProgressPrimitive.Root
-				data-slot="progress"
+				data-slot="progress-bar"
 				className={cx(
 					"bg-base-hover dark:bg-base shadow-inner relative h-3 w-full overflow-hidden rounded-md",
 					className,
@@ -133,7 +133,7 @@ function Indicator({ className, style, ...props }: IndicatorProps) {
 
 	return (
 		<ProgressPrimitive.Indicator
-			data-slot="progress-indicator"
+			data-slot="progress-bar-indicator"
 			className={cx("bg-accent-600 h-full w-full flex-1 transition-all", className)}
 			style={{ ...style, transform: `translateX(-${translatePercent}%)` }}
 			{...props}

--- a/packages/mantle/src/components/progress/progress-donut.tsx
+++ b/packages/mantle/src/components/progress/progress-donut.tsx
@@ -118,6 +118,7 @@ const Root = ({
 		<ProgressContext.Provider value={ctx}>
 			{/* biome-ignore lint/a11y/useFocusableInteractive: progress bars don't need to be focusable */}
 			<svg
+				data-slot="progress-donut"
 				aria-valuemax={max}
 				aria-valuemin={0}
 				aria-valuenow={valueNow}
@@ -191,7 +192,7 @@ const Indicator = ({ className, ...props }: ProgressDonutIndicatorProps) => {
 	const radius = calcRadius(strokeWidthPx);
 
 	return (
-		<g className={cx("text-accent-600", className)} {...props}>
+		<g data-slot="progress-donut-indicator" className={cx("text-accent-600", className)} {...props}>
 			{ctx.value === "indeterminate" && (
 				<defs>
 					<linearGradient id={gradientId}>

--- a/packages/mantle/src/components/radio-group/radio-group.tsx
+++ b/packages/mantle/src/components/radio-group/radio-group.tsx
@@ -44,7 +44,7 @@ type RadioGroupProps = PropsWithChildren<Omit<HeadlessRadioGroupProps, "as" | "c
  * ```
  */
 const Root = forwardRef<ComponentRef<typeof HeadlessRadioGroup>, RadioGroupProps>((props, ref) => (
-	<HeadlessRadioGroup {...props} ref={ref} />
+	<HeadlessRadioGroup data-slot="radio-group" {...props} ref={ref} />
 ));
 Root.displayName = "RadioGroup";
 
@@ -93,6 +93,7 @@ type RadioItemProps = Omit<HeadlessRadioProps, "children"> & PropsWithChildren;
 const Item = forwardRef<ComponentRef<"div">, RadioItemProps>(
 	({ children, className, ...props }, ref) => (
 		<HeadlessRadio
+			data-slot="radio-group-item"
 			className={cx(
 				"group/radio cursor-pointer aria-disabled:cursor-default [&_label]:cursor-inherit flex gap-2 py-1 text-sm focus:outline-hidden",
 				className,
@@ -152,6 +153,7 @@ const Indicator = ({ children, className, ...props }: RadioIndicatorProps) => {
 
 	return (
 		<div
+			data-slot="radio-group-indicator"
 			className={cx(
 				"radio-indicator inline-flex size-5 select-none items-center justify-center shrink-0",
 				className,
@@ -175,7 +177,14 @@ Indicator.displayName = "RadioIndicator";
  */
 const List = forwardRef<ComponentRef<typeof Root>, RadioGroupProps>(
 	({ className, ...props }, ref) => {
-		return <Root className={clsx("-space-y-px", className)} {...props} ref={ref} />;
+		return (
+			<Root
+				data-slot="radio-group-list"
+				className={clsx("-space-y-px", className)}
+				{...props}
+				ref={ref}
+			/>
+		);
 	},
 );
 List.displayName = "RadioGroupList";
@@ -190,6 +199,7 @@ const ListItem = forwardRef<ComponentRef<"div">, RadioListItemProps>(
 		return (
 			<HeadlessRadio
 				as="div"
+				data-slot="radio-group-list-item"
 				className={cx(
 					"group/radio border-form [&_label]:cursor-inherit relative flex select-none gap-2 border px-3 py-2 text-sm",
 					"cursor-pointer aria-disabled:cursor-default focus:outline-hidden",
@@ -226,6 +236,7 @@ const Card = forwardRef<ComponentRef<"div">, RadioCardProps>(
 		return (
 			<HeadlessRadio
 				as="div"
+				data-slot="radio-group-card"
 				className={clsx(
 					"group/radio border-card bg-card [&_label]:cursor-inherit relative rounded-md border p-4 text-sm",
 					"cursor-pointer aria-disabled:cursor-default focus:outline-hidden",
@@ -259,6 +270,7 @@ const ItemContent = ({ asChild = false, children, className, ...props }: RadioIt
 
 	return (
 		<Component
+			data-slot="radio-group-item-content"
 			className={clsx("min-w-0 flex-1", ctx.disabled && "opacity-50", className)}
 			{...props}
 		>
@@ -275,6 +287,7 @@ const ButtonGroup = forwardRef<ComponentRef<typeof Root>, RadioGroupProps>(
 	({ className, ...props }, ref) => {
 		return (
 			<Root
+				data-slot="radio-group-button-group"
 				className={clsx("flex flex-row flex-nowrap -space-x-px", className)}
 				{...props}
 				ref={ref}
@@ -294,6 +307,7 @@ const Button = forwardRef<ComponentRef<"div">, RadioButtonProps>(
 		return (
 			<HeadlessRadio
 				as="div"
+				data-slot="radio-group-button"
 				className={cx(
 					"group/radio border-form [&_label]:cursor-inherit relative flex flex-1 select-none items-center justify-center gap-2 border px-3 text-sm",
 					"h-9",
@@ -337,6 +351,7 @@ const InputSandbox = ({ children, onClick, onKeyDown, ...props }: RadioInputSand
 	return (
 		<div
 			role="none"
+			data-slot="radio-group-input-sandbox"
 			ref={ref}
 			onKeyDown={(event) => {
 				if (ctx.disabled) {

--- a/packages/mantle/src/components/select/select.tsx
+++ b/packages/mantle/src/components/select/select.tsx
@@ -158,7 +158,12 @@ const Group = forwardRef<
 	ComponentRef<typeof SelectPrimitive.Group>,
 	ComponentPropsWithoutRef<typeof SelectPrimitive.Group>
 >(({ className, ...props }, ref) => (
-	<SelectPrimitive.Group ref={ref} className={cx("space-y-px", className)} {...props} />
+	<SelectPrimitive.Group
+		ref={ref}
+		data-slot="select-group"
+		className={cx("space-y-px", className)}
+		{...props}
+	/>
 ));
 Group.displayName = "SelectGroup";
 
@@ -252,6 +257,7 @@ const Trigger = forwardRef<ComponentRef<typeof SelectPrimitive.Trigger>, SelectT
 		return (
 			<SelectPrimitive.Trigger
 				aria-invalid={ariaInvalid}
+				data-slot="select-trigger"
 				className={cx(
 					"h-9 text-sm",
 					"border-form bg-form text-strong font-sans placeholder:text-placeholder hover:bg-form-hover hover:text-strong flex w-full items-center justify-between gap-1.5 rounded-md border px-3 py-2 disabled:pointer-events-none disabled:opacity-50 [&>span]:line-clamp-1 [&>span]:text-left",
@@ -357,6 +363,7 @@ const Content = forwardRef<ComponentRef<typeof SelectPrimitive.Content>, SelectC
 		<SelectPrimitive.Portal>
 			<SelectPrimitive.Content
 				ref={ref}
+				data-slot="select-content"
 				className={cx(
 					"border-popover data-side-bottom:slide-in-from-top-2 data-side-left:slide-in-from-right-2 data-side-right:slide-in-from-left-2 data-side-top:slide-in-from-bottom-2 data-state-closed:animate-out data-state-closed:fade-out-0 data-state-closed:zoom-out-95 data-state-open:animate-in data-state-open:fade-in-0 data-state-open:zoom-in-95 relative z-50 max-h-96 min-w-32 overflow-hidden rounded-md border shadow-md",
 					"bg-popover font-sans",
@@ -418,6 +425,7 @@ const Label = forwardRef<
 >(({ className, ...props }, ref) => (
 	<SelectPrimitive.Label
 		ref={ref}
+		data-slot="select-label"
 		className={cx("px-2 py-1.5 text-sm font-medium", className)}
 		{...props}
 	/>
@@ -462,6 +470,7 @@ const Item = forwardRef<ComponentRef<typeof SelectPrimitive.Item>, SelectItemPro
 	({ className, children, icon, ...props }, ref) => (
 		<SelectPrimitive.Item
 			ref={ref}
+			data-slot="select-item"
 			className={cx(
 				"relative flex gap-2 w-full cursor-pointer select-none items-center rounded-md py-1.5 pl-2 pr-8 text-strong text-sm outline-hidden",
 				"focus:bg-active-menu-item",
@@ -514,7 +523,12 @@ const SelectSeparatorComponent = forwardRef<
 	ComponentRef<typeof Separator>,
 	ComponentPropsWithoutRef<typeof Separator>
 >(({ className, ...props }, ref) => (
-	<Separator ref={ref} className={cx("-mx-1 my-1 h-px w-auto", className)} {...props} />
+	<Separator
+		ref={ref}
+		data-slot="select-separator"
+		className={cx("-mx-1 my-1 h-px w-auto", className)}
+		{...props}
+	/>
 ));
 SelectSeparatorComponent.displayName = "SelectSeparator";
 

--- a/packages/mantle/src/components/separator/separator.tsx
+++ b/packages/mantle/src/components/separator/separator.tsx
@@ -49,6 +49,7 @@ const HorizontalSeparatorGroup = ({
 	return (
 		<SeparatorGroupContext.Provider value={{ orientation: "horizontal" }}>
 			<Comp
+				data-slot="horizontal-separator-group"
 				data-horizontal-separator-group
 				className={cx(
 					"group flex items-center gap-2 [&_*:not([data-separator])]:shrink-0",
@@ -126,6 +127,7 @@ const Separator = forwardRef<ComponentRef<"div">, SeparatorProps>(
 
 		return (
 			<Component
+				data-slot="separator"
 				className={cx(
 					"separator",
 					"dark-high-contrast:bg-black high-contrast:bg-black bg-gray-500/20 dark:bg-gray-600/20",

--- a/packages/mantle/src/components/sheet/sheet.tsx
+++ b/packages/mantle/src/components/sheet/sheet.tsx
@@ -208,6 +208,7 @@ const SheetOverlay = forwardRef<
 	ComponentPropsWithoutRef<typeof SheetPrimitive.Overlay>
 >(({ className, ...props }, ref) => (
 	<SheetPrimitive.Overlay
+		data-slot="sheet-overlay"
 		className={cx(
 			"bg-overlay data-state-closed:animate-out data-state-closed:fade-out-0 data-state-open:animate-in data-state-open:fade-in-0 fixed inset-0 z-40 backdrop-blur-xs",
 			className,
@@ -306,6 +307,7 @@ const Content = forwardRef<ComponentRef<"div">, SheetContentProps>(
 		<SheetPortal>
 			<SheetOverlay />
 			<SheetPrimitive.Content
+				data-slot="sheet-content"
 				data-mantle-modal-content
 				className={cx(SheetVariants({ side }), preferredWidth, className)}
 				ref={ref}
@@ -378,6 +380,7 @@ const CloseIconButton = ({
 }: SheetCloseIconButtonProps) => (
 	<SheetPrimitive.Close asChild>
 		<IconButton
+			data-slot="sheet-close-icon-button"
 			appearance={appearance}
 			icon={<XIcon />}
 			label={label}
@@ -439,7 +442,11 @@ CloseIconButton.displayName = "SheetCloseIconButton";
  * ```
  */
 const Body = ({ className, ...props }: HTMLAttributes<HTMLDivElement>) => (
-	<div className={cx("scrollbar text-body flex-1 overflow-y-auto p-6", className)} {...props} />
+	<div
+		data-slot="sheet-body"
+		className={cx("scrollbar text-body flex-1 overflow-y-auto p-6", className)}
+		{...props}
+	/>
 );
 Body.displayName = "SheetBody";
 
@@ -494,6 +501,7 @@ Body.displayName = "SheetBody";
  */
 const Header = ({ className, ...props }: HTMLAttributes<HTMLDivElement>) => (
 	<div
+		data-slot="sheet-header"
 		className={cx(
 			"border-dialog-muted flex shrink-0 flex-col gap-2 border-b py-4 pl-6 pr-4",
 			"has-[.icon-button]:pr-4", // when there are actions in the header, shorten the padding
@@ -555,6 +563,7 @@ Header.displayName = "SheetHeader";
  */
 const Footer = ({ className, ...props }: HTMLAttributes<HTMLDivElement>) => (
 	<div
+		data-slot="sheet-footer"
 		className={cx(
 			"border-dialog-muted flex shrink-0 justify-end gap-2 border-t px-6 py-2.5",
 			className,
@@ -618,6 +627,7 @@ const Title = forwardRef<
 	ComponentPropsWithoutRef<typeof SheetPrimitive.Title>
 >(({ className, ...props }, ref) => (
 	<SheetPrimitive.Title
+		data-slot="sheet-title"
 		ref={ref}
 		className={cx("text-strong flex-1 truncate text-lg font-medium", className)}
 		{...props}
@@ -675,7 +685,12 @@ Title.displayName = SheetPrimitive.Title.displayName;
  */
 const TitleGroup = forwardRef<ComponentRef<"div">, HTMLAttributes<HTMLDivElement>>(
 	({ children, className, ...props }, ref) => (
-		<div className={cx("flex items-center justify-between gap-2", className)} {...props} ref={ref}>
+		<div
+			data-slot="sheet-title-group"
+			className={cx("flex items-center justify-between gap-2", className)}
+			{...props}
+			ref={ref}
+		>
 			{children}
 		</div>
 	),
@@ -734,7 +749,12 @@ const Description = forwardRef<
 	ComponentRef<typeof SheetPrimitive.Description>,
 	ComponentPropsWithoutRef<typeof SheetPrimitive.Description>
 >(({ className, ...props }, ref) => (
-	<SheetPrimitive.Description ref={ref} className={cx("text-body text-sm", className)} {...props} />
+	<SheetPrimitive.Description
+		data-slot="sheet-description"
+		ref={ref}
+		className={cx("text-body text-sm", className)}
+		{...props}
+	/>
 ));
 Description.displayName = SheetPrimitive.Description.displayName;
 
@@ -788,7 +808,12 @@ Description.displayName = SheetPrimitive.Description.displayName;
  */
 const Actions = forwardRef<ComponentRef<"div">, HTMLAttributes<HTMLDivElement>>(
 	({ children, className, ...props }, ref) => (
-		<div className={cx("flex h-full items-center gap-2", className)} {...props} ref={ref}>
+		<div
+			data-slot="sheet-actions"
+			className={cx("flex h-full items-center gap-2", className)}
+			{...props}
+			ref={ref}
+		>
 			{children}
 		</div>
 	),

--- a/packages/mantle/src/components/skeleton/skeleton.tsx
+++ b/packages/mantle/src/components/skeleton/skeleton.tsx
@@ -29,6 +29,7 @@ const Skeleton = forwardRef<ComponentRef<"div">, Props>(
 
 		return (
 			<Component
+				data-slot="skeleton"
 				className={cx(
 					"dark-high-contrast:bg-black/30 high-contrast:bg-black/30 h-4 animate-pulse rounded-md bg-gray-300/25 dark:bg-gray-950/10",
 					className,

--- a/packages/mantle/src/components/skip-to-main-link/skip-to-main-link.tsx
+++ b/packages/mantle/src/components/skip-to-main-link/skip-to-main-link.tsx
@@ -46,6 +46,7 @@ const SkipToMainLink = ({
 	return (
 		<Anchor
 			{...props}
+			data-slot="skip-to-main-link"
 			href={`#${targetId}`}
 			onClick={(event) => {
 				event.preventDefault();

--- a/packages/mantle/src/components/switch/switch.tsx
+++ b/packages/mantle/src/components/switch/switch.tsx
@@ -33,6 +33,7 @@ const Switch = forwardRef<ComponentRef<typeof SwitchPrimitiveRoot>, SwitchProps>
 
 		return (
 			<SwitchPrimitiveRoot
+				data-slot="switch"
 				aria-readonly={readOnly}
 				className={cx(
 					"peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full outline-hidden",

--- a/packages/mantle/src/components/table/table.tsx
+++ b/packages/mantle/src/components/table/table.tsx
@@ -1,9 +1,7 @@
 import type { ComponentProps, ComponentRef } from "react";
 import { forwardRef, useLayoutEffect, useMemo, useRef, useState } from "react";
-import type { WithAsChild } from "../../types/as-child.js";
 import { composeRefs } from "../../utils/compose-refs/compose-refs.js";
 import { cx } from "../../utils/cx/cx.js";
-import { Slot } from "../slot/index.js";
 
 /**
  * The `<Table.Root>` is the root container element for all `Table`s.
@@ -47,13 +45,12 @@ import { Slot } from "../slot/index.js";
  *
  * @see https://mantle.ngrok.com/components/table#tableroot
  */
-const Root = forwardRef<ComponentRef<"div">, ComponentProps<"div"> & WithAsChild>(
-	({ asChild, children, className, ...props }, ref) => {
+const Root = forwardRef<ComponentRef<"div">, ComponentProps<"div">>(
+	({ children, className, ...props }, ref) => {
 		const horizontalOverflow = useHorizontalOverflowObserver<ComponentRef<"div">>();
-		const Comp = asChild ? Slot : "div";
 
 		return (
-			<Comp
+			<div
 				data-slot="table"
 				className={cx(
 					"group/table relative w-full overflow-hidden rounded-lg border border-card bg-white dark:bg-gray-100",
@@ -90,7 +87,7 @@ const Root = forwardRef<ComponentRef<"div">, ComponentProps<"div"> & WithAsChild
 				>
 					{children}
 				</div>
-			</Comp>
+			</div>
 		);
 	},
 );

--- a/packages/mantle/src/components/table/table.tsx
+++ b/packages/mantle/src/components/table/table.tsx
@@ -1,7 +1,9 @@
 import type { ComponentProps, ComponentRef } from "react";
 import { forwardRef, useLayoutEffect, useMemo, useRef, useState } from "react";
+import type { WithAsChild } from "../../types/as-child.js";
 import { composeRefs } from "../../utils/compose-refs/compose-refs.js";
 import { cx } from "../../utils/cx/cx.js";
+import { Slot } from "../slot/index.js";
 
 /**
  * The `<Table.Root>` is the root container element for all `Table`s.
@@ -45,12 +47,14 @@ import { cx } from "../../utils/cx/cx.js";
  *
  * @see https://mantle.ngrok.com/components/table#tableroot
  */
-const Root = forwardRef<ComponentRef<"div">, ComponentProps<"div">>(
-	({ children, className, ...props }, ref) => {
+const Root = forwardRef<ComponentRef<"div">, ComponentProps<"div"> & WithAsChild>(
+	({ asChild, children, className, ...props }, ref) => {
 		const horizontalOverflow = useHorizontalOverflowObserver<ComponentRef<"div">>();
+		const Comp = asChild ? Slot : "div";
 
 		return (
-			<div
+			<Comp
+				data-slot="table"
 				className={cx(
 					"group/table relative w-full overflow-hidden rounded-lg border border-card bg-white dark:bg-gray-100",
 					className,
@@ -86,7 +90,7 @@ const Root = forwardRef<ComponentRef<"div">, ComponentProps<"div">>(
 				>
 					{children}
 				</div>
-			</div>
+			</Comp>
 		);
 	},
 );
@@ -161,6 +165,7 @@ const Element = forwardRef<ComponentRef<"table">, ComponentProps<"table">>(
 	({ children, className, ...props }, ref) => {
 		return (
 			<table
+				data-slot="table-element"
 				ref={ref}
 				className={cx(
 					"table-auto border-separate border-spacing-0 caption-bottom w-full min-w-full text-left",
@@ -225,6 +230,7 @@ Element.displayName = "TableElement";
 const Head = forwardRef<ComponentRef<"thead">, ComponentProps<"thead">>(
 	({ children, className, ...props }, ref) => (
 		<thead
+			data-slot="table-head"
 			ref={ref}
 			className={cx(
 				//,
@@ -292,6 +298,7 @@ Head.displayName = "TableHead";
 const Body = forwardRef<ComponentRef<"tbody">, ComponentProps<"tbody">>(
 	({ children, className, ...props }, ref) => (
 		<tbody
+			data-slot="table-body"
 			className={cx(
 				//,
 				// In border-separate, <tr>/<tbody> borders don't render, so apply
@@ -360,6 +367,7 @@ Body.displayName = "TableBody";
 const Foot = forwardRef<ComponentRef<"tfoot">, ComponentProps<"tfoot">>(
 	({ children, className, ...props }, ref) => (
 		<tfoot
+			data-slot="table-foot"
 			ref={ref}
 			className={cx(
 				//,
@@ -426,6 +434,7 @@ Foot.displayName = "TableFoot";
 const Row = forwardRef<ComponentRef<"tr">, ComponentProps<"tr">>(
 	({ children, className, ...props }, ref) => (
 		<tr
+			data-slot="table-row"
 			ref={ref}
 			className={cx(
 				// This could be removed, or simplified
@@ -488,6 +497,7 @@ Row.displayName = "TableRow";
 const Header = forwardRef<ComponentRef<"th">, ComponentProps<"th">>(
 	({ children, className, ...props }, ref) => (
 		<th
+			data-slot="table-header"
 			ref={ref}
 			className={cx(
 				"h-11 px-4 text-left align-middle text-sm font-medium [&:has([role=checkbox])]:pr-0",
@@ -548,6 +558,7 @@ Header.displayName = "TableHeader";
 const Cell = forwardRef<ComponentRef<"td">, ComponentProps<"td">>(
 	({ children, className, ...props }, ref) => (
 		<td
+			data-slot="table-cell"
 			ref={ref}
 			className={cx(
 				"p-3 align-middle [&:has([role=checkbox])]:pr-0 font-mono text-mono",
@@ -608,6 +619,7 @@ Cell.displayName = "TableCell";
 const Caption = forwardRef<ComponentRef<"caption">, ComponentProps<"caption">>(
 	({ children, className, ...props }, ref) => (
 		<caption
+			data-slot="table-caption"
 			ref={ref}
 			className={cx("py-4 text-sm text-gray-500", "border-t border-card-muted", className)}
 			{...props}

--- a/packages/mantle/src/components/tabs/tabs.tsx
+++ b/packages/mantle/src/components/tabs/tabs.tsx
@@ -71,6 +71,7 @@ const Root = forwardRef<
 	}
 >(({ className, children, orientation = "horizontal", appearance = "classic", ...props }, ref) => (
 	<TabsPrimitiveRoot
+		data-slot="tabs"
 		className={cx("flex gap-4", orientation === "horizontal" ? "flex-col" : "flex-row", className)}
 		orientation={orientation}
 		ref={ref}
@@ -216,6 +217,7 @@ const List = forwardRef<
 	return (
 		<TabsPrimitiveList
 			aria-orientation={orientation}
+			data-slot="tabs-list"
 			className={cx(listVariants({ orientation, appearance }), className)}
 			ref={composeRefs(scrollRef, ref)}
 			{...props}
@@ -352,7 +354,7 @@ const Trigger = forwardRef<ComponentRef<typeof TabsPrimitiveTrigger>, TabsTrigge
 					{ tabIndex: 0 };
 
 			return (
-				<TabsPrimitiveTrigger asChild {...tabsTriggerProps} ref={ref}>
+				<TabsPrimitiveTrigger asChild data-slot="tabs-trigger" {...tabsTriggerProps} ref={ref}>
 					{cloneElement(
 						disabled ? <button type="button" /> : singleChild,
 						cloneProps,
@@ -366,7 +368,7 @@ const Trigger = forwardRef<ComponentRef<typeof TabsPrimitiveTrigger>, TabsTrigge
 		}
 
 		return (
-			<TabsPrimitiveTrigger ref={ref} {...tabsTriggerProps}>
+			<TabsPrimitiveTrigger data-slot="tabs-trigger" ref={ref} {...tabsTriggerProps}>
 				<TabsTriggerDecoration />
 				{children}
 			</TabsPrimitiveTrigger>
@@ -395,6 +397,7 @@ Trigger.displayName = "TabsTrigger";
  */
 const Badge = ({ className, children, ...props }: HTMLAttributes<HTMLSpanElement>) => (
 	<span
+		data-slot="tabs-badge"
 		className={cx(
 			"rounded-full bg-neutral-500/20 px-1.5 text-xs font-medium text-gray-600",
 			"group-data-state-active/tab-trigger:bg-neutral-950/10 group-data-state-active/tab-trigger:text-strong group-hover/tab-trigger:group-enabled/tab-trigger:group-data-state-active/tab-trigger:text-strong",
@@ -436,6 +439,7 @@ const Content = forwardRef<
 >(({ className, ...props }, ref) => (
 	<TabsPrimitiveContent
 		ref={ref}
+		data-slot="tabs-content"
 		className={cx("focus-visible:ring-focus-accent outline-hidden focus-visible:ring-4", className)}
 		{...props}
 	/>

--- a/packages/mantle/src/components/text-area/text-area.tsx
+++ b/packages/mantle/src/components/text-area/text-area.tsx
@@ -63,6 +63,7 @@ const TextArea = forwardRef<ComponentRef<"textarea">, Props>(
 			<textarea
 				aria-invalid={ariaInvalid}
 				data-validation={validation || undefined}
+				data-slot="text-area"
 				className={cx(
 					appearance === "monospaced" &&
 						"pointer-coarse:text-[0.9375rem] font-mono text-[0.8125rem]",

--- a/packages/mantle/src/components/toast/toast.tsx
+++ b/packages/mantle/src/components/toast/toast.tsx
@@ -63,6 +63,7 @@ const Toaster = ({
 
 	return (
 		<ToastPrimitive.Toaster
+			data-slot="toaster"
 			className={cx("toaster overlay-prompt pointer-events-auto *:duration-200", className)}
 			containerAriaLabel={containerAriaLabel}
 			dir={dir}
@@ -186,6 +187,7 @@ const Root = forwardRef<ComponentRef<"div">, ToastProps>(
 		return (
 			<ToastStateContext.Provider value={{ priority }}>
 				<Component
+					data-slot="toast"
 					className={cx(
 						"relative flex items-start gap-2 text-sm font-sans",
 						"p-3 pl-3.75",
@@ -233,6 +235,7 @@ const Icon = forwardRef<ComponentRef<"svg">, ToastIconProps>(
 			case "danger":
 				return (
 					<IconComponent
+						data-slot="toast-icon"
 						className={cx("text-danger-600", className)}
 						ref={ref}
 						svg={svg ?? <WarningIcon weight="fill" />}
@@ -242,6 +245,7 @@ const Icon = forwardRef<ComponentRef<"svg">, ToastIconProps>(
 			case "warning":
 				return (
 					<IconComponent
+						data-slot="toast-icon"
 						className={cx("text-warning-600", className)}
 						ref={ref}
 						svg={svg ?? <WarningDiamondIcon weight="fill" />}
@@ -251,6 +255,7 @@ const Icon = forwardRef<ComponentRef<"svg">, ToastIconProps>(
 			case "success":
 				return (
 					<IconComponent
+						data-slot="toast-icon"
 						className={cx("text-success-600", className)}
 						ref={ref}
 						svg={svg ?? <CheckCircleIcon weight="fill" />}
@@ -261,6 +266,7 @@ const Icon = forwardRef<ComponentRef<"svg">, ToastIconProps>(
 				return (
 					<IconComponent
 						//
+						data-slot="toast-icon"
 						className={cx("text-accent-600", className)}
 						ref={ref}
 						svg={<InfoIcon weight="fill" />}
@@ -299,6 +305,7 @@ const Action = forwardRef<ComponentRef<"button">, ToastActionProps>(
 
 		return (
 			<Component
+				data-slot="toast-action"
 				className={cx(
 					//,
 					"shrink-0",
@@ -343,6 +350,7 @@ const Message = forwardRef<ComponentRef<"p">, ToastMessageProps>(
 		return (
 			<Component
 				//
+				data-slot="toast-message"
 				className={cx("text-strong flex-1 text-sm font-body", className)}
 				ref={ref}
 				{...props}


### PR DESCRIPTION
Add stable `data-slot` attributes to every exported component and compound sub-part so consumers have a consistent styling hook that survives className overrides and asChild swaps. Simple components use `data-slot="<name>"`; compound sub-parts use `data-slot="<name>-<part>"`.

Expand `asChild` support (via `Slot`) to `Empty.Root`, `Empty.Actions`, `Code`, `ButtonGroup`, and `Table.Root` (inherited by `DataTable.Root`). SVG-rendering components are intentionally excluded since `Slot` targets `HTMLElement`-backed refs. Radix-backed components (Accordion, ProgressBar, etc.) already expose asChild through their underlying primitives.

To carry `data-slot`, wrap the formerly bare Radix re-exports `HoverCard.Trigger`, `Dialog.Trigger`, `Dialog.Close`, and `DropdownMenu.Trigger` in thin forwardRef components.

Breaking: `ProgressBar` `data-slot` values are renamed to match the compound-component naming convention — `progress` → `progress-bar` and `progress-indicator` → `progress-bar-indicator`. Consumers styling against the old values will need to update their selectors.

Also:

- Widen `SvgAttributes` in `icon/types.ts` to accept `data-slot`, with JSDoc.
- Update `Empty` docs to document `asChild` on `Root` and `Actions`.
- Update `Table` docs to document `asChild` on `Table.Root`.
- Update the `scaffold-component` skill to require `data-slot` on every rendered root and to make `asChild` the default expectation for new components, with explicit exception criteria (SVG, `svg`-prop patterns, third-party primitive delegates, pure utilities).