### PR TITLE
otp-input: add validation prop for error/success/warning states

### DIFF
--- a/.changeset/otp-input-validation.md
+++ b/.changeset/otp-input-validation.md
@@ -2,6 +2,6 @@
 "@ngrok/mantle": patch
 ---
 
-`OtpInput.Root` now accepts a `validation` prop (`"error" | "success" | "warning" | false`, or a function returning one). When set, every slot's borders and the active focus ring are recolored with the matching validation hue, mirroring the styling contract of `Input`. `validation="error"` additionally sets `aria-invalid` on the underlying input so assistive tech announces the failure state.
+`OtpInput.Root` now accepts a `validation` prop (`"error" | "success" | "warning" | false`, or a function returning one). When set, each group's outer borders and the active focus ring are recolored with the matching validation hue, mirroring the styling contract of `Input`. `validation="error"` additionally sets `aria-invalid` on the underlying input so assistive tech announces the failure state.
 
 Internal: `ProgressDonut` now uses the `$cssProperties` helper for inline CSS-variable styles instead of an `as CSSProperties` cast — no behavior change.

--- a/.changeset/otp-input-validation.md
+++ b/.changeset/otp-input-validation.md
@@ -3,3 +3,5 @@
 ---
 
 `OtpInput.Root` now accepts a `validation` prop (`"error" | "success" | "warning" | false`, or a function returning one). When set, every slot's borders and the active focus ring are recolored with the matching validation hue, mirroring the styling contract of `Input`. `validation="error"` additionally sets `aria-invalid` on the underlying input so assistive tech announces the failure state.
+
+Internal: `ProgressDonut` now uses the `$cssProperties` helper for inline CSS-variable styles instead of an `as CSSProperties` cast — no behavior change.

--- a/.changeset/otp-input-validation.md
+++ b/.changeset/otp-input-validation.md
@@ -1,0 +1,5 @@
+---
+"@ngrok/mantle": patch
+---
+
+`OtpInput.Root` now accepts a `validation` prop (`"error" | "success" | "warning" | false`, or a function returning one). When set, every slot's borders and the active focus ring are recolored with the matching validation hue, mirroring the styling contract of `Input`. `validation="error"` additionally sets `aria-invalid` on the underlying input so assistive tech announces the failure state.

--- a/apps/www/app/docs/components/otp-input.mdx
+++ b/apps/www/app/docs/components/otp-input.mdx
@@ -133,6 +133,65 @@ Pass `disabled` to the root to disable the entire input.
 </OtpInput.Root>
 ```
 
+## Validation
+
+Pass `validation="error"`, `"success"`, or `"warning"` on `OtpInput.Root` to
+recolor every slot's borders and the active focus ring with the matching
+validation hue. `validation="error"` also sets `aria-invalid` on the
+underlying input so assistive tech announces the failure state.
+
+`validation` may be a literal value or a function that returns a value — the
+function form is convenient for short-circuiting from form-library state, e.g.
+`validation={field.state.meta.errors.length > 0 && "error"}`.
+
+<Example className="flex-col gap-4">
+	<OtpInput.Root maxLength={6} validation="error">
+		<OtpInput.Group>
+			<OtpInput.Slot index={0} />
+			<OtpInput.Slot index={1} />
+			<OtpInput.Slot index={2} />
+		</OtpInput.Group>
+		<OtpInput.Separator />
+		<OtpInput.Group>
+			<OtpInput.Slot index={3} />
+			<OtpInput.Slot index={4} />
+			<OtpInput.Slot index={5} />
+		</OtpInput.Group>
+	</OtpInput.Root>
+	<OtpInput.Root maxLength={6} validation="success">
+		<OtpInput.Group>
+			<OtpInput.Slot index={0} />
+			<OtpInput.Slot index={1} />
+			<OtpInput.Slot index={2} />
+		</OtpInput.Group>
+		<OtpInput.Separator />
+		<OtpInput.Group>
+			<OtpInput.Slot index={3} />
+			<OtpInput.Slot index={4} />
+			<OtpInput.Slot index={5} />
+		</OtpInput.Group>
+	</OtpInput.Root>
+	<OtpInput.Root maxLength={6} validation="warning">
+		<OtpInput.Group>
+			<OtpInput.Slot index={0} />
+			<OtpInput.Slot index={1} />
+			<OtpInput.Slot index={2} />
+		</OtpInput.Group>
+		<OtpInput.Separator />
+		<OtpInput.Group>
+			<OtpInput.Slot index={3} />
+			<OtpInput.Slot index={4} />
+			<OtpInput.Slot index={5} />
+		</OtpInput.Group>
+	</OtpInput.Root>
+</Example>
+
+```tsx
+<OtpInput.Root maxLength={6} validation="error">
+	{/* ... */}
+</OtpInput.Root>
+```
+
 ## Polymorphism
 
 `OtpInput.Group` and `OtpInput.Separator` accept an `asChild` prop. When `true`,
@@ -188,17 +247,18 @@ parts via context.
 
 All props from the underlying [`OTPInput`](https://github.com/guilhermerodz/input-otp#api-reference) component, including standard `input` props, plus:
 
-| Prop                           | Type                            | Default  | Description                                                               |
-| ------------------------------ | ------------------------------- | -------- | ------------------------------------------------------------------------- |
-| `maxLength`                    | `number`                        | —        | The total number of character slots. Required.                            |
-| `value?`                       | `string`                        | —        | Controlled value.                                                         |
-| `onChange?`                    | `(value: string) => void`       | —        | Fired when the value changes.                                             |
-| `onComplete?`                  | `(value: string) => void`       | —        | Fired when the user fills the final slot.                                 |
-| `pattern?`                     | `string`                        | —        | Regex source restricting accepted characters (e.g. `REGEXP_ONLY_DIGITS`). |
-| `textAlign?`                   | `"left" \| "center" \| "right"` | `"left"` | Caret alignment within the hidden input.                                  |
-| `containerClassName?`          | `string`                        | —        | Class applied to the slot container element.                              |
-| `pasteTransformer?`            | `(pasted: string) => string`    | —        | Transform pasted text before it is consumed.                              |
-| `pushPasswordManagerStrategy?` | `"increase-width" \| "none"`    | —        | Strategy to push password-manager badges out of the way.                  |
+| Prop                           | Type                             | Default  | Description                                                               |
+| ------------------------------ | -------------------------------- | -------- | ------------------------------------------------------------------------- |
+| `maxLength`                    | `number`                         | —        | The total number of character slots. Required.                            |
+| `value?`                       | `string`                         | —        | Controlled value.                                                         |
+| `onChange?`                    | `(value: string) => void`        | —        | Fired when the value changes.                                             |
+| `onComplete?`                  | `(value: string) => void`        | —        | Fired when the user fills the final slot.                                 |
+| `pattern?`                     | `string`                         | —        | Regex source restricting accepted characters (e.g. `REGEXP_ONLY_DIGITS`). |
+| `textAlign?`                   | `"left" \| "center" \| "right"`  | `"left"` | Caret alignment within the hidden input.                                  |
+| `containerClassName?`          | `string`                         | —        | Class applied to the slot container element.                              |
+| `pasteTransformer?`            | `(pasted: string) => string`     | —        | Transform pasted text before it is consumed.                              |
+| `pushPasswordManagerStrategy?` | `"increase-width" \| "none"`     | —        | Strategy to push password-manager badges out of the way.                  |
+| `validation?`                  | `Validation \| () => Validation` | —        | Validation state. `"error"` also sets `aria-invalid` on the input.        |
 
 ### OtpInput.Group
 

--- a/apps/www/app/docs/components/otp-input.mdx
+++ b/apps/www/app/docs/components/otp-input.mdx
@@ -136,12 +136,13 @@ Pass `disabled` to the root to disable the entire input.
 ## Validation
 
 Pass `validation="error"`, `"success"`, or `"warning"` on `OtpInput.Root` to
-recolor every slot's borders and the active focus ring with the matching
+recolor each group's outer borders and the active focus ring with the matching
 validation hue. `validation="error"` also sets `aria-invalid` on the
 underlying input so assistive tech announces the failure state.
 
-`validation` may be a literal value or a function that returns a value — the
-function form is convenient for short-circuiting from form-library state, e.g.
+`validation` may be a literal value or a function that returns a value. Since
+the prop also accepts `false`, form-library state can short-circuit validation
+styling, e.g.
 `validation={field.state.meta.errors.length > 0 && "error"}`.
 
 <Example className="flex-col gap-4">

--- a/packages/mantle/src/components/otp-input/otp-input.browser.test.tsx
+++ b/packages/mantle/src/components/otp-input/otp-input.browser.test.tsx
@@ -20,6 +20,12 @@ type RenderOtpProps = {
 	onChange?: (value: string) => void;
 	onComplete?: (value: string) => void;
 	pasteTransformer?: (pasted: string) => string;
+	validation?:
+		| "error"
+		| "success"
+		| "warning"
+		| false
+		| (() => "error" | "success" | "warning" | false);
 };
 
 function renderOtp(props: RenderOtpProps = {}) {
@@ -293,6 +299,57 @@ describe("OtpInput (browser)", () => {
 			const customGroup = screen.getByTestId("custom-group");
 			expect(customGroup.tagName).toBe("SECTION");
 			expect(customGroup).toHaveAttribute("data-slot", "otp-input-group");
+		});
+	});
+
+	describe("validation", () => {
+		test("no validation prop leaves data-validation unset on the bridge and aria-invalid unset on the input", () => {
+			const { input } = renderOtp();
+
+			const bridge = document.querySelector("[data-otp-state]");
+			expect(bridge).not.toBeNull();
+			expect(bridge).not.toHaveAttribute("data-validation");
+			expect(input).not.toHaveAttribute("aria-invalid");
+		});
+
+		test("validation='error' sets data-validation=error on the bridge and aria-invalid on the input", () => {
+			const { input } = renderOtp({ validation: "error" });
+
+			const bridge = document.querySelector("[data-otp-state]");
+			expect(bridge).toHaveAttribute("data-validation", "error");
+			expect(input).toHaveAttribute("aria-invalid", "true");
+		});
+
+		test("validation='success' sets data-validation=success and does NOT mark aria-invalid", () => {
+			const { input } = renderOtp({ validation: "success" });
+
+			const bridge = document.querySelector("[data-otp-state]");
+			expect(bridge).toHaveAttribute("data-validation", "success");
+			expect(input).not.toHaveAttribute("aria-invalid");
+		});
+
+		test("validation='warning' sets data-validation=warning and does NOT mark aria-invalid", () => {
+			const { input } = renderOtp({ validation: "warning" });
+
+			const bridge = document.querySelector("[data-otp-state]");
+			expect(bridge).toHaveAttribute("data-validation", "warning");
+			expect(input).not.toHaveAttribute("aria-invalid");
+		});
+
+		test("validation as a function is resolved and applied", () => {
+			const { input } = renderOtp({ validation: () => "error" });
+
+			const bridge = document.querySelector("[data-otp-state]");
+			expect(bridge).toHaveAttribute("data-validation", "error");
+			expect(input).toHaveAttribute("aria-invalid", "true");
+		});
+
+		test("validation={false} is treated as no validation", () => {
+			const { input } = renderOtp({ validation: false });
+
+			const bridge = document.querySelector("[data-otp-state]");
+			expect(bridge).not.toHaveAttribute("data-validation");
+			expect(input).not.toHaveAttribute("aria-invalid");
 		});
 	});
 

--- a/packages/mantle/src/components/otp-input/otp-input.browser.test.tsx
+++ b/packages/mantle/src/components/otp-input/otp-input.browser.test.tsx
@@ -14,6 +14,7 @@ import { OtpInput, REGEXP_ONLY_DIGITS } from "./otp-input.js";
 // type is a discriminated union (render | children) which doesn't compose
 // cleanly with `Partial<>`. The runtime contract is the same.
 type RenderOtpProps = {
+	"aria-invalid"?: boolean | "true" | "false" | "grammar" | "spelling";
 	maxLength?: number;
 	disabled?: boolean;
 	pattern?: string;
@@ -334,6 +335,14 @@ describe("OtpInput (browser)", () => {
 			const bridge = document.querySelector("[data-otp-state]");
 			expect(bridge).toHaveAttribute("data-validation", "warning");
 			expect(input).not.toHaveAttribute("aria-invalid");
+		});
+
+		test("aria-invalid='true' forces data-validation=error with non-error validation", () => {
+			const { input } = renderOtp({ "aria-invalid": "true", validation: "success" });
+
+			const bridge = document.querySelector("[data-otp-state]");
+			expect(bridge).toHaveAttribute("data-validation", "error");
+			expect(input).toHaveAttribute("aria-invalid", "true");
 		});
 
 		test("validation as a function is resolved and applied", () => {

--- a/packages/mantle/src/components/otp-input/otp-input.tsx
+++ b/packages/mantle/src/components/otp-input/otp-input.tsx
@@ -13,6 +13,26 @@ import type { Validation, WithValidation } from "../input/types.js";
 type OtpState = "idle" | "caret" | "range" | "all";
 
 /**
+ * The color token name (`danger` / `success` / `warning`) that backs each
+ * validation value. The `Validation` vocabulary (`"error"` / `"success"` /
+ * `"warning"`) doesn't exactly match the color-token vocabulary — the
+ * `error` validation maps to the `danger` color hue.
+ */
+type ValidationHue = "danger" | "success" | "warning";
+
+const validationHues = {
+	error: "danger",
+	success: "success",
+	warning: "warning",
+} as const satisfies Record<Exclude<Validation, false>, ValidationHue>;
+
+const validationBorderColor = <T extends ValidationHue = ValidationHue>(hue: T) =>
+	`var(--color-${hue}-600)`;
+
+const validationRingColor = <T extends ValidationHue = ValidationHue>(hue: T) =>
+	`var(--ring-color-focus-${hue})`;
+
+/**
  * Map the count of active slots to a discrete `data-otp-state` value used by
  * descendant CSS selectors. Split out from the rendering component so the
  * decision tree reads as a flat `if`/`else` chain rather than a nested
@@ -69,11 +89,12 @@ const MantleOtpBridge = ({
 	// slot/group classes reference these vars instead of having one
 	// branch per validation value. When no validation is set, the vars
 	// are left undefined and the validation utilities (gated on
-	// `group-data-[validation]`) don't apply.
-	const validationStyle = validation
+	// `group-data-validation`) don't apply.
+	const hue = validation ? validationHues[validation] : undefined;
+	const validationStyle = hue
 		? $cssProperties({
-				"--otp-validation-border": `var(--color-${validation}-600)`,
-				"--otp-validation-ring": `var(--ring-color-focus-${validation})`,
+				"--otp-validation-border": validationBorderColor(hue),
+				"--otp-validation-ring": validationRingColor(hue),
 			})
 		: undefined;
 

--- a/packages/mantle/src/components/otp-input/otp-input.tsx
+++ b/packages/mantle/src/components/otp-input/otp-input.tsx
@@ -5,6 +5,7 @@ import { OTPInput, OTPInputContext } from "input-otp";
 import type { ComponentProps, ComponentRef, ReactNode } from "react";
 import { forwardRef, useContext } from "react";
 import type { WithAsChild } from "../../types/as-child.js";
+import { $cssProperties } from "../../types/index.js";
 import { cx } from "../../utils/cx/cx.js";
 import { Slot as AsChildSlot } from "../slot/index.js";
 import type { Validation, WithValidation } from "../input/types.js";
@@ -64,6 +65,18 @@ const MantleOtpBridge = ({
 	);
 	const otpState = computeOtpState({ totalActive, total });
 
+	// Map the validation hue to two CSS custom properties — descendant
+	// slot/group classes reference these vars instead of having one
+	// branch per validation value. When no validation is set, the vars
+	// are left undefined and the validation utilities (gated on
+	// `group-data-[validation]`) don't apply.
+	const validationStyle = validation
+		? $cssProperties({
+				"--otp-validation-border": `var(--color-${validation}-600)`,
+				"--otp-validation-ring": `var(--ring-color-focus-${validation})`,
+			})
+		: undefined;
+
 	// `display: contents` keeps this element in the DOM tree (so `group/`
 	// ancestor selectors resolve) without producing a layout box.
 	return (
@@ -71,6 +84,7 @@ const MantleOtpBridge = ({
 			className="group/otp contents"
 			data-otp-state={otpState}
 			data-validation={validation || undefined}
+			style={validationStyle}
 		>
 			{children}
 		</div>
@@ -198,13 +212,11 @@ const Group = forwardRef<HTMLDivElement, OtpInputGroupProps>(
 					// another active slot at the same nesting level, the
 					// group has at least 2 actives → draw the ring.
 					"has-[[data-active]~[data-active]]:ring-focus-accent has-[[data-active]~[data-active]]:ring-4",
-					// Validation overrides for the group-level range/all ring.
-					// When the parent root has a validation state set, recolor
-					// the multi-active ring so the validation feedback wins
-					// over the default accent focus ring.
-					"group-data-[validation=error]/otp:has-[[data-active]~[data-active]]:ring-focus-danger",
-					"group-data-[validation=success]/otp:has-[[data-active]~[data-active]]:ring-focus-success",
-					"group-data-[validation=warning]/otp:has-[[data-active]~[data-active]]:ring-focus-warning",
+					// Validation override for the group-level range/all ring.
+					// `--otp-validation-ring` is set on the bridge based on
+					// the validation value, so a single class covers
+					// error/success/warning instead of one per hue.
+					"group-data-validation/otp:has-[[data-active]~[data-active]]:ring-(--otp-validation-ring)",
 					className,
 				)}
 				{...props}
@@ -307,25 +319,16 @@ const OtpInputSlotImpl = forwardRef<HTMLDivElement, OtpInputSlotProps>(
 					// `Input` tints the container border, not the internal
 					// elements. The all-state and caret-active overrides
 					// still recolor every border so a fully-active slot or
-					// select-all reads as a solid tinted box.
-					"group-data-[validation=error]/otp:border-y-danger-600",
-					"group-data-[validation=error]/otp:first:border-l-danger-600",
-					"group-data-[validation=error]/otp:last:border-r-danger-600",
-					"group-data-[validation=error]/otp:data-active:group-data-[otp-state=caret]/otp:border-danger-600",
-					"group-data-[validation=error]/otp:data-active:group-data-[otp-state=caret]/otp:ring-focus-danger",
-					"group-data-[validation=error]/otp:group-data-[otp-state=all]/otp:border-danger-600",
-					"group-data-[validation=success]/otp:border-y-success-600",
-					"group-data-[validation=success]/otp:first:border-l-success-600",
-					"group-data-[validation=success]/otp:last:border-r-success-600",
-					"group-data-[validation=success]/otp:data-active:group-data-[otp-state=caret]/otp:border-success-600",
-					"group-data-[validation=success]/otp:data-active:group-data-[otp-state=caret]/otp:ring-focus-success",
-					"group-data-[validation=success]/otp:group-data-[otp-state=all]/otp:border-success-600",
-					"group-data-[validation=warning]/otp:border-y-warning-600",
-					"group-data-[validation=warning]/otp:first:border-l-warning-600",
-					"group-data-[validation=warning]/otp:last:border-r-warning-600",
-					"group-data-[validation=warning]/otp:data-active:group-data-[otp-state=caret]/otp:border-warning-600",
-					"group-data-[validation=warning]/otp:data-active:group-data-[otp-state=caret]/otp:ring-focus-warning",
-					"group-data-[validation=warning]/otp:group-data-[otp-state=all]/otp:border-warning-600",
+					// select-all reads as a solid tinted box. The bridge
+					// sets `--otp-validation-{border,ring}` per validation
+					// value, so a single set of classes covers
+					// error/success/warning.
+					"group-data-validation/otp:border-y-(--otp-validation-border)",
+					"group-data-validation/otp:first:border-l-(--otp-validation-border)",
+					"group-data-validation/otp:last:border-r-(--otp-validation-border)",
+					"group-data-validation/otp:data-active:group-data-[otp-state=caret]/otp:border-(--otp-validation-border)",
+					"group-data-validation/otp:data-active:group-data-[otp-state=caret]/otp:ring-(--otp-validation-ring)",
+					"group-data-validation/otp:group-data-[otp-state=all]/otp:border-(--otp-validation-border)",
 					className,
 				)}
 				{...props}

--- a/packages/mantle/src/components/otp-input/otp-input.tsx
+++ b/packages/mantle/src/components/otp-input/otp-input.tsx
@@ -7,6 +7,7 @@ import { forwardRef, useContext } from "react";
 import type { WithAsChild } from "../../types/as-child.js";
 import { cx } from "../../utils/cx/cx.js";
 import { Slot as AsChildSlot } from "../slot/index.js";
+import type { Validation, WithValidation } from "../input/types.js";
 
 type OtpState = "idle" | "caret" | "range" | "all";
 
@@ -48,7 +49,13 @@ const computeOtpState = ({
  * - `"range"` — multiple but not all slots active (partial selection)
  * - `"all"` — every slot active (cmd+a / select-all)
  */
-const MantleOtpBridge = ({ children }: { children: ReactNode }) => {
+const MantleOtpBridge = ({
+	children,
+	validation,
+}: {
+	children: ReactNode;
+	validation?: Validation;
+}) => {
 	const inputOtpContext = useContext(OTPInputContext);
 	const total = inputOtpContext.slots.length;
 	const totalActive = inputOtpContext.slots.reduce(
@@ -60,7 +67,11 @@ const MantleOtpBridge = ({ children }: { children: ReactNode }) => {
 	// `display: contents` keeps this element in the DOM tree (so `group/`
 	// ancestor selectors resolve) without producing a layout box.
 	return (
-		<div className="group/otp contents" data-otp-state={otpState}>
+		<div
+			className="group/otp contents"
+			data-otp-state={otpState}
+			data-validation={validation || undefined}
+		>
 			{children}
 		</div>
 	);
@@ -70,9 +81,10 @@ const MantleOtpBridge = ({ children }: { children: ReactNode }) => {
 // union — `OtpInput.Root` always wraps its children in `MantleOtpBridge`,
 // so consumers compose with `OtpInput.Group` / `OtpInput.Slot` children
 // rather than a render prop.
-type OtpInputRootProps = Omit<ComponentProps<typeof OTPInput>, "render" | "children"> & {
-	children?: ReactNode;
-};
+type OtpInputRootProps = Omit<ComponentProps<typeof OTPInput>, "render" | "children"> &
+	WithValidation & {
+		children?: ReactNode;
+	};
 
 /**
  * The root of the OTP input. Renders an accessible single hidden input that
@@ -80,6 +92,11 @@ type OtpInputRootProps = Omit<ComponentProps<typeof OTPInput>, "render" | "child
  * (active, char, fake caret) to descendant `OtpInput.Slot` parts via context.
  *
  * Wraps the `input-otp` library by Guilherme Rodz.
+ *
+ * Pass `validation="error"` (or `"success"` / `"warning"`) to recolor every
+ * slot's borders and the active focus ring with the matching validation hue.
+ * `validation="error"` also sets `aria-invalid` on the underlying input so
+ * assistive tech announces the failure state.
  *
  * @see https://mantle.ngrok.com/components/otp-input
  *
@@ -104,10 +121,25 @@ type OtpInputRootProps = Omit<ComponentProps<typeof OTPInput>, "render" | "child
 // owns its hidden `<input>` and its render contract — swapping the element
 // would break input-otp's internal focus and selection management.
 const Root = forwardRef<ComponentRef<typeof OTPInput>, OtpInputRootProps>(
-	({ children, className, containerClassName, ...props }, ref) => {
+	(
+		{
+			"aria-invalid": ariaInvalid,
+			children,
+			className,
+			containerClassName,
+			validation: _validation,
+			...props
+		},
+		ref,
+	) => {
+		const validation =
+			(typeof _validation === "function" ? _validation() : _validation) || undefined;
+		const resolvedAriaInvalid = ariaInvalid ?? (validation === "error" || undefined);
+
 		return (
 			<OTPInput
 				ref={ref}
+				aria-invalid={resolvedAriaInvalid}
 				data-slot="otp-input"
 				containerClassName={cx(
 					"flex items-center gap-2 has-disabled:opacity-50",
@@ -116,7 +148,7 @@ const Root = forwardRef<ComponentRef<typeof OTPInput>, OtpInputRootProps>(
 				className={cx("disabled:cursor-not-allowed", className)}
 				{...props}
 			>
-				<MantleOtpBridge>{children}</MantleOtpBridge>
+				<MantleOtpBridge validation={validation}>{children}</MantleOtpBridge>
 			</OTPInput>
 		);
 	},
@@ -166,6 +198,13 @@ const Group = forwardRef<HTMLDivElement, OtpInputGroupProps>(
 					// another active slot at the same nesting level, the
 					// group has at least 2 actives → draw the ring.
 					"has-[[data-active]~[data-active]]:ring-focus-accent has-[[data-active]~[data-active]]:ring-4",
+					// Validation overrides for the group-level range/all ring.
+					// When the parent root has a validation state set, recolor
+					// the multi-active ring so the validation feedback wins
+					// over the default accent focus ring.
+					"group-data-[validation=error]/otp:has-[[data-active]~[data-active]]:ring-focus-danger",
+					"group-data-[validation=success]/otp:has-[[data-active]~[data-active]]:ring-focus-success",
+					"group-data-[validation=warning]/otp:has-[[data-active]~[data-active]]:ring-focus-warning",
 					className,
 				)}
 				{...props}
@@ -261,6 +300,32 @@ const OtpInputSlotImpl = forwardRef<HTMLDivElement, OtpInputSlotProps>(
 					// seamlessly while still keeping the slot grid
 					// readable at full opacity.
 					"group-data-[otp-state=all]/otp:border-accent-600",
+					// Validation overrides. Only the *outer* edges of the
+					// group are tinted (top + bottom on every slot, left on
+					// the first slot, right on the last slot) so adjacent
+					// slots still join with a neutral divider — matching how
+					// `Input` tints the container border, not the internal
+					// elements. The all-state and caret-active overrides
+					// still recolor every border so a fully-active slot or
+					// select-all reads as a solid tinted box.
+					"group-data-[validation=error]/otp:border-y-danger-600",
+					"group-data-[validation=error]/otp:first:border-l-danger-600",
+					"group-data-[validation=error]/otp:last:border-r-danger-600",
+					"group-data-[validation=error]/otp:data-active:group-data-[otp-state=caret]/otp:border-danger-600",
+					"group-data-[validation=error]/otp:data-active:group-data-[otp-state=caret]/otp:ring-focus-danger",
+					"group-data-[validation=error]/otp:group-data-[otp-state=all]/otp:border-danger-600",
+					"group-data-[validation=success]/otp:border-y-success-600",
+					"group-data-[validation=success]/otp:first:border-l-success-600",
+					"group-data-[validation=success]/otp:last:border-r-success-600",
+					"group-data-[validation=success]/otp:data-active:group-data-[otp-state=caret]/otp:border-success-600",
+					"group-data-[validation=success]/otp:data-active:group-data-[otp-state=caret]/otp:ring-focus-success",
+					"group-data-[validation=success]/otp:group-data-[otp-state=all]/otp:border-success-600",
+					"group-data-[validation=warning]/otp:border-y-warning-600",
+					"group-data-[validation=warning]/otp:first:border-l-warning-600",
+					"group-data-[validation=warning]/otp:last:border-r-warning-600",
+					"group-data-[validation=warning]/otp:data-active:group-data-[otp-state=caret]/otp:border-warning-600",
+					"group-data-[validation=warning]/otp:data-active:group-data-[otp-state=caret]/otp:ring-focus-warning",
+					"group-data-[validation=warning]/otp:group-data-[otp-state=all]/otp:border-warning-600",
 					className,
 				)}
 				{...props}

--- a/packages/mantle/src/components/otp-input/otp-input.tsx
+++ b/packages/mantle/src/components/otp-input/otp-input.tsx
@@ -128,8 +128,8 @@ type OtpInputRootProps = Omit<ComponentProps<typeof OTPInput>, "render" | "child
  *
  * Wraps the `input-otp` library by Guilherme Rodz.
  *
- * Pass `validation="error"` (or `"success"` / `"warning"`) to recolor every
- * slot's borders and the active focus ring with the matching validation hue.
+ * Pass `validation="error"` (or `"success"` / `"warning"`) to recolor each
+ * group's outer borders and the active focus ring with the matching validation hue.
  * `validation="error"` also sets `aria-invalid` on the underlying input so
  * assistive tech announces the failure state.
  *
@@ -167,8 +167,10 @@ const Root = forwardRef<ComponentRef<typeof OTPInput>, OtpInputRootProps>(
 		},
 		ref,
 	) => {
-		const validation =
-			(typeof _validation === "function" ? _validation() : _validation) || undefined;
+		const isInvalid = ariaInvalid != null && ariaInvalid !== "false";
+		const validation = isInvalid
+			? "error"
+			: (typeof _validation === "function" ? _validation() : _validation) || undefined;
 		const resolvedAriaInvalid = ariaInvalid ?? (validation === "error" || undefined);
 
 		return (

--- a/packages/mantle/src/components/progress/progress-donut.tsx
+++ b/packages/mantle/src/components/progress/progress-donut.tsx
@@ -1,6 +1,7 @@
 import clsx from "clsx";
 import { createContext, useContext, useId, useMemo } from "react";
-import type { CSSProperties, ComponentProps, HTMLAttributes } from "react";
+import type { ComponentProps, HTMLAttributes } from "react";
+import { $cssProperties } from "../../types/index.js";
 import { cx } from "../../utils/cx/cx.js";
 import { clamp, isNumber, isValidMaxNumber, isValidValueNumber } from "./math.js";
 import type { ValueType } from "./types.js";
@@ -151,7 +152,7 @@ const Root = ({
 					fill="transparent"
 					stroke="currentColor"
 					strokeWidth={strokeWidthPx}
-					style={{ "--radius": radius } as CSSProperties}
+					style={$cssProperties({ "--radius": radius })}
 				/>
 				{children}
 			</svg>
@@ -215,7 +216,7 @@ const Indicator = ({ className, ...props }: ProgressDonutIndicatorProps) => {
 				strokeDashoffset={100 - percentage}
 				strokeLinecap="round"
 				strokeWidth={strokeWidthPx}
-				style={{ "--radius": radius } as CSSProperties}
+				style={$cssProperties({ "--radius": radius })}
 				transform="rotate(-90)" // rotate -90 degrees so it starts from the top
 			/>
 		</g>


### PR DESCRIPTION
  Mirrors the styling contract of `Input` — recolors the group's outer
  borders and the active focus ring with the matching validation hue, and
  sets `aria-invalid` on the underlying input when validation="error".
  Internal slot dividers stay neutral so the group still reads as one box.