### PR TITLE
feat(mantle): add "when to use" guidance for tooltip/popover/hover-card

### DIFF
--- a/.changeset/alert-anchor-inherits-variant-color.md
+++ b/.changeset/alert-anchor-inherits-variant-color.md
@@ -1,0 +1,7 @@
+---
+"@ngrok/mantle": patch
+---
+
+Anchors (`<a>` elements, including those rendered by the `Anchor` component) that are descendants of `Alert.Root` now inherit the alert's variant text color (e.g. `text-warning-700` inside a warning alert) and are underlined at all times — not just on hover. This keeps inline links visually coherent with the surrounding alert copy while still marking them as links.
+
+**Visual change**: consumers that currently render links inside `Alert.Root` will see those links shift from the default `text-accent-600` to the alert's priority color, and the underline will be persistent rather than hover-only.

--- a/.changeset/tooltip-popover-hover-card-when-to-use.md
+++ b/.changeset/tooltip-popover-hover-card-when-to-use.md
@@ -1,0 +1,5 @@
+---
+"@ngrok/mantle": patch
+---
+
+Add "when to use" guidance and WAI-ARIA cross-references to the `Tooltip`, `Popover`, and `HoverCard` compound-namespace JSDoc so editor hover tips surface the correct component for each use case.

--- a/apps/www/app/docs/components/hover-card.mdx
+++ b/apps/www/app/docs/components/hover-card.mdx
@@ -22,7 +22,7 @@ A `HoverCard` shows a preview of richer content (a user card, link preview, etc.
 - Prefer [`Popover`](/components/popover) when the content must be reachable by all users and may contain interactive elements.
 
 > [!WARNING]
-> Hover cards are for sighted users only — the content is not reached by keyboard and is ignored by screen readers. Any information inside a `HoverCard` must also be available through another fully accessible path (usually the underlying link).
+> Do not rely on a `HoverCard` as the only accessible path to important content. Because it opens on pointer hover, it is not a reliable path for keyboard or screen reader users. Any information inside a `HoverCard` must also be available through another fully accessible path (usually the underlying link).
 
 <Example className="gap-2">
 	<HoverCard.Root>

--- a/apps/www/app/docs/components/hover-card.mdx
+++ b/apps/www/app/docs/components/hover-card.mdx
@@ -14,6 +14,16 @@ import { Example } from "~/components/example";
 
 For sighted users to preview content available behind a link.
 
+## When to use
+
+A `HoverCard` shows a preview of richer content (a user card, link preview, etc.) when a sighted user hovers a link or trigger.
+
+- Prefer [`Tooltip`](/components/tooltip) for short, non-interactive labels on controls.
+- Prefer [`Popover`](/components/popover) when the content must be reachable by all users and may contain interactive elements.
+
+> [!WARNING]
+> Hover cards are for sighted users only — the content is not reached by keyboard and is ignored by screen readers. Any information inside a `HoverCard` must also be available through another fully accessible path (usually the underlying link).
+
 <Example className="gap-2">
 	<HoverCard.Root>
 		<HoverCard.Trigger asChild>

--- a/apps/www/app/docs/components/popover.mdx
+++ b/apps/www/app/docs/components/popover.mdx
@@ -12,6 +12,15 @@ import { Example } from "~/components/example";
 
 Displays rich content in a portal, triggered by a button.
 
+## When to use
+
+A `Popover` is a non-modal dialog anchored to a trigger. Use it when the floating content must be interactive — forms, menus of actions, filters, settings.
+
+- Prefer [`Tooltip`](/components/tooltip) for a short, non-interactive label on a control (for example, the purpose of an icon-only button).
+- Prefer [`HoverCard`](/components/hover-card) for a sighted-only preview of content that already lives behind a link.
+
+Popover follows the [WAI-ARIA dialog pattern](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/): focus is managed, `Tab` cycles through interactive content, and `Escape` closes and returns focus to the trigger.
+
 <Example className="gap-2">
 	<Popover.Root>
 		<Popover.Trigger asChild>

--- a/apps/www/app/docs/components/popover.mdx
+++ b/apps/www/app/docs/components/popover.mdx
@@ -19,7 +19,7 @@ A `Popover` is a non-modal dialog anchored to a trigger. Use it when the floatin
 - Prefer [`Tooltip`](/components/tooltip) for a short, non-interactive label on a control (for example, the purpose of an icon-only button).
 - Prefer [`HoverCard`](/components/hover-card) for a sighted-only preview of content that already lives behind a link.
 
-Popover follows the [WAI-ARIA dialog pattern](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/): focus is managed, `Tab` cycles through interactive content, and `Escape` closes and returns focus to the trigger.
+Popover is a non-modal dialog by default: focus moves into the content on open, `Escape` closes and returns focus to the trigger, clicking outside dismisses, and the page (body and any scroll containers) continues to scroll normally. Pass `modal` on `Popover.Root` to trap focus inside the content, block interaction with the rest of the page, and lock body scroll while the popover is open (the [WAI-ARIA dialog pattern](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/)).
 
 <Example className="gap-2">
 	<Popover.Root>

--- a/apps/www/app/docs/components/tooltip.mdx
+++ b/apps/www/app/docs/components/tooltip.mdx
@@ -3,25 +3,23 @@ title: Tooltip
 description: A popup that displays information related to an element when the element receives keyboard focus or the mouse hovers over it.
 ---
 
-import { Alert } from "@ngrok/mantle/alert";
 import { Button } from "@ngrok/mantle/button";
 import { Tooltip } from "@ngrok/mantle/tooltip";
-import { LightbulbIcon } from "@phosphor-icons/react";
 import { Example } from "~/components/example";
 
 # Tooltip
 
 A popup that displays information related to an element when the element receives keyboard focus or the mouse hovers over it.
 
-<Alert.Root priority="warning">
-	<Alert.Icon svg={<LightbulbIcon />} />
-	<Alert.Content>
-		<Alert.Title>
-			<strong>Note:</strong> Wrap your app with `TooltipProvider` once at the root to enable
-			tooltips throughout your application.
-		</Alert.Title>
-	</Alert.Content>
-</Alert.Root>
+## When to use
+
+A `Tooltip` shows a short, non-interactive label when a control receives keyboard focus or a pointer hover. Reach for it to clarify the purpose of an icon-only button or provide a brief hint about a control.
+
+- Prefer [`Popover`](/components/popover) when the floating content needs buttons, links, inputs, or anything else focusable.
+- Prefer [`HoverCard`](/components/hover-card) for a sighted-only preview of content that already lives behind a link.
+
+> [!WARNING]
+> Per the [WAI-ARIA tooltip pattern](https://www.w3.org/WAI/ARIA/apg/patterns/tooltip/), tooltips must not contain interactive or focusable content — the tooltip itself never receives focus, so anything inside it is unreachable for keyboard users. If the floating content needs to be interactive, use [`Popover`](/components/popover) instead.
 
 <Example>
 	<Tooltip.Root>
@@ -63,6 +61,9 @@ Tooltip.Root
 ```
 
 ## API Reference
+
+> [!NOTE]
+> Wrap your app with `TooltipProvider` once at the root to enable tooltips throughout your application.
 
 ### TooltipProvider
 

--- a/apps/www/app/docs/components/tooltip.mdx
+++ b/apps/www/app/docs/components/tooltip.mdx
@@ -63,7 +63,7 @@ Tooltip.Root
 ## API Reference
 
 > [!NOTE]
-> Wrap your app with `TooltipProvider` once at the root to enable tooltips throughout your application.
+> Wrap your app with `TooltipProvider` once at the root to share global tooltip behavior — such as consistent delay and hover settings — across your application.
 
 ### TooltipProvider
 

--- a/packages/mantle/src/components/alert/alert.tsx
+++ b/packages/mantle/src/components/alert/alert.tsx
@@ -51,15 +51,15 @@ const alertVariants = cva(
 			 */
 			priority: {
 				danger:
-					"border-danger-500/50 bg-danger-500/10 text-danger-700 [&_code]:bg-danger-500/10 [&_code]:border-danger-500/20 [&_code]:text-danger-900",
+					"border-danger-500/50 bg-danger-500/10 text-danger-700 [&_code]:bg-danger-500/10 [&_code]:border-danger-500/20 [&_code]:text-danger-900 [&_a]:text-danger-700 [&_a]:underline",
 				important:
-					"border-important-500/50 bg-important-500/10 text-important-700 [&_code]:bg-important-500/10 [&_code]:border-important-500/20 [&_code]:text-important-900",
-				info: "border-info-500/50 bg-info-500/10 text-info-700 [&_code]:bg-info-500/10 [&_code]:border-info-500/20 [&_code]:text-info-900",
+					"border-important-500/50 bg-important-500/10 text-important-700 [&_code]:bg-important-500/10 [&_code]:border-important-500/20 [&_code]:text-important-900 [&_a]:text-important-700 [&_a]:underline",
+				info: "border-info-500/50 bg-info-500/10 text-info-700 [&_code]:bg-info-500/10 [&_code]:border-info-500/20 [&_code]:text-info-900 [&_a]:text-info-700 [&_a]:underline",
 				// neutral: "border-neutral-500/50 bg-neutral-500/10 text-neutral-700",
 				success:
-					"border-success-500/50 bg-success-500/10 text-success-700 [&_code]:bg-success-500/10 [&_code]:border-success-500/20 [&_code]:text-success-900",
+					"border-success-500/50 bg-success-500/10 text-success-700 [&_code]:bg-success-500/10 [&_code]:border-success-500/20 [&_code]:text-success-900 [&_a]:text-success-700 [&_a]:underline",
 				warning:
-					"border-warning-500/50 bg-warning-500/10 text-warning-700 [&_code]:bg-warning-500/10 [&_code]:border-warning-500/20 [&_code]:text-warning-900",
+					"border-warning-500/50 bg-warning-500/10 text-warning-700 [&_code]:bg-warning-500/10 [&_code]:border-warning-500/20 [&_code]:text-warning-900 [&_a]:text-warning-700 [&_a]:underline",
 			} as const satisfies Record<Priority, string>,
 			/**
 			 * Controls the visual style of the Alert.

--- a/packages/mantle/src/components/hover-card/hover-card.tsx
+++ b/packages/mantle/src/components/hover-card/hover-card.tsx
@@ -120,6 +120,13 @@ Content.displayName = HoverCardPrimitive.Content.displayName;
 /**
  * A floating card that appears when a user hovers over a trigger element.
  *
+ * `HoverCard` is intended for sighted users only — its content is not reached
+ * by keyboard and is ignored by screen readers. Use it for supplemental
+ * previews of content that is already available through another accessible
+ * path (typically the underlying link). Prefer `Popover` when the floating
+ * content must be reachable by all users, or `Tooltip` for short,
+ * non-interactive labels on controls.
+ *
  * @see https://mantle.ngrok.com/components/hover-card
  *
  * @example

--- a/packages/mantle/src/components/hover-card/hover-card.tsx
+++ b/packages/mantle/src/components/hover-card/hover-card.tsx
@@ -120,12 +120,13 @@ Content.displayName = HoverCardPrimitive.Content.displayName;
 /**
  * A floating card that appears when a user hovers over a trigger element.
  *
- * `HoverCard` is intended for sighted users only — its content is not reached
- * by keyboard and is ignored by screen readers. Use it for supplemental
- * previews of content that is already available through another accessible
- * path (typically the underlying link). Prefer `Popover` when the floating
- * content must be reachable by all users, or `Tooltip` for short,
- * non-interactive labels on controls.
+ * `HoverCard` is intended primarily for sighted users — it is not a
+ * reliably discoverable path for keyboard or screen reader users, since it
+ * opens on pointer hover. Use it for supplemental previews of content that
+ * is already available through another accessible path (typically the
+ * underlying link). Prefer `Popover` when the floating content must be
+ * reachable by all users, or `Tooltip` for short, non-interactive labels on
+ * controls.
  *
  * @see https://mantle.ngrok.com/components/hover-card
  *

--- a/packages/mantle/src/components/popover/popover.tsx
+++ b/packages/mantle/src/components/popover/popover.tsx
@@ -171,7 +171,15 @@ Content.displayName = "PopoverContent";
 /**
  * A floating overlay that displays rich content in a portal, triggered by a button.
  *
+ * `Popover` follows the WAI-ARIA dialog pattern: focus is managed, `Tab`
+ * cycles through interactive descendants, and `Escape` closes and returns
+ * focus to the trigger. Use a `Popover` when the floating content must be
+ * interactive — forms, action menus, filters, settings. Prefer `Tooltip` for
+ * short, non-interactive labels on controls, or `HoverCard` for a
+ * sighted-only preview of content that already lives behind a link.
+ *
  * @see https://mantle.ngrok.com/components/popover
+ * @see https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/
  *
  * @example
  * Composition:

--- a/packages/mantle/src/components/popover/popover.tsx
+++ b/packages/mantle/src/components/popover/popover.tsx
@@ -171,12 +171,16 @@ Content.displayName = "PopoverContent";
 /**
  * A floating overlay that displays rich content in a portal, triggered by a button.
  *
- * `Popover` follows the WAI-ARIA dialog pattern: focus is managed, `Tab`
- * cycles through interactive descendants, and `Escape` closes and returns
- * focus to the trigger. Use a `Popover` when the floating content must be
- * interactive — forms, action menus, filters, settings. Prefer `Tooltip` for
- * short, non-interactive labels on controls, or `HoverCard` for a
- * sighted-only preview of content that already lives behind a link.
+ * `Popover` is a non-modal dialog by default: focus moves into the content
+ * when it opens, `Escape` closes and returns focus to the trigger, clicking
+ * outside dismisses, and the page (body and any scroll containers) continues
+ * to scroll normally. Pass `modal` on `Popover.Root` to trap focus inside
+ * the content, block interaction with the rest of the page, and lock body
+ * scroll while the popover is open. Use a `Popover` when the floating
+ * content must be interactive — forms, action menus, filters, settings.
+ * Prefer `Tooltip` for short, non-interactive labels on controls, or
+ * `HoverCard` for a sighted-only preview of content that already lives
+ * behind a link.
  *
  * @see https://mantle.ngrok.com/components/popover
  * @see https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/

--- a/packages/mantle/src/components/tooltip/tooltip.tsx
+++ b/packages/mantle/src/components/tooltip/tooltip.tsx
@@ -123,7 +123,7 @@ Content.displayName = "Tooltip.Content";
 
 /**
  * A popup that displays information related to an element when the element receives keyboard focus or the mouse hovers over it.
- * Will throw if you have not wrapped your app in a `TooltipProvider`.
+ * Wrapping your app in a `TooltipProvider` is recommended to share global tooltip behavior (delay, hover settings) across your application.
  *
  * Use a `Tooltip` for short, non-interactive labels — for example, to clarify
  * the purpose of an icon-only button. Per the WAI-ARIA tooltip pattern,

--- a/packages/mantle/src/components/tooltip/tooltip.tsx
+++ b/packages/mantle/src/components/tooltip/tooltip.tsx
@@ -123,10 +123,17 @@ Content.displayName = "Tooltip.Content";
 
 /**
  * A popup that displays information related to an element when the element receives keyboard focus or the mouse hovers over it.
- * This is the root, stateful component that manages the open/closed state of the tooltip.
  * Will throw if you have not wrapped your app in a `TooltipProvider`.
  *
+ * Use a `Tooltip` for short, non-interactive labels — for example, to clarify
+ * the purpose of an icon-only button. Per the WAI-ARIA tooltip pattern,
+ * tooltips never receive focus, so interactive content inside them is
+ * unreachable for keyboard users. Prefer `Popover` when the floating content
+ * must be interactive, or `HoverCard` for a sighted-only preview of content
+ * that already lives behind a link.
+ *
  * @see https://mantle.ngrok.com/components/tooltip
+ * @see https://www.w3.org/WAI/ARIA/apg/patterns/tooltip/
  *
  * @example
  * Composition:


### PR DESCRIPTION
Expand JSDoc on the Tooltip, Popover, and HoverCard compound namespaces with when-to-use prose and WAI-ARIA pattern links so IDE hover tips steer consumers to the right component. Add matching "## When to use" sections with cross-links to each docs page; tooltip and hover-card carry [!WARNING] callouts for the a11y constraints. Replace the inline TooltipProvider Alert.Root with a [!NOTE] callout moved above the TooltipProvider API reference.

Style anchors inside Alert.Root with the alert's variant text color and always-on underline so inline links stay visually coherent with the surrounding copy.