### PR TITLE
feat(mantle): data-table row cursor, simpler useCopyToClipboard, fix useComposedRefs

### DIFF
--- a/.changeset/data-table-row-auto-cursor.md
+++ b/.changeset/data-table-row-auto-cursor.md
@@ -1,0 +1,5 @@
+---
+"@ngrok/mantle": patch
+---
+
+`DataTable.Row` now auto-applies `cursor-pointer` when an `onClick` handler is provided, so consumers no longer need to add it manually. Pass a different `cursor-*` class via `className` (for example, `cursor-wait`) to override.

--- a/.changeset/use-composed-refs-fix.md
+++ b/.changeset/use-composed-refs-fix.md
@@ -1,0 +1,5 @@
+---
+"@ngrok/mantle": patch
+---
+
+Fix `useComposedRefs` returning a thunk (`() => (node) => void`) instead of a ref callback, which meant the composed ref never actually received the DOM node. The hook now returns a stable ref callback that reads the latest refs via an internal ref box, so passed refs stay up-to-date without causing ref thrashing on every render.

--- a/.changeset/use-copy-to-clipboard-return-fn.md
+++ b/.changeset/use-copy-to-clipboard-return-fn.md
@@ -1,0 +1,13 @@
+---
+"@ngrok/mantle": patch
+---
+
+**Breaking:** `useCopyToClipboard` now returns the async copy function directly instead of a `[state, copyFn]` tuple. The internal `useState` that tracked the last copied value has been removed, eliminating an extra render per successful copy.
+
+```tsx
+// Before
+const [, copyToClipboard] = useCopyToClipboard();
+
+// After
+const copyToClipboard = useCopyToClipboard();
+```

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -1,95 +1,87 @@
 # Conventions
 
-Code style, patterns, and conventions for the Mantle design system. This is the single source of truth — all READMEs and tooling reference this file.
+Single source of truth for code style, patterns, and conventions in the Mantle design system monorepo. All rules below are mandatory — call out and fix violations.
 
-## File & Module Conventions
+## Files & Modules
 
-- **File naming**: kebab-case for all files and directories
-- **Modules**: Use ESM (`import`/`export`, `const`, `async/await`, arrow functions)
-- **Exports**: Prefer named exports over default exports
-- **Imports**: Use relative paths in `packages/`, use `~/path/to/thing` alias paths in `apps/`
-- **Type imports**: Use `import type { ... }` for type-only imports
+- File naming: kebab-case (except framework-required filenames like `entry.server.tsx`, `react-router.config.ts`)
+- ESM only: `import`/`export`, `const`, `async/await`, arrow functions
+- Prefer named exports; use `import type` for type-only imports
+- Imports: relative paths in `/packages`, `~/path/to/thing` aliases in `/apps`
 
 ## Formatting & Linting
 
-- **Formatter**: oxfmt with tabs (tabWidth: 2), double quotes — see [`.oxcfmtrc.json`](./.oxcfmtrc.json)
-- **Linter**: oxlint — see [`.oxlintrc.json`](./.oxlintrc.json)
-
-## TypeScript
-
-- **Strict mode**: Enabled.  
-  _Why:_ Forces explicit handling of nullability and unsafe assumptions.
-
-- **Shared configs**: Use `@cfg/tsconfig` (see `config/tsconfig/`).  
-  _Why:_ One canonical baseline prevents drift across packages/apps.
-
-- **No `any`**: `any` is forbidden. Use real types; use `unknown` when truly unknown and narrow it.  
-  _Why:_ `any` disables type safety; `unknown` preserves it until proven.
-
-- **Use `type`**: Use `type` for all declarations. `interface` is not allowed in application code.  
-  _Why:_ `type` covers all shapes (unions, intersections, primitives, tuples), expands inline in IntelliSense for easier inspection, and avoids declaration merging—keeping types closed and predictable.
+- Formatter: oxfmt (tabs, tabWidth 2, double quotes) — see `.oxfmtrc.json`
+- Linter: oxlint — see `.oxlintrc.json`
+- Never biome, prettier, or eslint
 
 ## Code Quality
 
-- **Control flow**: NEVER use single-line if/loop blocks. Always use braces `{}` even for single statements
-- **Variable naming**: Always use descriptive, clear names — avoid unclear abbreviations or single-letter shortcuts. Widely-understood initialisms (for example, URL, CSS, SSR) are allowed when they improve clarity. Apply this principle to all variables; the examples below are illustrative, not exhaustive:
-  - Use `error` instead of `e` or `err` for error variables
-  - Use `event` instead of `e` or `evt` for event parameters
-  - Use `element` instead of `el` or `elem` for DOM element variables
-- **JSDoc**: All exported functions, components, and prop types must have JSDoc comments
-- **Comments should explain why, not what**: Avoid overuse of inline comments that restate the code
-- **Inline one-off handlers**: If an event handler is used only once, define it inline instead of hoisting it into the component
-- **Errors are control flow**: `console.error` is not handling. Every error path must either return a defined recovery value or throw
-- **Avoid nested ternaries**: Prefer early returns or component-based branching over nested ternaries. A single ternary is fine; nesting them harms readability
-- **No non-null assertions**: The postfix `!` operator (`value!`) is forbidden. Use proper null checks, early returns, or restructure the code to narrow the type instead
-- **No type assertions**: The `as` operator is forbidden in application code. Do not use `value as Type`. The only allowed exception is inside a dedicated type guard implementation. Type assertions must never be used to silence TypeScript errors or bypass proper type modeling.
+- Always brace control flow — no single-line `if`/`for` bodies
+- Descriptive names — `error` not `e`, `event` not `evt`, `element` not `el`. Widely-known initialisms (URL, CSS, SSR) are fine.
+- JSDoc on every function, method, component, and prop type.
+- Comments explain _why_, not _what_. Don't restate the code.
+- Inline single-use event handlers; don't hoist them
+- Errors are control flow — `console.error` is not handling. Every error path returns a recovery value or throws.
+- Avoid nested ternaries: Prefer early returns or component-based branching over nested ternaries. A single ternary is fine; nesting them harms readability
+- Never use `React.FC` / `FC` — use inline function types
+- Prefer named options objects over positional params: any boolean param, 3+ params, or 2 params when call sites wouldn't be self-evident (`fn({ enabled: true })`, not `fn(true)`)
+
+### TypeScript
+
+- Strict mode enabled. Shared configs from `@cfg/tsconfig`.
+- No `any` — use `unknown` and narrow it
+- No `interface` — use `type` (covers all shapes, no declaration merging, expands inline in IntelliSense)
+- No non-null assertions: The postfix `!` operator (`value!`) is forbidden. Use proper null checks, early returns, or restructure the code to narrow the type instead
+- No type assertions: The `as` operator is forbidden in application code. Do not use `value as Type`. The only allowed exceptions are `as const` (to narrow literal types) and inside a dedicated type guard implementation. Type assertions must never be used to silence TypeScript errors or bypass proper type modeling.
 
 ## className Composition
 
-All `className` values must be created with `cx` from `../../utils/cx/cx.js` (internal) or `@ngrok/mantle/cx` (external consumers). Any use of string interpolation, `+`, ternaries, or conditional expressions to build class names is disallowed.
-
 ```tsx
-// ✅ Internal usage
-import { cx } from "../../utils/cx/cx.js";
+import { cx } from "@ngrok/mantle/cx";
 
+// ✅
 <div className={cx("foo", condition && "bar", { baz: isActive })} />
 
-// ❌ No string interpolation, +, or ternaries
+// ❌ no string interpolation, +, or ternaries inside className
 <div className={`foo ${condition ? "bar" : ""}`} />
 ```
 
-## Component Structure
-
-Components live in `packages/mantle/src/components/<component-name>/`:
-
-```
-├── index.ts              # Re-exports (public API)
-├── my-component.tsx      # Implementation
-└── my-component.test.tsx # Colocated tests
-```
-
-### Compound Components
-
-Compound components use the **POJO namespace pattern** — see [`decisions/2025-07-16-compound-component-named-exports.md`](./decisions/2025-07-16-compound-component-named-exports.md) for the full rationale.
-
-```tsx
-const Select = { Root, Content, Trigger, Value };
-// Usage: <Select.Root><Select.Trigger /><Select.Content /></Select.Root>
-```
-
-Every property on the namespace object must have a JSDoc comment. The namespace object should have a `displayName` for React DevTools.
-
 ## Testing
 
-- **Runner**: Vitest (UTC timezone for consistent test runs)
-- **Libraries**: `@testing-library/react`, `@testing-library/user-event`, `@testing-library/jest-dom`
-- **File naming**: Colocate tests as `*.test.ts` or `*.test.tsx` next to source files
+- Runner: Vitest. Two modes — happy-dom (default, no per-file Playwright startup) and real-browser Chromium via Playwright.
+- Libraries: `@testing-library/react`, `@testing-library/dom`, `@testing-library/jest-dom`
+- File naming, colocated with source:
+  - happy-dom: `*.test.{ts,tsx}`
+  - browser: `*.browser.test.{ts,tsx}`
+- No `*.test.*` under `app/routes/` — React Router treats that as route modules. Put route-behavior tests under the owning `app/features/*` area.
+- No snapshot tests of rendered HTML. Use declarative assertions (`getByRole`, `getByText`, `toBeInTheDocument`). `toMatchInlineSnapshot` is OK for serialized data shapes only.
+- Business logic MUST be thoroughly tested, including edge cases (transformations, validation, conditional rendering, state machines, parsing/formatting).
+- Every bug fix adds a regression test that fails before the fix and passes after — unless genuinely infeasible (document why in the PR).
 
-## Icons
+### When to reach for browser mode
 
-- **Primary**: `@phosphor-icons/react`
-- **Custom ngrok icons**: `@ngrok/mantle/icons`
+Default to happy-dom. Reach for browser mode only when the test depends on a real-browser API happy-dom doesn't (correctly) implement:
 
-## Theming
+- Web Animations API (`getAnimations`, `Animation.finished`)
+- IntersectionObserver / ResizeObserver
+- Inline `<script>` execution (3rd-party SDK bootstrappers like GTM/Ketch)
+- `<noscript>` parsing — happy-dom drops noscript children
+- Real layout, scroll, `:focus-visible`, real `getBoundingClientRect` / `getComputedStyle`
+- Clipboard API, Drag-and-drop / `DataTransfer`, `FileReader`
+- Pointer/touch events, real hover, focus-within
+- Selection / Range / `contenteditable` caret behavior
+- HTML5 form constraint validation end-to-end
+- `matchMedia` + `prefers-*` reactivity
+- Native `<dialog>.showModal()` / Popover API
+- IndexedDB, BroadcastChannel, cross-tab `storage` events, MessageChannel
+- Canvas 2D / WebGL / OffscreenCanvas
+- Real `requestAnimationFrame` timing
 
-Built-in light/dark mode via `ThemeProvider` with FOUC prevention. Styling uses Tailwind CSS 4.
+If the test only touches DOM structure, ARIA, event handlers, or pure state — stay in happy-dom.
+
+## Package Management
+
+- All external deps use exact pinned versions (no `^` / `~`). Single-use: `pnpm add -E <package>`.
+- Shared deps go through the `catalog:` in `pnpm-workspace.yaml`, then referenced as `catalog:`. Add to catalog first if the dep will be used across packages.
+- For `@pkg/*` workspace packages, use `catalog:` in `devDependencies` and `peerDependencies` (not `dependencies`) so apps install the dep themselves and avoid duplicates.

--- a/apps/www/app/components/doc-actions.tsx
+++ b/apps/www/app/components/doc-actions.tsx
@@ -17,7 +17,7 @@ type Props = {
 export function DocActions({ markdownPath }: Props) {
 	const location = useLocation();
 	const markdownUrl = markdownPath ?? `${location.pathname}.md`;
-	const [, copyToClipboard] = useCopyToClipboard();
+	const copyToClipboard = useCopyToClipboard();
 	const queryClient = useQueryClient();
 
 	async function copyMarkdownPage() {

--- a/apps/www/app/components/hash-link-heading.tsx
+++ b/apps/www/app/components/hash-link-heading.tsx
@@ -35,7 +35,7 @@ type Props = ComponentProps<"h1" | "h2" | "h3" | "h4" | "h5" | "h6">;
  * ```
  */
 function HashLinkHeading({ id, className, children, ...props }: Props) {
-	const [, copyToClipboard] = useCopyToClipboard();
+	const copyToClipboard = useCopyToClipboard();
 	const [wasCopied, setWasCopied] = useState(false);
 	const timeoutHandle = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
 

--- a/apps/www/app/docs/components/data-table.mdx
+++ b/apps/www/app/docs/components/data-table.mdx
@@ -10,6 +10,13 @@ import { EmptyPaymentsDemo, EndpointsDemo, PaymentsDemo } from "~/features/data-
 
 Tables purposefully designed for dynamic, application data with features like sorting, filtering, and pagination. Powered by [TanStack Table](https://tanstack.com/table/latest/docs/introduction).
 
+## When to use
+
+A `DataTable` is for **dynamic, application data** — anywhere users need to sort, filter, paginate, select, or click rows. It is built on top of [`Table`](/components/table) and wires up [TanStack Table](https://tanstack.com/table/latest/docs/introduction) so you get those behaviors out of the box.
+
+- Prefer [`Table`](/components/table) for **static, presentational** tabular content (pricing matrices, reference tables, invoice summaries).
+- All TanStack Table utilities (`createColumnHelper`, `getCoreRowModel`, `getSortedRowModel`, `getPaginationRowModel`, `getFilteredRowModel`, `useReactTable`, etc.) are re-exported from `@ngrok/mantle/data-table` — you do not need to add `@tanstack/react-table` as a separate dependency.
+
 <Example className="flex-col gap-6">
 	<div className="w-full">
 		<PaymentsDemo />
@@ -22,6 +29,62 @@ Tables purposefully designed for dynamic, application data with features like so
 	</div>
 </Example>
 
+## Quick start
+
+The minimum viable `DataTable`. Copy, paste, replace the type and data:
+
+```tsx
+import {
+	DataTable,
+	createColumnHelper,
+	getCoreRowModel,
+	useReactTable,
+} from "@ngrok/mantle/data-table";
+
+type Row = { id: string; name: string };
+
+const columnHelper = createColumnHelper<Row>();
+
+const columns = [
+	columnHelper.accessor("name", {
+		id: "name",
+		header: (props) => (
+			<DataTable.Header>
+				<DataTable.HeaderSortButton column={props.column} sortingMode="alphanumeric">
+					Name
+				</DataTable.HeaderSortButton>
+			</DataTable.Header>
+		),
+		cell: (props) => <DataTable.Cell key={props.cell.id}>{props.getValue()}</DataTable.Cell>,
+	}),
+];
+
+function MyTable({ data }: { data: Row[] }) {
+	const table = useReactTable({
+		data,
+		columns,
+		getCoreRowModel: getCoreRowModel(),
+	});
+
+	const rows = table.getRowModel().rows;
+
+	return (
+		<DataTable.Root table={table}>
+			<DataTable.Head />
+			<DataTable.Body>
+				{rows.length > 0 ? (
+					rows.map((row) => <DataTable.Row key={row.id} row={row} />)
+				) : (
+					<DataTable.EmptyRow>No results.</DataTable.EmptyRow>
+				)}
+			</DataTable.Body>
+		</DataTable.Root>
+	);
+}
+```
+
+A fuller example matching the demo above — sortable columns, pagination, filtering, row-click navigation, and a sticky action column:
+
 ```tsx
 import {
 	DataTable,
@@ -32,6 +95,8 @@ import {
 	getSortedRowModel,
 	useReactTable,
 } from "@ngrok/mantle/data-table";
+import { href, useNavigate } from "react-router";
+import { useMemo } from "react";
 
 type Payment = {
 	id: string;
@@ -41,6 +106,7 @@ type Payment = {
 };
 
 const columnHelper = createColumnHelper<Payment>();
+
 const columns = [
 	columnHelper.accessor("id", {
 		id: "id",
@@ -57,6 +123,7 @@ const columns = [
 ];
 
 function PaymentsExample() {
+	const navigate = useNavigate();
 	const data = useMemo(() => examplePayments, []);
 
 	const table = useReactTable({
@@ -81,10 +148,9 @@ function PaymentsExample() {
 				{rows.length > 0 ? (
 					rows.map((row) => (
 						<DataTable.Row
-							className="cursor-pointer"
 							key={row.id}
 							onClick={() => {
-								window.alert(`Clicked payment row: ${row.original.id}`);
+								navigate(href("/payments/:id", { id: row.original.id }));
 							}}
 							row={row}
 						/>
@@ -118,84 +184,475 @@ DataTable.Root
     └── DataTable.EmptyRow
 ```
 
+## Rules
+
+Follow these invariants for a correctly styled, accessible, and behaving `DataTable`.
+
+1. **Type columns with `createColumnHelper<TData>()`.** It threads `TData` through `header`, `cell`, and `row.original` so consumers get inference instead of `unknown`.
+2. **Wrap every body cell in `DataTable.Cell`.** A raw `<td>` skips the mantle typography, padding, and sticky-column styling.
+3. **Wrap every header in `DataTable.Header`.** For sortable columns, also wrap its contents in `DataTable.HeaderSortButton` — the icon, cycling behavior, and screen-reader announcements are provided by that button.
+4. **Key rows with `row.id`.** TanStack Table tracks row identity across sort/filter/pagination; using array indexes will re-mount rows incorrectly.
+5. **Always branch on `rows.length > 0` and render `DataTable.EmptyRow`** for the empty case. The empty row spans all columns and preserves the table's frame — returning `null` leaves an empty `<tbody>` and collapses the frame.
+6. **Place an action column last, using `columnHelper.display({ ... })`.** Pair `DataTable.ActionHeader` (in `header`) with `DataTable.ActionCell` (in `cell`) so the pinned column aligns across header and body when scrolling horizontally.
+7. **Pass `onClick` to `DataTable.Row` for row-click behavior.** The row auto-applies `cursor-pointer` when `onClick` is set — do not add it yourself. Override with another `cursor-*` class (for example, `cursor-wait`) via `className` if needed.
+8. **Stop click propagation inside `DataTable.ActionCell` when the row is clickable.** Without it, clicks on dropdown triggers, buttons, and links inside the action cell will bubble and fire the row `onClick`.
+9. **Provide a keyboard-accessible equivalent for row navigation.** A `<tr>` is not focusable and is not announced as interactive to assistive tech. If clicking a row navigates, render a `<Link>` in the primary cell so keyboard and screen-reader users have a reachable equivalent.
+10. **Register the row models you use.** `useReactTable` only wires up what you pass in: `getSortedRowModel()` for sorting, `getPaginationRowModel()` for pagination, `getFilteredRowModel()` for filtering. Missing one and the corresponding feature silently no-ops.
+
+## Anti-patterns
+
+Common mistakes. The left column is what not to do; the right column is the fix.
+
+```tsx
+// ❌ Raw <td> — misses mantle styling
+cell: (props) => <td>{props.getValue()}</td>,
+// ✅
+cell: (props) => <DataTable.Cell>{props.getValue()}</DataTable.Cell>,
+
+// ❌ Manual cursor-pointer — redundant, can desync from behavior
+<DataTable.Row className="cursor-pointer" onClick={handle} row={row} />
+// ✅
+<DataTable.Row onClick={handle} row={row} />
+
+// ❌ Plain button for a sortable header — no icon, no ARIA
+header: () => <button onClick={() => column.toggleSorting()}>Name</button>,
+// ✅
+header: (props) => (
+	<DataTable.Header>
+		<DataTable.HeaderSortButton column={props.column} sortingMode="alphanumeric">
+			Name
+		</DataTable.HeaderSortButton>
+	</DataTable.Header>
+),
+
+// ❌ Clickable row with a dropdown inside — trigger click fires the row onClick
+<DataTable.Row onClick={navigate} row={row}>
+	<DataTable.ActionCell>
+		<DropdownMenu.Root>...</DropdownMenu.Root>
+	</DataTable.ActionCell>
+</DataTable.Row>
+// ✅ Stop propagation at the action cell boundary
+<DataTable.Row onClick={navigate} row={row}>
+	<DataTable.ActionCell onClick={(event) => event.stopPropagation()}>
+		<DropdownMenu.Root>...</DropdownMenu.Root>
+	</DataTable.ActionCell>
+</DataTable.Row>
+
+// ❌ Empty state returns null — collapses the table frame
+<DataTable.Body>{rows.map((row) => <DataTable.Row key={row.id} row={row} />)}</DataTable.Body>
+// ✅ Use DataTable.EmptyRow
+<DataTable.Body>
+	{rows.length > 0
+		? rows.map((row) => <DataTable.Row key={row.id} row={row} />)
+		: <DataTable.EmptyRow>No results.</DataTable.EmptyRow>}
+</DataTable.Body>
+
+// ❌ Declared sorting but forgot the row model
+useReactTable({ data, columns, getCoreRowModel: getCoreRowModel() });
+// ✅
+useReactTable({
+	data,
+	columns,
+	getCoreRowModel: getCoreRowModel(),
+	getSortedRowModel: getSortedRowModel(),
+});
+```
+
+## Recipes
+
+### Navigating on row click
+
+Pass `onClick` to `DataTable.Row` and navigate with React Router's `href()` + `useNavigate()`. Render a `<Link>` inside the primary cell for keyboard and screen-reader users — the row `onClick` acts as a larger pointer target on top.
+
+```tsx
+import { DataTable } from "@ngrok/mantle/data-table";
+import { Link, href, useNavigate } from "react-router";
+
+const columns = [
+	columnHelper.accessor("id", {
+		id: "id",
+		header: (props) => (
+			<DataTable.Header>
+				<DataTable.HeaderSortButton column={props.column} sortingMode="alphanumeric">
+					ID
+				</DataTable.HeaderSortButton>
+			</DataTable.Header>
+		),
+		cell: (props) => (
+			<DataTable.Cell>
+				<Link to={href("/payments/:id", { id: props.row.original.id })}>{props.getValue()}</Link>
+			</DataTable.Cell>
+		),
+	}),
+	// ... more columns
+];
+
+function PaymentsTable({ data }: { data: Payment[] }) {
+	const navigate = useNavigate();
+	const table = useReactTable({ data, columns, getCoreRowModel: getCoreRowModel() });
+	const rows = table.getRowModel().rows;
+
+	return (
+		<DataTable.Root table={table}>
+			<DataTable.Head />
+			<DataTable.Body>
+				{rows.map((row) => (
+					<DataTable.Row
+						key={row.id}
+						onClick={() => {
+							navigate(href("/payments/:id", { id: row.original.id }));
+						}}
+						row={row}
+					/>
+				))}
+			</DataTable.Body>
+		</DataTable.Root>
+	);
+}
+```
+
+### Action column with a dropdown menu
+
+Define the action column with `columnHelper.display`, pair `DataTable.ActionHeader` with `DataTable.ActionCell`, and stop click propagation on the cell if the row is also clickable.
+
+```tsx
+import { IconButton } from "@ngrok/mantle/button";
+import { DataTable } from "@ngrok/mantle/data-table";
+import { DropdownMenu } from "@ngrok/mantle/dropdown-menu";
+import { Icon } from "@ngrok/mantle/icon";
+import { DotsThreeIcon } from "@phosphor-icons/react/DotsThree";
+import { PencilSimpleIcon } from "@phosphor-icons/react/PencilSimple";
+import { TrashIcon } from "@phosphor-icons/react/Trash";
+
+columnHelper.display({
+	id: "actions",
+	header: () => <DataTable.ActionHeader />,
+	cell: (props) => (
+		<DataTable.ActionCell onClick={(event) => event.stopPropagation()}>
+			<DropdownMenu.Root>
+				<DropdownMenu.Trigger asChild>
+					<IconButton
+						appearance="ghost"
+						size="sm"
+						type="button"
+						label="Open actions"
+						icon={<DotsThreeIcon weight="bold" />}
+					/>
+				</DropdownMenu.Trigger>
+				<DropdownMenu.Content align="end">
+					<DropdownMenu.Item onSelect={() => editRow(props.row.original)}>
+						<Icon svg={<PencilSimpleIcon />} /> Edit
+					</DropdownMenu.Item>
+					<DropdownMenu.Item
+						className="text-danger-600"
+						onSelect={() => deleteRow(props.row.original)}
+					>
+						<Icon svg={<TrashIcon />} /> Delete
+					</DropdownMenu.Item>
+				</DropdownMenu.Content>
+			</DropdownMenu.Root>
+		</DataTable.ActionCell>
+	),
+});
+```
+
+### Customizing cells (badges, numeric, truncation)
+
+Cell rendering is just React. Use `Badge` for status pills, `text-right` for numeric columns, and `truncate max-w-*` for long strings.
+
+```tsx
+import { Badge } from "@ngrok/mantle/badge";
+import { DataTable } from "@ngrok/mantle/data-table";
+
+// Status pill
+columnHelper.accessor("status", {
+	id: "status",
+	header: (props) => (
+		<DataTable.Header>
+			<DataTable.HeaderSortButton column={props.column} sortingMode="alphanumeric">
+				Status
+			</DataTable.HeaderSortButton>
+		</DataTable.Header>
+	),
+	cell: (props) => {
+		const status = props.getValue();
+		const color = status === "success" ? "green" : status === "failed" ? "red" : "amber";
+		return (
+			<DataTable.Cell>
+				<Badge color={color} appearance="muted">
+					{status}
+				</Badge>
+			</DataTable.Cell>
+		);
+	},
+}),
+
+// Right-aligned numeric — the header button also needs justify-end + iconPlacement="start"
+// so the sort affordance stays visually paired with the label
+columnHelper.accessor("amount", {
+	id: "amount",
+	header: (props) => (
+		<DataTable.Header>
+			<DataTable.HeaderSortButton
+				className="justify-end"
+				column={props.column}
+				iconPlacement="start"
+				sortingMode="alphanumeric"
+			>
+				Amount
+			</DataTable.HeaderSortButton>
+		</DataTable.Header>
+	),
+	cell: (props) => (
+		<DataTable.Cell className="text-right">${props.getValue().toFixed(2)}</DataTable.Cell>
+	),
+}),
+
+// Truncate a long URL
+columnHelper.accessor("url", {
+	id: "url",
+	header: (props) => (
+		<DataTable.Header className="min-w-100">
+			<DataTable.HeaderSortButton column={props.column} sortingMode="alphanumeric">
+				URL
+			</DataTable.HeaderSortButton>
+		</DataTable.Header>
+	),
+	cell: (props) => <DataTable.Cell className="truncate max-w-100">{props.getValue()}</DataTable.Cell>,
+}),
+```
+
+### Pagination controls
+
+Register `getPaginationRowModel()` and drive page controls from the table instance (`table.getState().pagination`, `table.previousPage()`, `table.nextPage()`, `table.setPageIndex()`, `table.getPageCount()`).
+
+```tsx
+import { Button } from "@ngrok/mantle/button";
+import {
+	DataTable,
+	getCoreRowModel,
+	getPaginationRowModel,
+	useReactTable,
+} from "@ngrok/mantle/data-table";
+
+function PaginatedTable({ data }: { data: Payment[] }) {
+	const table = useReactTable({
+		data,
+		columns,
+		getCoreRowModel: getCoreRowModel(),
+		getPaginationRowModel: getPaginationRowModel(),
+		initialState: { pagination: { pageSize: 25 } },
+	});
+
+	const rows = table.getRowModel().rows;
+	const { pageIndex } = table.getState().pagination;
+
+	return (
+		<>
+			<DataTable.Root table={table}>
+				<DataTable.Head />
+				<DataTable.Body>
+					{rows.length > 0 ? (
+						rows.map((row) => <DataTable.Row key={row.id} row={row} />)
+					) : (
+						<DataTable.EmptyRow>No results.</DataTable.EmptyRow>
+					)}
+				</DataTable.Body>
+			</DataTable.Root>
+
+			<div className="flex items-center justify-between gap-2">
+				<span>
+					Page {pageIndex + 1} of {table.getPageCount()}
+				</span>
+				<div className="flex gap-2">
+					<Button
+						type="button"
+						onClick={() => table.previousPage()}
+						disabled={!table.getCanPreviousPage()}
+					>
+						Previous
+					</Button>
+					<Button type="button" onClick={() => table.nextPage()} disabled={!table.getCanNextPage()}>
+						Next
+					</Button>
+				</div>
+			</div>
+		</>
+	);
+}
+```
+
+### Row selection with checkboxes
+
+Use `columnHelper.display` for the checkbox column and read selection from `table.getState().rowSelection`.
+
+```tsx
+import { Checkbox } from "@ngrok/mantle/checkbox";
+import { DataTable, getCoreRowModel, useReactTable } from "@ngrok/mantle/data-table";
+import { useState } from "react";
+
+const columns = [
+	columnHelper.display({
+		id: "select",
+		header: ({ table }) => (
+			<DataTable.Header className="w-10">
+				<Checkbox
+					checked={
+						table.getIsAllRowsSelected()
+							? true
+							: table.getIsSomeRowsSelected()
+								? "indeterminate"
+								: false
+					}
+					onCheckedChange={(value) => table.toggleAllRowsSelected(value === true)}
+					aria-label="Select all rows"
+				/>
+			</DataTable.Header>
+		),
+		cell: ({ row }) => (
+			<DataTable.Cell className="w-10">
+				<Checkbox
+					checked={row.getIsSelected()}
+					onCheckedChange={(value) => row.toggleSelected(value === true)}
+					aria-label="Select row"
+				/>
+			</DataTable.Cell>
+		),
+	}),
+	// ... data columns
+];
+
+function SelectableTable({ data }: { data: Payment[] }) {
+	const [rowSelection, setRowSelection] = useState({});
+	const table = useReactTable({
+		data,
+		columns,
+		getCoreRowModel: getCoreRowModel(),
+		state: { rowSelection },
+		onRowSelectionChange: setRowSelection,
+		enableRowSelection: true,
+	});
+
+	const selectedRows = table.getSelectedRowModel().rows;
+
+	return (
+		<DataTable.Root table={table}>
+			<DataTable.Head />
+			<DataTable.Body>
+				{table.getRowModel().rows.map((row) => (
+					<DataTable.Row key={row.id} row={row} />
+				))}
+			</DataTable.Body>
+		</DataTable.Root>
+	);
+}
+```
+
 ## API Reference
 
-The `DataTable` components are built on top of [TanStack Table](https://tanstack.com/table/latest/docs/introduction). All TanStack Table utilities (`createColumnHelper`, `getCoreRowModel`, `getSortedRowModel`, etc.) are re-exported from `@ngrok/mantle/data-table`.
+The `DataTable` components are built on top of [TanStack Table](https://tanstack.com/table/latest/docs/introduction). All TanStack Table utilities (`createColumnHelper`, `getCoreRowModel`, `getSortedRowModel`, `getPaginationRowModel`, `getFilteredRowModel`, `useReactTable`, etc.) are re-exported from `@ngrok/mantle/data-table`.
 
 ### DataTable.Root
 
-The root container for the data table. Wraps all other DataTable sub-components and provides the table context.
+The root container for the data table. Wraps all other `DataTable` sub-components and provides the table context. Delegates rendering to [`Table.Root`](/components/table#tableroot).
 
-| Prop    | Type                   | Default | Description                            |
-| :------ | :--------------------- | :------ | :------------------------------------- |
-| `table` | `TableInstance<TData>` |         | The TanStack Table instance to render. |
-
-All additional props from [Table.Root](/components/table).
+| Prop         | Type                   | Default | Description                                                                          |
+| :----------- | :--------------------- | :------ | :----------------------------------------------------------------------------------- |
+| `table`      | `TableInstance<TData>` |         | The TanStack Table instance returned from `useReactTable`. **Required.**             |
+| `children`   | `ReactNode`            |         | Typically `DataTable.Head` and `DataTable.Body`.                                     |
+| `className?` | `string`               |         | Extra classes merged onto the wrapper. Remaining props forward to the wrapper `div`. |
 
 ### DataTable.Head
 
-Automatically renders column headers from the table instance. Does not accept children.
+Automatically renders column headers from the table instance by iterating `table.getHeaderGroups()`. Does not accept children — the headers come from each column's `header` definition.
 
-All props from the HTML `thead` element.
+| Prop         | Type     | Default | Description                                                                                     |
+| :----------- | :------- | :------ | :---------------------------------------------------------------------------------------------- |
+| `className?` | `string` |         | Extra classes merged onto the `<thead>`. Remaining props forward to the HTML `<thead>` element. |
 
 ### DataTable.Body
 
-The table body container for rows of data.
+The `<tbody>` container for rows of data. Typically wraps a map of `DataTable.Row` or a fallback `DataTable.EmptyRow`.
 
-All props from the HTML `tbody` element.
+| Prop         | Type        | Default | Description                                                                                     |
+| :----------- | :---------- | :------ | :---------------------------------------------------------------------------------------------- |
+| `children`   | `ReactNode` |         | `DataTable.Row` elements, or a `DataTable.EmptyRow` when there is no data.                      |
+| `className?` | `string`    |         | Extra classes merged onto the `<tbody>`. Remaining props forward to the HTML `<tbody>` element. |
 
 ### DataTable.Row
 
-Renders a single data row using the column definitions from the table instance.
+Renders a single body row using the column definitions from the table instance. Does not accept children — cells come from each column's `cell` definition.
 
-| Prop  | Type              | Default | Description                                |
-| :---- | :---------------- | :------ | :----------------------------------------- |
-| `row` | `TableRow<TData>` |         | The TanStack Table row instance to render. |
+When `onClick` is provided, the row automatically receives `cursor-pointer`. Pass a different `cursor-*` class via `className` (for example, `cursor-wait`) to override.
 
-All additional props from the HTML `tr` element.
+| Prop         | Type                                               | Default | Description                                                                                        |
+| :----------- | :------------------------------------------------- | :------ | :------------------------------------------------------------------------------------------------- |
+| `row`        | `TableRow<TData>`                                  |         | The TanStack Table row instance to render. **Required.**                                           |
+| `onClick?`   | `(event: MouseEvent<HTMLTableRowElement>) => void` |         | Fires when the row is clicked. Applying this auto-adds `cursor-pointer`.                           |
+| `className?` | `string`                                           |         | Extra classes merged onto the `<tr>`. A `cursor-*` class here overrides the auto `cursor-pointer`. |
+
+Remaining props forward to the HTML `<tr>` element.
 
 ### DataTable.EmptyRow
 
-An empty state row that spans all columns. Use when there is no data to display.
+An empty-state row that spans every column. Render this as the `else` branch when `rows.length === 0` to keep the table's frame intact.
 
-All props from the HTML `tr` element.
+| Prop         | Type        | Default | Description                                                                               |
+| :----------- | :---------- | :------ | :---------------------------------------------------------------------------------------- |
+| `children`   | `ReactNode` |         | The empty-state content (e.g. a centered "No results" message).                           |
+| `className?` | `string`    |         | Extra classes merged onto the `<tr>`. Remaining props forward to the HTML `<tr>` element. |
 
 ### DataTable.Header
 
-A header cell component optimized for data table header actions.
+A `<th>` cell optimized for header actions. Wrap sortable headers' contents in `DataTable.HeaderSortButton`.
 
-All props from [Table.Header](/components/table).
+| Prop         | Type        | Default | Description                                                                               |
+| :----------- | :---------- | :------ | :---------------------------------------------------------------------------------------- |
+| `children`   | `ReactNode` |         | Usually a `DataTable.HeaderSortButton`. For non-sortable columns, plain text is fine.     |
+| `className?` | `string`    |         | Extra classes merged onto the `<th>`. Remaining props forward to the HTML `<th>` element. |
 
 ### DataTable.HeaderSortButton
 
-A sortable button toggle for column headers. Clicking cycles through sort directions.
+A sortable button toggle for column headers. Clicking cycles through sort directions: `unsorted → asc → desc → unsorted` for `"alphanumeric"`, and `unsorted → desc → asc → unsorted` (newest-first) for `"time"`. Renders a sort icon that reflects the current direction.
 
-| Prop              | Type                                          | Default | Description                         |
-| :---------------- | :-------------------------------------------- | :------ | :---------------------------------- |
-| `column`          | `Column<TData, TValue>`                       |         | The TanStack Table column instance. |
-| `sortingMode`     | `"alphanumeric" \| "time"`                    |         | The sorting mode of the column.     |
-| `disableSorting?` | `boolean`                                     | `false` | Disable sorting for this column.    |
-| `sortIcon?`       | `(sortDirection: SortDirection) => ReactNode` |         | Custom sort icon override.          |
-| `iconPlacement?`  | `"start" \| "end"`                            | `"end"` | The side the sort icon renders on.  |
+| Prop              | Type                                             | Default | Description                                                                                                                             |
+| :---------------- | :----------------------------------------------- | :------ | :-------------------------------------------------------------------------------------------------------------------------------------- |
+| `column`          | `Column<TData, TValue>`                          |         | The TanStack Table column instance (from `props.column` in `header`). **Required.**                                                     |
+| `sortingMode`     | `"alphanumeric" \| "time"`                       |         | Which direction sequence to cycle through. **Required** unless `disableSorting` is `true`.                                              |
+| `disableSorting?` | `boolean`                                        | `false` | Prevents sorting and hides the sort icon. Makes `sortingMode` unnecessary.                                                              |
+| `sortIcon?`       | `(sortDirection: SortDirection) => ReactNode`    |         | Override the default sort icon. `sortDirection` is `"asc" \| "desc" \| "unsorted"`.                                                     |
+| `iconPlacement?`  | `"start" \| "end"`                               | `"end"` | The side the sort icon renders on. Use `"start"` for right-aligned numeric columns.                                                     |
+| `onClick?`        | `(event: MouseEvent<HTMLButtonElement>) => void` |         | Called before the sort toggles. Call `event.preventDefault()` to skip the toggle.                                                       |
+| `className?`      | `string`                                         |         | Extra classes merged onto the underlying [`Button`](/components/button) — for example, `justify-end` for right-aligned numeric columns. |
 
-All additional props from [Button](/components/button).
+All additional props from [`Button`](/components/button).
 
 ### DataTable.Cell
 
-A table cell component for rendering individual data cells.
+A `<td>` for rendering individual data cells. Provides mantle typography, padding, and alignment. Re-exported from [`Table.Cell`](/components/table#tablecell).
 
-All props from [Table.Cell](/components/table).
-
-### DataTable.ActionCell
-
-A sticky action cell positioned at the end of each row for action buttons.
-
-All props from [Table.Cell](/components/table).
+| Prop         | Type        | Default | Description                                                                               |
+| :----------- | :---------- | :------ | :---------------------------------------------------------------------------------------- |
+| `children`   | `ReactNode` |         | The cell's rendered value. Any React node is allowed.                                     |
+| `className?` | `string`    |         | Extra classes merged onto the `<td>`. Remaining props forward to the HTML `<td>` element. |
 
 ### DataTable.ActionHeader
 
-A sticky header cell that pairs with `DataTable.ActionCell`. Use this as the
-header for the action column so the pinned column stays visually aligned
-across the header and every body row when the table scrolls horizontally.
+A sticky-right `<th>` that pairs with `DataTable.ActionCell`. Use as the `header` for your action column so the pinned column stays aligned across the header and every body row when the table scrolls horizontally. Automatically opts out of stickiness when the table is empty so the scroll-fade shows correctly.
 
-All props from [Table.Header](/components/table).
+| Prop         | Type        | Default | Description                                                                               |
+| :----------- | :---------- | :------ | :---------------------------------------------------------------------------------------- |
+| `children?`  | `ReactNode` |         | Header content. Usually empty for action columns.                                         |
+| `className?` | `string`    |         | Extra classes merged onto the `<th>`. Remaining props forward to the HTML `<th>` element. |
+
+### DataTable.ActionCell
+
+A sticky-right `<td>` for per-row action buttons (typically an `IconButton` that opens a `DropdownMenu`).
+
+When the row has an `onClick`, pass `onClick={(event) => event.stopPropagation()}` on the action cell so clicks on controls inside do not bubble and trigger the row handler.
+
+| Prop         | Type                                                | Default | Description                                                                               |
+| :----------- | :-------------------------------------------------- | :------ | :---------------------------------------------------------------------------------------- |
+| `children`   | `ReactNode`                                         |         | The row's action controls.                                                                |
+| `onClick?`   | `(event: MouseEvent<HTMLTableCellElement>) => void` |         | Use with `event.stopPropagation()` to prevent bubbling to a clickable row.                |
+| `className?` | `string`                                            |         | Extra classes merged onto the `<td>`. Remaining props forward to the HTML `<td>` element. |

--- a/apps/www/app/docs/components/table.mdx
+++ b/apps/www/app/docs/components/table.mdx
@@ -89,6 +89,13 @@ export const ExampleTable = () => {
 
 A structured way to display data in rows and columns.
 
+## When to use
+
+`Table` is the thin, semantic primitive for static tabular content — invoice summaries, pricing matrices, reference tables in documentation. Rows and cells render exactly what you put in them; there is no sorting, filtering, selection, or pagination built in.
+
+- Prefer [`DataTable`](/components/data-table) for dynamic, application data — anywhere users need to sort, filter, paginate, select, or click rows. `DataTable` is built on top of `Table` and powered by [TanStack Table](https://tanstack.com/table/latest/docs/introduction).
+- Use `Table` directly only when your data is static and none of those behaviors apply.
+
 <Example className="gap-2">
 	<ExampleTable />
 </Example>

--- a/apps/www/app/features/data-table-demo.tsx
+++ b/apps/www/app/features/data-table-demo.tsx
@@ -90,7 +90,7 @@ const columns = [
 		id: "actions",
 		header: () => <DataTable.ActionHeader />,
 		cell: () => (
-			<DataTable.ActionCell>
+			<DataTable.ActionCell onClick={(event) => event.stopPropagation()}>
 				<DropdownMenu.Root>
 					<DropdownMenu.Trigger asChild>
 						<IconButton
@@ -142,7 +142,6 @@ export function PaymentsDemo() {
 				{rows.length > 0 ? (
 					rows.map((row) => (
 						<DataTable.Row
-							className="cursor-pointer"
 							key={row.id}
 							onClick={() => {
 								window.alert(`Clicked payment row: ${row.original.id}`);
@@ -407,7 +406,7 @@ export function EmptyPaymentsDemo() {
 			<DataTable.Head />
 			<DataTable.Body>
 				{rows.length > 0 ? (
-					rows.map((row) => <DataTable.Row className="cursor-pointer" key={row.id} row={row} />)
+					rows.map((row) => <DataTable.Row key={row.id} row={row} />)
 				) : (
 					<DataTable.EmptyRow>
 						<p className="flex items-center justify-center min-h-20">No results.</p>

--- a/apps/www/app/features/icons-explorer.tsx
+++ b/apps/www/app/features/icons-explorer.tsx
@@ -66,7 +66,7 @@ export function IconsExplorer() {
 }
 
 function ListItem({ item }: { item: IconData }) {
-	const [, copyToClipboard] = useCopyToClipboard();
+	const copyToClipboard = useCopyToClipboard();
 	const [wasCopied, setWasCopied] = useState(false);
 	const timeoutHandle = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
 	const copyText = `import { ${item.name} } from "@ngrok/mantle/icons";`;

--- a/packages/mantle/src/components/code-block/code-block.tsx
+++ b/packages/mantle/src/components/code-block/code-block.tsx
@@ -520,7 +520,7 @@ type CodeBlockCopyButtonProps = Omit<ComponentProps<"button">, "children" | "typ
 const CopyButton = forwardRef<ComponentRef<"button">, CodeBlockCopyButtonProps>(
 	({ className, onCopy, onCopyError, onClick, ...props }, ref) => {
 		const { copyTextRef } = useCodeBlockContext();
-		const [, copyToClipboard] = useCopyToClipboard();
+		const copyToClipboard = useCopyToClipboard();
 		const [wasCopied, setWasCopied] = useState(false);
 		const timeoutHandle = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
 

--- a/packages/mantle/src/components/data-table/data-table.test.tsx
+++ b/packages/mantle/src/components/data-table/data-table.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import { userEvent } from "@testing-library/user-event";
+import type { ComponentProps } from "react";
 import invariant from "tiny-invariant";
 import { describe, expect, test, vi } from "vitest";
 import { DataTable, createColumnHelper, getCoreRowModel, useReactTable } from "./index.js";
@@ -16,7 +17,7 @@ const columns = [
 ];
 const data: Row[] = [{ id: "row-1", name: "Alice" }];
 
-function Harness(props: Omit<React.ComponentProps<typeof DataTable.Row>, "row">) {
+function Harness(props: Omit<ComponentProps<typeof DataTable.Row>, "row">) {
 	const table = useReactTable({
 		data,
 		columns,

--- a/packages/mantle/src/components/data-table/data-table.test.tsx
+++ b/packages/mantle/src/components/data-table/data-table.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import invariant from "tiny-invariant";
+import { describe, expect, test, vi } from "vitest";
+import { DataTable, createColumnHelper, getCoreRowModel, useReactTable } from "./index.js";
+
+type Row = { id: string; name: string };
+
+const columnHelper = createColumnHelper<Row>();
+const columns = [
+	columnHelper.accessor("name", {
+		id: "name",
+		header: () => <DataTable.Header>Name</DataTable.Header>,
+		cell: (props) => <DataTable.Cell>{props.getValue()}</DataTable.Cell>,
+	}),
+];
+const data: Row[] = [{ id: "row-1", name: "Alice" }];
+
+function Harness(props: Omit<React.ComponentProps<typeof DataTable.Row>, "row">) {
+	const table = useReactTable({
+		data,
+		columns,
+		getCoreRowModel: getCoreRowModel(),
+	});
+	const row = table.getRowModel().rows[0];
+	invariant(row, "Harness expected at least one row");
+	return (
+		<DataTable.Root table={table}>
+			<DataTable.Body>
+				<DataTable.Row data-testid="row" row={row} {...props} />
+			</DataTable.Body>
+		</DataTable.Root>
+	);
+}
+
+describe("DataTable.Row", () => {
+	test("applies `cursor-pointer` when `onClick` is provided", () => {
+		render(<Harness onClick={() => {}} />);
+		expect(screen.getByTestId("row")).toHaveClass("cursor-pointer");
+	});
+
+	test("does not apply `cursor-pointer` when no `onClick` is provided", () => {
+		render(<Harness />);
+		expect(screen.getByTestId("row")).not.toHaveClass("cursor-pointer");
+	});
+
+	test("invokes `onClick` when the row is clicked", async () => {
+		const user = userEvent.setup();
+		const handleClick = vi.fn();
+		render(<Harness onClick={handleClick} />);
+
+		await user.click(screen.getByTestId("row"));
+
+		expect(handleClick).toHaveBeenCalledTimes(1);
+	});
+
+	test("consumer `className` takes precedence over the auto `cursor-pointer`", () => {
+		render(<Harness onClick={() => {}} className="cursor-wait" />);
+		const row = screen.getByTestId("row");
+		expect(row).toHaveClass("cursor-wait");
+		expect(row).not.toHaveClass("cursor-pointer");
+	});
+});

--- a/packages/mantle/src/components/data-table/data-table.tsx
+++ b/packages/mantle/src/components/data-table/data-table.tsx
@@ -49,19 +49,25 @@ type DataTableProps<TData> = ComponentProps<typeof Table.Root> & {
 };
 
 /**
- * A data table component that provides sorting and other data table functionality.
- * Built on top of TanStack Table for advanced table features.
+ * The root container for a data table. Wraps all other `DataTable`
+ * sub-components and provides the table context via the `table` instance
+ * returned from `useReactTable`. Built on top of TanStack Table.
  *
  * @see https://mantle.ngrok.com/components/data-table#datatableroot
  *
  * @example
  * ```tsx
- * <DataTable table={table}>
+ * const table = useReactTable({ data, columns, getCoreRowModel: getCoreRowModel() });
+ * const rows = table.getRowModel().rows;
+ *
+ * <DataTable.Root table={table}>
  *   <DataTable.Head />
  *   <DataTable.Body>
- *     <DataTable.Rows />
+ *     {rows.length > 0
+ *       ? rows.map((row) => <DataTable.Row key={row.id} row={row} />)
+ *       : <DataTable.EmptyRow>No results.</DataTable.EmptyRow>}
  *   </DataTable.Body>
- * </DataTable>
+ * </DataTable.Root>
  * ```
  */
 function Root<TData>({ children, table, ...props }: DataTableProps<TData>) {
@@ -111,25 +117,33 @@ type DataTableHeaderSortButtonProps<TData, TValue> = Omit<ComponentProps<typeof 
 	);
 
 /**
- * A sortable button toggle for a column header in a data table.
- * If the column is sortable, clicking the button will toggle the sorting
- * direction.
+ * A sortable button toggle for a column header in a data table. Renders a sort
+ * icon that reflects the current direction, handles ARIA announcements, and
+ * cycles through sort states on click.
+ *
+ * Each click cycles through:
+ * - For `"alphanumeric"` sorting: `unsorted → ascending → descending → unsorted`
+ * - For `"time"` sorting: `unsorted → newest-first → oldest-first → unsorted`
+ *
+ * For right-aligned numeric columns, pass `className="justify-end"` and
+ * `iconPlacement="start"` so the sort icon stays paired with the label.
  *
  * @see https://mantle.ngrok.com/components/data-table#datatableheadersortbutton
  *
  * @example
  * ```tsx
- * <DataTable.HeaderSortButton
- *   column={column}
- *   sortingMode="alphanumeric"
- * >
- *   Column Title
- * </DataTable.HeaderSortButton>
+ * columnHelper.accessor("email", {
+ *   id: "email",
+ *   header: (props) => (
+ *     <DataTable.Header>
+ *       <DataTable.HeaderSortButton column={props.column} sortingMode="alphanumeric">
+ *         Email
+ *       </DataTable.HeaderSortButton>
+ *     </DataTable.Header>
+ *   ),
+ *   cell: (props) => <DataTable.Cell>{props.getValue()}</DataTable.Cell>,
+ * });
  * ```
- *
- * Each click cycles through:
- * - For alphanumeric sorting: unsorted ➡️ ascending ➡️ descending ➡️ unsorted
- * - For time sorting: unsorted ➡️ newest-to-oldest ➡️ oldest-to-newest ➡️ unsorted
  */
 function HeaderSortButton<TData, TValue>({
 	children,
@@ -197,18 +211,25 @@ function HeaderSortButton<TData, TValue>({
 type DataTableHeaderProps = ComponentProps<typeof Table.Header>;
 
 /**
- * A header for a data table.
- * This is typically used to wrap the `DataTable.HeaderSortButton` component.
+ * A `<th>` optimized for header actions. Wrap each column's header content in
+ * this; for sortable columns, nest a `DataTable.HeaderSortButton` inside.
+ * Non-sortable columns can render plain text.
  *
  * @see https://mantle.ngrok.com/components/data-table#datatableheader
  *
  * @example
  * ```tsx
- * <DataTable.Header>
- *   <DataTable.HeaderSortButton column={column} sortingMode="alphanumeric">
- *     Column Title
- *   </DataTable.HeaderSortButton>
- * </DataTable.Header>
+ * columnHelper.accessor("name", {
+ *   id: "name",
+ *   header: (props) => (
+ *     <DataTable.Header>
+ *       <DataTable.HeaderSortButton column={props.column} sortingMode="alphanumeric">
+ *         Name
+ *       </DataTable.HeaderSortButton>
+ *     </DataTable.Header>
+ *   ),
+ *   cell: (props) => <DataTable.Cell>{props.getValue()}</DataTable.Cell>,
+ * });
  * ```
  */
 function Header({ children, className, ...props }: DataTableHeaderProps) {
@@ -257,9 +278,37 @@ type DataTableRowProps<TData> = Omit<ComponentProps<typeof Table.Row>, "children
 	row: TableRow<TData>;
 };
 
-function Row<TData>({ row, ...props }: DataTableRowProps<TData>) {
+/**
+ * A single data table body row rendered from a TanStack Table row instance.
+ * Does not accept children — cells come from each column's `cell` definition.
+ *
+ * When `onClick` is provided, the row automatically receives `cursor-pointer`.
+ * Pass a different `cursor-*` class via `className` (e.g. `cursor-default`,
+ * `cursor-wait`) to override. For keyboard and screen-reader access, also
+ * render a `<Link>` inside the primary cell — a `<tr>` is not focusable.
+ *
+ * @see https://mantle.ngrok.com/components/data-table#datatablerow
+ *
+ * @example
+ * ```tsx
+ * const navigate = useNavigate();
+ *
+ * {rows.map((row) => (
+ *   <DataTable.Row
+ *     key={row.id}
+ *     row={row}
+ *     onClick={() => navigate(href("/payments/:id", { id: row.original.id }))}
+ *   />
+ * ))}
+ * ```
+ */
+function Row<TData>({ className, row, ...props }: DataTableRowProps<TData>) {
 	return (
-		<Table.Row data-slot="data-table-row" {...props}>
+		<Table.Row
+			data-slot="data-table-row"
+			className={cx(props.onClick && "cursor-pointer", className)}
+			{...props}
+		>
 			{row.getVisibleCells().map((cell) => (
 				<Fragment key={cell.id}>
 					{flexRender(cell.column.columnDef.cell, cell.getContext())}
@@ -314,6 +363,29 @@ function StickyColIndicator() {
 
 type DataTableActionCellProps = ComponentProps<typeof Table.Cell>;
 
+/**
+ * A sticky-right `<td>` for per-row action buttons (typically an `IconButton`
+ * that opens a `DropdownMenu`). Pair with `DataTable.ActionHeader`.
+ *
+ * If the row has `onClick`, pass `onClick={(event) => event.stopPropagation()}`
+ * on this cell so clicks on action controls don't bubble and fire the row
+ * handler.
+ *
+ * @see https://mantle.ngrok.com/components/data-table#datatableactioncell
+ *
+ * @example
+ * ```tsx
+ * columnHelper.display({
+ *   id: "actions",
+ *   header: () => <DataTable.ActionHeader />,
+ *   cell: () => (
+ *     <DataTable.ActionCell onClick={(event) => event.stopPropagation()}>
+ *       <DropdownMenu.Root>...</DropdownMenu.Root>
+ *     </DataTable.ActionCell>
+ *   ),
+ * });
+ * ```
+ */
 function ActionCell({ children, className, ...props }: DataTableActionCellProps) {
 	return (
 		<Table.Cell
@@ -391,8 +463,14 @@ HeaderSortButton.displayName = "DataTableHeaderSortButton";
 Row.displayName = "DataTableRow";
 
 /**
- * A data table component that provides sorting and other data table functionality.
- * Built on top of TanStack Table for advanced table features.
+ * A data table for dynamic, application data — sortable, filterable, paginatable,
+ * and selectable. Built on top of TanStack Table; every TanStack utility
+ * (`createColumnHelper`, `getCoreRowModel`, `getSortedRowModel`,
+ * `getPaginationRowModel`, `getFilteredRowModel`, `useReactTable`, …) is
+ * re-exported from `@ngrok/mantle/data-table`.
+ *
+ * Prefer the plain `Table` when content is static and none of those behaviors
+ * apply.
  *
  * @see https://mantle.ngrok.com/components/data-table
  *
@@ -414,12 +492,45 @@ Row.displayName = "DataTableRow";
  *
  * @example
  * ```tsx
- * <DataTable table={table}>
- *   <DataTable.Head />
- *   <DataTable.Body>
- *     <DataTable.Rows />
- *   </DataTable.Body>
- * </DataTable>
+ * import {
+ *   DataTable,
+ *   createColumnHelper,
+ *   getCoreRowModel,
+ *   useReactTable,
+ * } from "@ngrok/mantle/data-table";
+ *
+ * type Row = { id: string; name: string };
+ *
+ * const columnHelper = createColumnHelper<Row>();
+ * const columns = [
+ *   columnHelper.accessor("name", {
+ *     id: "name",
+ *     header: (props) => (
+ *       <DataTable.Header>
+ *         <DataTable.HeaderSortButton column={props.column} sortingMode="alphanumeric">
+ *           Name
+ *         </DataTable.HeaderSortButton>
+ *       </DataTable.Header>
+ *     ),
+ *     cell: (props) => <DataTable.Cell>{props.getValue()}</DataTable.Cell>,
+ *   }),
+ * ];
+ *
+ * function MyTable({ data }: { data: Row[] }) {
+ *   const table = useReactTable({ data, columns, getCoreRowModel: getCoreRowModel() });
+ *   const rows = table.getRowModel().rows;
+ *
+ *   return (
+ *     <DataTable.Root table={table}>
+ *       <DataTable.Head />
+ *       <DataTable.Body>
+ *         {rows.length > 0
+ *           ? rows.map((row) => <DataTable.Row key={row.id} row={row} />)
+ *           : <DataTable.EmptyRow>No results.</DataTable.EmptyRow>}
+ *       </DataTable.Body>
+ *     </DataTable.Root>
+ *   );
+ * }
  * ```
  */
 const DataTable = {
@@ -430,32 +541,47 @@ const DataTable = {
 	 *
 	 * @example
 	 * ```tsx
+	 * const table = useReactTable({ data, columns, getCoreRowModel: getCoreRowModel() });
+	 * const rows = table.getRowModel().rows;
+	 *
 	 * <DataTable.Root table={table}>
 	 *   <DataTable.Head />
 	 *   <DataTable.Body>
-	 *     <DataTable.Rows />
+	 *     {rows.length > 0
+	 *       ? rows.map((row) => <DataTable.Row key={row.id} row={row} />)
+	 *       : <DataTable.EmptyRow>No results.</DataTable.EmptyRow>}
 	 *   </DataTable.Body>
 	 * </DataTable.Root>
 	 * ```
 	 */
 	Root,
 	/**
-	 * A sticky action cell positioned at the end of each row for action buttons.
+	 * A sticky action cell positioned at the end of each row, typically holding
+	 * an `IconButton` that opens a `DropdownMenu`. Pair with `DataTable.ActionHeader`.
+	 *
+	 * If the row has `onClick`, stop propagation on this cell so clicks on action
+	 * controls don't bubble up and fire the row handler.
 	 *
 	 * @see https://mantle.ngrok.com/components/data-table#datatableactioncell
 	 *
 	 * @example
 	 * ```tsx
-	 * <DataTable.ActionCell>
-	 *   <Button size="sm">Edit</Button>
-	 *   <Button size="sm">Delete</Button>
-	 * </DataTable.ActionCell>
+	 * columnHelper.display({
+	 *   id: "actions",
+	 *   header: () => <DataTable.ActionHeader />,
+	 *   cell: () => (
+	 *     <DataTable.ActionCell onClick={(event) => event.stopPropagation()}>
+	 *       <DropdownMenu.Root>...</DropdownMenu.Root>
+	 *     </DataTable.ActionCell>
+	 *   ),
+	 * });
 	 * ```
 	 */
 	ActionCell,
 	/**
 	 * A sticky header cell that pairs with `DataTable.ActionCell`, keeping the
 	 * action column aligned across the header and body when scrolling horizontally.
+	 * Use as the `header` for a `columnHelper.display` action column.
 	 *
 	 * @see https://mantle.ngrok.com/components/data-table#datatableactionheader
 	 *
@@ -464,100 +590,151 @@ const DataTable = {
 	 * columnHelper.display({
 	 *   id: "actions",
 	 *   header: () => <DataTable.ActionHeader />,
-	 *   cell: () => <DataTable.ActionCell>{...}</DataTable.ActionCell>,
-	 * })
+	 *   cell: () => (
+	 *     <DataTable.ActionCell onClick={(event) => event.stopPropagation()}>
+	 *       <DropdownMenu.Root>...</DropdownMenu.Root>
+	 *     </DataTable.ActionCell>
+	 *   ),
+	 * });
 	 * ```
 	 */
 	ActionHeader,
 	/**
-	 * A table cell component for rendering individual data cells.
+	 * A `<td>` for rendering an individual data cell. Re-exported from
+	 * `Table.Cell`. Every cell rendered by a column's `cell` function should
+	 * be wrapped in this — a raw `<td>` skips mantle typography and padding.
 	 *
 	 * @see https://mantle.ngrok.com/components/data-table#datatablecell
 	 *
 	 * @example
 	 * ```tsx
-	 * <DataTable.Cell>
-	 *   Cell content
-	 * </DataTable.Cell>
+	 * columnHelper.accessor("name", {
+	 *   id: "name",
+	 *   header: (props) => <DataTable.Header>Name</DataTable.Header>,
+	 *   cell: (props) => <DataTable.Cell>{props.getValue()}</DataTable.Cell>,
+	 * });
 	 * ```
 	 */
 	Cell: Table.Cell,
 	/**
-	 * The table body container for rows of data.
+	 * The `<tbody>` container for rows of data. Typically wraps a map of
+	 * `DataTable.Row`, with a `DataTable.EmptyRow` fallback when there is
+	 * no data.
 	 *
 	 * @see https://mantle.ngrok.com/components/data-table#datatablebody
 	 *
 	 * @example
 	 * ```tsx
 	 * <DataTable.Body>
-	 *   <DataTable.Rows />
+	 *   {rows.length > 0
+	 *     ? rows.map((row) => <DataTable.Row key={row.id} row={row} />)
+	 *     : <DataTable.EmptyRow>No results.</DataTable.EmptyRow>}
 	 * </DataTable.Body>
 	 * ```
 	 */
 	Body,
 	/**
-	 * An empty state row that spans all columns when there's no data to display.
+	 * An empty-state row that spans every column. Render this as the `else`
+	 * branch when `rows.length === 0` to keep the table's frame intact instead
+	 * of collapsing to an empty `<tbody>`.
 	 *
 	 * @see https://mantle.ngrok.com/components/data-table#datatableemptyrow
 	 *
 	 * @example
 	 * ```tsx
-	 * <DataTable.EmptyRow>
-	 *   No data available
-	 * </DataTable.EmptyRow>
+	 * <DataTable.Body>
+	 *   {rows.length > 0
+	 *     ? rows.map((row) => <DataTable.Row key={row.id} row={row} />)
+	 *     : <DataTable.EmptyRow>No results.</DataTable.EmptyRow>}
+	 * </DataTable.Body>
 	 * ```
 	 */
 	EmptyRow,
 	/**
-	 * The table header container that renders column headers automatically.
+	 * The `<thead>` container that renders column headers automatically from
+	 * `table.getHeaderGroups()`. Does not accept children — headers come from
+	 * each column's `header` definition.
 	 *
 	 * @see https://mantle.ngrok.com/components/data-table#datatablehead
 	 *
 	 * @example
 	 * ```tsx
-	 * <DataTable.Head />
+	 * <DataTable.Root table={table}>
+	 *   <DataTable.Head />
+	 *   <DataTable.Body>...</DataTable.Body>
+	 * </DataTable.Root>
 	 * ```
 	 */
 	Head,
 	/**
-	 * A header cell component optimized for data table header actions.
+	 * A `<th>` optimized for header actions. Wrap each column's header content
+	 * in this; for sortable columns, nest a `DataTable.HeaderSortButton` inside.
 	 *
 	 * @see https://mantle.ngrok.com/components/data-table#datatableheader
 	 *
 	 * @example
 	 * ```tsx
-	 * <DataTable.Header>
-	 *   <DataTable.HeaderSortButton column={column} sortingMode="alphanumeric">
-	 *     Column Title
-	 *   </DataTable.HeaderSortButton>
-	 * </DataTable.Header>
+	 * columnHelper.accessor("name", {
+	 *   id: "name",
+	 *   header: (props) => (
+	 *     <DataTable.Header>
+	 *       <DataTable.HeaderSortButton column={props.column} sortingMode="alphanumeric">
+	 *         Name
+	 *       </DataTable.HeaderSortButton>
+	 *     </DataTable.Header>
+	 *   ),
+	 *   cell: (props) => <DataTable.Cell>{props.getValue()}</DataTable.Cell>,
+	 * });
 	 * ```
 	 */
 	Header,
 	/**
-	 * A sortable button toggle for column headers with sorting functionality.
+	 * A sortable button toggle for a column header. Clicks cycle through
+	 * sort directions: for `"alphanumeric"`, `unsorted → asc → desc → unsorted`;
+	 * for `"time"`, `unsorted → desc (newest-first) → asc → unsorted`.
+	 *
+	 * Pass `className="justify-end"` and `iconPlacement="start"` for
+	 * right-aligned numeric columns so the sort icon stays paired with the label.
 	 *
 	 * @see https://mantle.ngrok.com/components/data-table#datatableheadersortbutton
 	 *
 	 * @example
 	 * ```tsx
-	 * <DataTable.HeaderSortButton
-	 *   column={column}
-	 *   sortingMode="alphanumeric"
-	 * >
-	 *   Column Title
-	 * </DataTable.HeaderSortButton>
+	 * columnHelper.accessor("email", {
+	 *   id: "email",
+	 *   header: (props) => (
+	 *     <DataTable.Header>
+	 *       <DataTable.HeaderSortButton column={props.column} sortingMode="alphanumeric">
+	 *         Email
+	 *       </DataTable.HeaderSortButton>
+	 *     </DataTable.Header>
+	 *   ),
+	 *   cell: (props) => <DataTable.Cell>{props.getValue()}</DataTable.Cell>,
+	 * });
 	 * ```
 	 */
 	HeaderSortButton,
 	/**
-	 * A single data table row component for rendering custom row layouts.
+	 * A single data table body row rendered from a TanStack Table row instance.
+	 * Does not accept children — cells come from each column's `cell` definition.
+	 *
+	 * When `onClick` is provided, the row automatically receives `cursor-pointer`.
+	 * Pass a different `cursor-*` class via `className` to override. For keyboard
+	 * and screen-reader access, also render a `<Link>` inside the primary cell.
 	 *
 	 * @see https://mantle.ngrok.com/components/data-table#datatablerow
 	 *
 	 * @example
 	 * ```tsx
-	 * <DataTable.Row row={row} />
+	 * const navigate = useNavigate();
+	 *
+	 * {rows.map((row) => (
+	 *   <DataTable.Row
+	 *     key={row.id}
+	 *     row={row}
+	 *     onClick={() => navigate(href("/payments/:id", { id: row.original.id }))}
+	 *   />
+	 * ))}
 	 * ```
 	 */
 	Row,

--- a/packages/mantle/src/hooks/use-copy-to-clipboard.browser.test.tsx
+++ b/packages/mantle/src/hooks/use-copy-to-clipboard.browser.test.tsx
@@ -16,7 +16,7 @@ describe("useCopyToClipboard (browser)", () => {
 	});
 
 	test("writes the value to navigator.clipboard", async () => {
-		const writeTextSpy = vi.spyOn(navigator.clipboard, "writeText");
+		const writeTextSpy = vi.spyOn(navigator.clipboard, "writeText").mockResolvedValue(undefined);
 
 		const { result } = renderHook(() => useCopyToClipboard());
 		const copyToClipboard = result.current;
@@ -31,7 +31,7 @@ describe("useCopyToClipboard (browser)", () => {
 	});
 
 	test("calls writeText with the most recently copied value", async () => {
-		const writeTextSpy = vi.spyOn(navigator.clipboard, "writeText");
+		const writeTextSpy = vi.spyOn(navigator.clipboard, "writeText").mockResolvedValue(undefined);
 
 		const { result } = renderHook(() => useCopyToClipboard());
 		const copyToClipboard = result.current;
@@ -88,7 +88,7 @@ describe("useCopyToClipboard (browser)", () => {
 	});
 
 	test("awaiting copyToClipboard resolves after the clipboard write completes", async () => {
-		const writeTextSpy = vi.spyOn(navigator.clipboard, "writeText");
+		const writeTextSpy = vi.spyOn(navigator.clipboard, "writeText").mockResolvedValue(undefined);
 
 		const { result } = renderHook(() => useCopyToClipboard());
 		const copyToClipboard = result.current;

--- a/packages/mantle/src/hooks/use-copy-to-clipboard.browser.test.tsx
+++ b/packages/mantle/src/hooks/use-copy-to-clipboard.browser.test.tsx
@@ -1,60 +1,52 @@
-import { act, renderHook, waitFor } from "@testing-library/react";
+import { act, renderHook } from "@testing-library/react";
 import { describe, expect, test, vi } from "vitest";
 import { useCopyToClipboard } from "./use-copy-to-clipboard.js";
 
 describe("useCopyToClipboard (browser)", () => {
-	test("initial state is an empty string", () => {
+	test("returns an async copy function", () => {
 		const { result } = renderHook(() => useCopyToClipboard());
-		const [state] = result.current;
-		expect(state).toBe("");
+		expect(typeof result.current).toBe("function");
 	});
 
-	test("updates state to the copied value", async () => {
-		const { result } = renderHook(() => useCopyToClipboard());
-		const [, copyToClipboard] = result.current;
-
-		act(() => {
-			copyToClipboard("hello clipboard");
-		});
-
-		await waitFor(() => {
-			const [state] = result.current;
-			expect(state).toBe("hello clipboard");
-		});
+	test("returns a stable reference across renders", () => {
+		const { result, rerender } = renderHook(() => useCopyToClipboard());
+		const first = result.current;
+		rerender();
+		expect(result.current).toBe(first);
 	});
 
 	test("writes the value to navigator.clipboard", async () => {
+		const writeTextSpy = vi.spyOn(navigator.clipboard, "writeText");
+
 		const { result } = renderHook(() => useCopyToClipboard());
-		const [, copyToClipboard] = result.current;
+		const copyToClipboard = result.current;
 
-		act(() => {
-			copyToClipboard("written to clipboard");
+		await act(async () => {
+			await copyToClipboard("written to clipboard");
 		});
 
-		await waitFor(async () => {
-			// Chromium grants clipboard-write by default in Playwright — read it back to verify
-			const text = await navigator.clipboard.readText();
-			expect(text).toBe("written to clipboard");
-		});
+		expect(writeTextSpy).toHaveBeenCalledWith("written to clipboard");
+
+		vi.restoreAllMocks();
 	});
 
-	test("state reflects the most recently copied value", async () => {
+	test("calls writeText with the most recently copied value", async () => {
+		const writeTextSpy = vi.spyOn(navigator.clipboard, "writeText");
+
 		const { result } = renderHook(() => useCopyToClipboard());
-		const [, copyToClipboard] = result.current;
+		const copyToClipboard = result.current;
 
-		act(() => {
-			copyToClipboard("first value");
+		await act(async () => {
+			await copyToClipboard("first value");
 		});
-		await waitFor(() => {
-			expect(result.current[0]).toBe("first value");
+		await act(async () => {
+			await copyToClipboard("second value");
 		});
 
-		act(() => {
-			copyToClipboard("second value");
-		});
-		await waitFor(() => {
-			expect(result.current[0]).toBe("second value");
-		});
+		expect(writeTextSpy).toHaveBeenNthCalledWith(1, "first value");
+		expect(writeTextSpy).toHaveBeenNthCalledWith(2, "second value");
+
+		vi.restoreAllMocks();
 	});
 
 	test("polyfill removes the textarea from the DOM even when select() throws", async () => {
@@ -66,7 +58,7 @@ describe("useCopyToClipboard (browser)", () => {
 		});
 
 		const { result } = renderHook(() => useCopyToClipboard());
-		const [, copyToClipboard] = result.current;
+		const copyToClipboard = result.current;
 
 		await act(async () => {
 			await expect(copyToClipboard("cleanup test")).rejects.toThrow("clipboard unavailable");
@@ -78,43 +70,39 @@ describe("useCopyToClipboard (browser)", () => {
 	});
 
 	test("falls back to the polyfill when clipboard.writeText is unavailable", async () => {
-		// Simulate an environment where the Clipboard API is missing.
-		// The hook catches the error and calls the execCommand polyfill, then still sets state.
 		vi.spyOn(navigator.clipboard, "writeText").mockRejectedValueOnce(
 			new Error("clipboard unavailable"),
 		);
+		const execCommandSpy = vi.spyOn(document, "execCommand").mockImplementationOnce(() => true);
 
 		const { result } = renderHook(() => useCopyToClipboard());
-		const [, copyToClipboard] = result.current;
+		const copyToClipboard = result.current;
 
-		act(() => {
-			copyToClipboard("polyfill value");
+		await act(async () => {
+			await copyToClipboard("polyfill value");
 		});
 
-		// State should still update via the polyfill path
-		await waitFor(() => {
-			expect(result.current[0]).toBe("polyfill value");
-		});
+		expect(execCommandSpy).toHaveBeenCalledWith("copy");
 
 		vi.restoreAllMocks();
 	});
 
 	test("awaiting copyToClipboard resolves after the clipboard write completes", async () => {
+		const writeTextSpy = vi.spyOn(navigator.clipboard, "writeText");
+
 		const { result } = renderHook(() => useCopyToClipboard());
-		const [, copyToClipboard] = result.current;
+		const copyToClipboard = result.current;
 
 		await act(async () => {
 			await copyToClipboard("awaited value");
 		});
 
-		// State is already updated by the time the promise resolves — no waitFor needed
-		expect(result.current[0]).toBe("awaited value");
+		expect(writeTextSpy).toHaveBeenCalledWith("awaited value");
 
-		const text = await navigator.clipboard.readText();
-		expect(text).toBe("awaited value");
+		vi.restoreAllMocks();
 	});
 
-	test("state is not updated when both clipboard API and polyfill fail", async () => {
+	test("throws when both clipboard API and polyfill fail", async () => {
 		vi.spyOn(navigator.clipboard, "writeText").mockRejectedValueOnce(
 			new Error("clipboard unavailable"),
 		);
@@ -123,14 +111,11 @@ describe("useCopyToClipboard (browser)", () => {
 		});
 
 		const { result } = renderHook(() => useCopyToClipboard());
-		const [, copyToClipboard] = result.current;
+		const copyToClipboard = result.current;
 
 		await act(async () => {
-			await expect(copyToClipboard("should not persist")).rejects.toThrow();
+			await expect(copyToClipboard("should throw")).rejects.toThrow("clipboard unavailable");
 		});
-
-		// State stays at the initial empty string since both paths failed
-		expect(result.current[0]).toBe("");
 
 		vi.restoreAllMocks();
 	});

--- a/packages/mantle/src/hooks/use-copy-to-clipboard.tsx
+++ b/packages/mantle/src/hooks/use-copy-to-clipboard.tsx
@@ -1,50 +1,15 @@
-import { useCallback, useState } from "react";
+import { copyToClipboard } from "../utils/copy-to-clipboard.js";
 
 /**
- * A hook that allows you to copy a string to the clipboard.
+ * A hook that returns an async function to copy a string to the clipboard.
  *
- * The returned `copyToClipboard` function is async — `await` it to know
- * whether the write succeeded. It throws when both the Clipboard API and
- * the `execCommand` polyfill fail.
+ * `await` the returned function to know whether the write succeeded. It
+ * throws when both the Clipboard API and the `execCommand` polyfill fail.
  *
  * Inspired by: https://usehooks.com/usecopytoclipboard
  */
 function useCopyToClipboard() {
-	const [state, setState] = useState<string>("");
-
-	const copyToClipboard = useCallback(async (value: string) => {
-		try {
-			if (typeof window.navigator?.clipboard?.writeText === "function") {
-				await navigator.clipboard.writeText(value);
-			} else {
-				throw new Error("writeText not supported");
-			}
-		} catch (clipboardError) {
-			try {
-				copyToClipboardPolyfill(value);
-			} catch {
-				throw clipboardError; // both approaches failed; propagate
-			}
-		}
-		setState(value);
-	}, []);
-
-	return [state, copyToClipboard] as const;
+	return copyToClipboard;
 }
 
 export { useCopyToClipboard };
-
-/**
- * A fallback copy to clipboard function for older browsers.
- */
-function copyToClipboardPolyfill(text: string) {
-	const tempTextArea = document.createElement("textarea");
-	tempTextArea.value = text;
-	document.body.appendChild(tempTextArea);
-	try {
-		tempTextArea.select();
-		document.execCommand("copy");
-	} finally {
-		document.body.removeChild(tempTextArea);
-	}
-}

--- a/packages/mantle/src/utils/compose-refs/compose-refs.tsx
+++ b/packages/mantle/src/utils/compose-refs/compose-refs.tsx
@@ -8,12 +8,12 @@ type PossibleRef<T> = Ref<T> | undefined;
  * Accepts callback refs and RefObject(s)
  */
 function composeRefs<T>(...refs: PossibleRef<T>[]) {
-	return (node: T) => {
+	return (node: T | null) => {
 		for (const ref of refs) {
 			if (typeof ref === "function") {
 				ref(node);
 			} else if (ref != null) {
-				(ref as MutableRefObject<T>).current = node;
+				(ref as MutableRefObject<T | null>).current = node;
 			}
 		}
 	};
@@ -26,12 +26,12 @@ function composeRefs<T>(...refs: PossibleRef<T>[]) {
 function useComposedRefs<T>(...refs: PossibleRef<T>[]) {
 	const latestRefs = useRef(refs);
 	latestRefs.current = refs;
-	return useCallback((node: T) => {
+	return useCallback((node: T | null) => {
 		for (const ref of latestRefs.current) {
 			if (typeof ref === "function") {
 				ref(node);
 			} else if (ref != null) {
-				(ref as MutableRefObject<T>).current = node;
+				(ref as MutableRefObject<T | null>).current = node;
 			}
 		}
 	}, []);

--- a/packages/mantle/src/utils/compose-refs/compose-refs.tsx
+++ b/packages/mantle/src/utils/compose-refs/compose-refs.tsx
@@ -1,5 +1,5 @@
 import type { MutableRefObject, Ref } from "react";
-import { useCallback } from "react";
+import { useCallback, useRef } from "react";
 
 type PossibleRef<T> = Ref<T> | undefined;
 
@@ -24,7 +24,17 @@ function composeRefs<T>(...refs: PossibleRef<T>[]) {
  * Accepts callback refs and RefObject(s)
  */
 function useComposedRefs<T>(...refs: PossibleRef<T>[]) {
-	return useCallback(() => composeRefs(...refs), [refs]);
+	const latestRefs = useRef(refs);
+	latestRefs.current = refs;
+	return useCallback((node: T) => {
+		for (const ref of latestRefs.current) {
+			if (typeof ref === "function") {
+				ref(node);
+			} else if (ref != null) {
+				(ref as MutableRefObject<T>).current = node;
+			}
+		}
+	}, []);
 }
 
 export { composeRefs, useComposedRefs };

--- a/packages/mantle/src/utils/copy-to-clipboard.ts
+++ b/packages/mantle/src/utils/copy-to-clipboard.ts
@@ -1,0 +1,41 @@
+/**
+ * Copy the given string to the clipboard. Uses the Clipboard API when
+ * available and falls back to an `execCommand("copy")` polyfill for older
+ * browsers.
+ *
+ * Throws when both approaches fail — `await` the call to observe success.
+ */
+async function copyToClipboard(value: string) {
+	try {
+		if (typeof window.navigator?.clipboard?.writeText === "function") {
+			await navigator.clipboard.writeText(value);
+		} else {
+			throw new Error("writeText not supported");
+		}
+	} catch (clipboardError) {
+		try {
+			copyToClipboardPolyfill(value);
+		} catch {
+			throw clipboardError; // both approaches failed; propagate
+		}
+	}
+}
+
+/**
+ * A fallback copy to clipboard function for older browsers that lack the
+ * Clipboard API. Creates a temporary `<textarea>`, selects it, and invokes
+ * the deprecated `document.execCommand("copy")` API.
+ */
+function copyToClipboardPolyfill(text: string) {
+	const tempTextArea = document.createElement("textarea");
+	tempTextArea.value = text;
+	document.body.appendChild(tempTextArea);
+	try {
+		tempTextArea.select();
+		document.execCommand("copy");
+	} finally {
+		document.body.removeChild(tempTextArea);
+	}
+}
+
+export { copyToClipboard };

--- a/packages/mantle/src/utils/copy-to-clipboard.ts
+++ b/packages/mantle/src/utils/copy-to-clipboard.ts
@@ -1,13 +1,19 @@
+import { canUseDOM } from "../components/browser-only/browser-only.js";
+
 /**
  * Copy the given string to the clipboard. Uses the Clipboard API when
  * available and falls back to an `execCommand("copy")` polyfill for older
  * browsers.
  *
- * Throws when both approaches fail — `await` the call to observe success.
+ * Throws when called outside a DOM environment, or when both the Clipboard
+ * API and the polyfill fail — `await` the call to observe success.
  */
 async function copyToClipboard(value: string) {
+	if (!canUseDOM()) {
+		throw new Error("copyToClipboard requires a DOM environment");
+	}
 	try {
-		if (typeof window.navigator?.clipboard?.writeText === "function") {
+		if (typeof navigator.clipboard?.writeText === "function") {
 			await navigator.clipboard.writeText(value);
 		} else {
 			throw new Error("writeText not supported");
@@ -25,6 +31,9 @@ async function copyToClipboard(value: string) {
  * A fallback copy to clipboard function for older browsers that lack the
  * Clipboard API. Creates a temporary `<textarea>`, selects it, and invokes
  * the deprecated `document.execCommand("copy")` API.
+ *
+ * Throws when `execCommand("copy")` returns `false` (the call failed but
+ * did not throw) so the caller can fall through to another strategy.
  */
 function copyToClipboardPolyfill(text: string) {
 	const tempTextArea = document.createElement("textarea");
@@ -32,7 +41,10 @@ function copyToClipboardPolyfill(text: string) {
 	document.body.appendChild(tempTextArea);
 	try {
 		tempTextArea.select();
-		document.execCommand("copy");
+		const copied = document.execCommand("copy");
+		if (!copied) {
+			throw new Error('document.execCommand("copy") failed');
+		}
 	} finally {
 		document.body.removeChild(tempTextArea);
 	}

--- a/packages/mantle/src/utils/index.ts
+++ b/packages/mantle/src/utils/index.ts
@@ -1,3 +1,5 @@
+export { copyToClipboard } from "./copy-to-clipboard.js";
+
 export { inView } from "./in-view.js";
 export type { InViewOptions, MarginType, ViewChangeHandler } from "./in-view.js";
 


### PR DESCRIPTION
- DataTable.Row now auto-applies `cursor-pointer` when `onClick` is provided; override by passing a different `cursor-*` via `className`. Includes tests and updated docs/demo.

- useCopyToClipboard no longer tracks an internal `[state, copyFn]` tuple — it returns the async copy function directly, eliminating an extra render per successful copy. The underlying implementation moved to `utils/copy-to-clipboard.ts` and is re-exported from `@ngrok/mantle/utils`. Call sites in code-block, icons-explorer, hash-link-heading, and doc-actions updated. Breaking return-shape change; patch bump per changeset policy.

- useComposedRefs previously returned a thunk `() => (node) => void` instead of a ref callback, so the composed ref never received the DOM node. Now returns a stable ref callback backed by a latest-refs ref box, avoiding ref thrashing across renders.