### PR TITLE
feat(label): default to font-medium when not wrapping a form control

### DIFF
--- a/.changeset/label-default-font-medium.md
+++ b/.changeset/label-default-font-medium.md
@@ -1,0 +1,7 @@
+---
+"@ngrok/mantle": patch
+---
+
+`Label` now defaults to `font-medium` when it doesn't wrap an interactive form control, and inherits weight when it does (e.g. `<Label><Input /></Label>`). The default is applied through a `:where()`-wrapped selector so the rule's total specificity is `(0,0,0)` — a user-supplied `font-bold` / `font-normal` / `font-semibold` overrides it cleanly without needing the `!` important modifier.
+
+Detection covers `<input>`, `<textarea>`, `<select>`, `<button>`, and `[contenteditable]` descendants, which transitively covers mantle's checkbox/radio (real `<input>`), select/multi-select/menu triggers (real `<button>`), and any third-party control built on those primitives. The `[contenteditable]` attribute selector would normally raise the rule's specificity to `(0,1,0)` and tie with a bare utility class — wrapping the whole selector in `:where()` flattens it back to `(0,0,0)` so user overrides still win.

--- a/apps/www/app/docs/components/input.mdx
+++ b/apps/www/app/docs/components/input.mdx
@@ -14,40 +14,58 @@ import { Example } from "~/components/example";
 Fundamental component for inputs.
 
 <Example className="flex flex-col gap-6">
-	<Label className="block w-full max-w-80 space-y-1">
-		<p>Username</p>
-		<Input placeholder="Enter a username" />
-	</Label>
-	<Label className="block w-full max-w-80 space-y-1">
-		<p>Email</p>
-		<Input placeholder="Enter your email" autoComplete="email" />
-	</Label>
+	<div className="flex w-full max-w-80 flex-col gap-1.5">
+		<Label htmlFor="input-username">Username</Label>
+		<Input placeholder="Enter a username" name="username" id="input-username" />
+	</div>
+	<div className="flex w-full max-w-80 flex-col gap-1.5">
+		<Label htmlFor="input-email">Email</Label>
+		<Input id="input-email" placeholder="Enter your email" autoComplete="email" />
+	</div>
 	<div className="w-full max-w-80 space-y-2">
-		<p>Validation States:</p>
+		<p className="font-medium">Validation States:</p>
 		<div className="flex w-full flex-col gap-6">
-			<Label className="space-y-1">
-				<p>Error</p>
-				<Input placeholder={'validation="error"'} validation="error" />
-			</Label>
-			<Label className="space-y-1">
-				<p>Success</p>
-				<Input placeholder={'validation="success"'} validation="success" />
-			</Label>
-			<Label className="space-y-1">
-				<p>Warning</p>
-				<Input placeholder={'validation="warning"'} validation="warning" />
-			</Label>
+			<div className="flex flex-col gap-1.5">
+				<Label htmlFor="input-error">Error</Label>
+				<Input id="input-error" placeholder={'validation="error"'} validation="error" />
+			</div>
+			<div className="flex flex-col gap-1.5">
+				<Label htmlFor="input-success">Success</Label>
+				<Input id="input-success" placeholder={'validation="success"'} validation="success" />
+			</div>
+			<div className="flex flex-col gap-1.5">
+				<Label htmlFor="input-warning">Warning</Label>
+				<Input id="input-warning" placeholder={'validation="warning"'} validation="warning" />
+			</div>
 		</div>
 	</div>
 </Example>
 
 ```tsx
 import { Input } from "@ngrok/mantle/input";
+import { Label } from "@ngrok/mantle/label";
 
-<Input placeholder="Enter a username" />
-<Input placeholder="Enter a username" validation="error" />
-<Input placeholder="Enter a username" validation="success" />
-<Input placeholder="Enter a username" validation="warning" />
+<div className="flex w-full max-w-80 flex-col gap-1.5">
+	<Label htmlFor="username">Username</Label>
+	<Input id="username" name="username" placeholder="Enter a username" />
+</div>
+<div className="flex w-full max-w-80 flex-col gap-1.5">
+	<Label htmlFor="email">Email</Label>
+	<Input id="email" placeholder="Enter your email" autoComplete="email" />
+</div>
+
+<div className="flex flex-col gap-1.5">
+	<Label htmlFor="error">Error</Label>
+	<Input id="error" validation="error" />
+</div>
+<div className="flex flex-col gap-1.5">
+	<Label htmlFor="success">Success</Label>
+	<Input id="success" validation="success" />
+</div>
+<div className="flex flex-col gap-1.5">
+	<Label htmlFor="warning">Warning</Label>
+	<Input id="warning" validation="warning" />
+</div>
 ```
 
 ## Child Elements
@@ -57,50 +75,65 @@ You can compose additional visual or functional elements within the `Input` usin
 Note: when composing with interactive content (e.g. a `button`), you will need to consider whether or not that element should be tab-indexable or receive focus!
 
 <Example className="grid grid-cols-2 place-items-center gap-6">
-	<Label className="block w-full max-w-80 space-y-1">
-		<p>Search with start icon</p>
-		<Input className="max-w-64" placeholder="Search...">
+	<div className="flex w-full max-w-80 flex-col gap-1.5">
+		<Label htmlFor="input-search-start">Search with start icon</Label>
+		<Input id="input-search-start" className="max-w-64" placeholder="Search...">
 			<MagnifyingGlassIcon />
 			<InputCapture />
 		</Input>
-	</Label>
-	<Label className="block w-full max-w-80 space-y-1">
-		<p>Search with end icon</p>
-		<Input className="max-w-64" placeholder="Search...">
+	</div>
+	<div className="flex w-full max-w-80 flex-col gap-1.5">
+		<Label htmlFor="input-search-end">Search with end icon</Label>
+		<Input id="input-search-end" className="max-w-64" placeholder="Search...">
 			<InputCapture />
 			<InfoIcon />
 		</Input>
-	</Label>
-	<Label className="block w-full max-w-80 space-y-1">
-		<p>Search with start and end icons</p>
-		<Input className="max-w-64" placeholder="Search...">
-			<MagnifyingGlassIcon />
-			<InputCapture />
-			<InfoIcon />
-		</Input>
-	</Label>
-	<Label className="block w-full max-w-80 space-y-1">
-		<p>Search with start icon (error)</p>
-		<Input className="max-w-64" placeholder="Search..." validation="error">
-			<MagnifyingGlassIcon />
-			<InputCapture />
-		</Input>
-	</Label>
-	<Label className="block w-full max-w-80 space-y-1">
-		<p>Search with end icon (error)</p>
-		<Input className="max-w-64" placeholder="Search..." validation="error">
-			<InputCapture />
-			<InfoIcon />
-		</Input>
-	</Label>
-	<Label className="block w-full max-w-80 space-y-1">
-		<p>Search with start and end icons (error)</p>
-		<Input className="max-w-64" validation="error" placeholder="Search...">
+	</div>
+	<div className="flex w-full max-w-80 flex-col gap-1.5">
+		<Label htmlFor="input-search-both">Search with start and end icons</Label>
+		<Input id="input-search-both" className="max-w-64" placeholder="Search...">
 			<MagnifyingGlassIcon />
 			<InputCapture />
 			<InfoIcon />
 		</Input>
-	</Label>
+	</div>
+	<div className="flex w-full max-w-80 flex-col gap-1.5">
+		<Label htmlFor="input-search-start-error">Search with start icon (error)</Label>
+		<Input
+			id="input-search-start-error"
+			className="max-w-64"
+			placeholder="Search..."
+			validation="error"
+		>
+			<MagnifyingGlassIcon />
+			<InputCapture />
+		</Input>
+	</div>
+	<div className="flex w-full max-w-80 flex-col gap-1.5">
+		<Label htmlFor="input-search-end-error">Search with end icon (error)</Label>
+		<Input
+			id="input-search-end-error"
+			className="max-w-64"
+			placeholder="Search..."
+			validation="error"
+		>
+			<InputCapture />
+			<InfoIcon />
+		</Input>
+	</div>
+	<div className="flex w-full max-w-80 flex-col gap-1.5">
+		<Label htmlFor="input-search-both-error">Search with start and end icons (error)</Label>
+		<Input
+			id="input-search-both-error"
+			className="max-w-64"
+			validation="error"
+			placeholder="Search..."
+		>
+			<MagnifyingGlassIcon />
+			<InputCapture />
+			<InfoIcon />
+		</Input>
+	</div>
 </Example>
 
 ```tsx
@@ -109,28 +142,28 @@ import { Label } from "@ngrok/mantle/label";
 import { InfoIcon } from "@phosphor-icons/react/Info";
 import { MagnifyingGlassIcon } from "@phosphor-icons/react/MagnifyingGlass";
 
-<Label className="block w-full max-w-80 space-y-1">
-	<p>Search with start icon</p>
-	<Input className="max-w-64" placeholder="Search...">
+<div className="flex w-full max-w-80 flex-col gap-1.5">
+	<Label htmlFor="search-start">Search with start icon</Label>
+	<Input id="search-start" className="max-w-64" placeholder="Search...">
 		<MagnifyingGlassIcon />
 		<InputCapture />
 	</Input>
-</Label>
-<Label className="block w-full max-w-80 space-y-1">
-	<p>Search with end icon</p>
-	<Input className="max-w-64" placeholder="Search...">
+</div>
+<div className="flex w-full max-w-80 flex-col gap-1.5">
+	<Label htmlFor="search-end">Search with end icon</Label>
+	<Input id="search-end" className="max-w-64" placeholder="Search...">
 		<InputCapture />
 		<InfoIcon />
 	</Input>
-</Label>
-<Label className="block w-full max-w-80 space-y-1">
-	<p>Search with start and end icons</p>
-	<Input className="max-w-64" placeholder="Search...">
+</div>
+<div className="flex w-full max-w-80 flex-col gap-1.5">
+	<Label htmlFor="search-both">Search with start and end icons</Label>
+	<Input id="search-both" className="max-w-64" placeholder="Search...">
 		<MagnifyingGlassIcon />
 		<InputCapture />
 		<InfoIcon />
 	</Input>
-</Label>
+</div>
 ```
 
 ## When to use InputCapture

--- a/apps/www/app/docs/components/label.mdx
+++ b/apps/www/app/docs/components/label.mdx
@@ -132,12 +132,12 @@ import { Label } from "@ngrok/mantle/label";
 
 <div className="flex flex-col gap-1.5">
 	<Label htmlFor="name" disabled>Name</Label>
-	<Input id="name" type="text" disabled value="foo" />
+	<Input id="name" type="text" disabled readOnly value="foo" />
 </div>
 
 <div className="flex items-center gap-2">
 	<Label htmlFor="name" disabled>Name:</Label>
-	<Input id="name" type="text" disabled value="foo" />
+	<Input id="name" type="text" disabled readOnly value="foo" />
 </div>
 ```
 

--- a/apps/www/app/docs/components/label.mdx
+++ b/apps/www/app/docs/components/label.mdx
@@ -26,37 +26,118 @@ A caption for a form control — input, checkbox, radio, switch, select. Renders
 
 Either wrap the control inside the `<Label>` (implicit association — simplest) or set `htmlFor` to the control's `id` (explicit — required when the control isn't a child).
 
+For the explicit form, React's [`useId()`](https://react.dev/reference/react/useId) is the easiest way to generate a unique, SSR-stable id without hand-managing strings:
+
+```tsx
+import { useId } from "react";
+
+function EmailField() {
+	const id = useId();
+	return (
+		<div className="flex flex-col gap-1.5">
+			<Label htmlFor={id}>Email</Label>
+			<Input id={id} type="email" />
+		</div>
+	);
+}
+```
+
+When you're using [TanStack Form](https://tanstack.com/form), `field.name` is already a stable, unique string for each field — pass it as both `htmlFor` on the `Label` and `id` on the input. You get a guaranteed-correct association for free without calling `useId()` separately:
+
+```tsx
+<form.Field name="email">
+	{(field) => (
+		<div className="flex flex-col gap-1.5">
+			<Label htmlFor={field.name}>Email</Label>
+			<Input
+				id={field.name}
+				name={field.name}
+				type="email"
+				value={field.state.value}
+				onBlur={field.handleBlur}
+				onChange={(event) => field.handleChange(event.target.value)}
+			/>
+		</div>
+	)}
+</form.Field>
+```
+
+## Font weight
+
+A `Label` automatically gets `font-medium` when it doesn't contain a nested form control (`<input>`, `<textarea>`, `<select>`, `<button>`, or `[contenteditable]`). The default is detected via `:has()` and applied through a `:where()`-wrapped variant so its specificity is `0` — any font-weight utility you pass on the `Label` itself overrides cleanly:
+
+<Example className="flex flex-col gap-6">
+	<div className="flex flex-col gap-1.5">
+		<Label htmlFor="email-fw-1">Email</Label>
+		<Input id="email-fw-1" type="email" />
+	</div>
+	<div className="flex flex-col gap-1.5">
+		<Label htmlFor="email-fw-2" className="font-bold">
+			Email
+		</Label>
+		<Input id="email-fw-2" type="email" />
+	</div>
+</Example>
+
+```tsx
+<div className="flex flex-col gap-1.5">
+	<Label htmlFor="email">Email</Label>          {/* → font-medium */}
+	<Input id="email" type="email" />
+</div>
+
+<div className="flex flex-col gap-1.5">
+	<Label htmlFor="email" className="font-bold">Email</Label>  {/* → font-bold */}
+	<Input id="email" type="email" />
+</div>
+```
+
+When the `Label` _wraps_ a control, the auto-default is skipped on purpose — otherwise the control's own typography would inherit the medium weight from the label. In that case, apply `font-medium` to your own caption element (a `<span>` or `<p>`) inside the label:
+
+<Example>
+	<Label htmlFor="email-fw-3" className="flex flex-col gap-1.5">
+		<span className="font-medium">Email</span>
+		<Input id="email-fw-3" type="email" />
+	</Label>
+</Example>
+
+```tsx
+<Label htmlFor="email" className="flex flex-col gap-1.5">
+	<span className="font-medium">Email</span>
+	<Input id="email" type="email" />
+</Label>
+```
+
 ## Disabled state
 
 Pass `disabled` to render the label in a disabled style. Typically you'll want this to mirror the underlying control's disabled state so the visual treatment stays consistent.
 
-<Example className="grid gap-6">
-	<Label htmlFor="name" className="grid gap-2">
-		<span className="font-medium">Name</span> <Input type="text" id="name" />
-	</Label>
-	<div className="flex items-center gap-2">
-		<Label htmlFor="name-2" className="font-medium">
+<Example className="flex flex-col gap-6">
+	<div className="flex flex-col gap-1.5">
+		<Label htmlFor="name-disabled" disabled>
 			Name
 		</Label>
-		<Input type="text" id="name-2" />
+		<Input id="name-disabled" type="text" disabled value="foo" readOnly />
 	</div>
-	<Label htmlFor="name-disabled" className="grid gap-2">
-		<span className="font-medium">Name</span>{" "}
-		<Input type="text" id="name-disabled" disabled readOnly validation="error" value="foo" />
-	</Label>
+	<div className="flex items-center gap-2">
+		<Label htmlFor="name-disabled-inline" disabled>
+			Name:
+		</Label>
+		<Input id="name-disabled-inline" type="text" disabled value="foo" readOnly />
+	</div>
 </Example>
 
 ```tsx
 import { Input } from "@ngrok/mantle/input";
 import { Label } from "@ngrok/mantle/label";
 
-<Label htmlFor="name" className="grid gap-2">
-	<span className="font-medium">Name</span> <Input type="text" id="name" />
-</Label>
+<div className="flex flex-col gap-1.5">
+	<Label htmlFor="name" disabled>Name</Label>
+	<Input id="name" type="text" disabled value="foo" />
+</div>
 
 <div className="flex items-center gap-2">
-	<Label htmlFor="name-2" className="font-medium">Name:</Label>
-	<Input type="text" id="name-2" />
+	<Label htmlFor="name" disabled>Name:</Label>
+	<Input id="name" type="text" disabled value="foo" />
 </div>
 ```
 

--- a/apps/www/app/docs/components/password-input.mdx
+++ b/apps/www/app/docs/components/password-input.mdx
@@ -9,12 +9,12 @@ import { Label } from "@ngrok/mantle/label";
 import { useState } from "react";
 import { Example } from "~/components/example";
 
-export const ControlledVisibility = () => {
+export const ControlledVisibility = ({ id }) => {
 	const [showPassword, setShowPassword] = useState(false);
 
     return (
     	<div className="flex flex-wrap items-center gap-2">
-    		<PasswordInput showValue={showPassword} onValueVisibilityChange={setShowPassword} />
+    		<PasswordInput id={id} showValue={showPassword} onValueVisibilityChange={setShowPassword} />
     		<Button
     			type="button"
     			appearance="outlined"
@@ -57,25 +57,32 @@ Always pair with a [`Label`](/components/label). The toggle button has its own a
 When revealed, the input switches to `type="text"` — some password managers may pause autofill in this state, which is the intended security tradeoff.
 
 <Example className="flex-col gap-4">
-	<Label className="block w-full max-w-64 space-y-1">
-		<p>Password</p>
-		<PasswordInput />
-	</Label>
-	<Label className="block w-full max-w-64 space-y-1">
-		<p>Password (error)</p>
-		<PasswordInput validation="error" />
-	</Label>
-	<Label className="block w-full max-w-64 space-y-1">
-		<p>Controlled Visibility</p>
-		<ControlledVisibility />
-	</Label>
+	<div className="flex w-full max-w-64 flex-col gap-1.5">
+		<Label htmlFor="password">Password</Label>
+		<PasswordInput id="password" />
+	</div>
+	<div className="flex w-full max-w-64 flex-col gap-1.5">
+		<Label htmlFor="password-error">Password (error)</Label>
+		<PasswordInput id="password-error" validation="error" />
+	</div>
+	<div className="flex w-full max-w-64 flex-col gap-1.5">
+		<Label htmlFor="password-controlled">Controlled Visibility</Label>
+		<ControlledVisibility id="password-controlled" />
+	</div>
 </Example>
 
 ```tsx
+import { Label } from "@ngrok/mantle/label";
 import { PasswordInput } from "@ngrok/mantle/input";
 
-<PasswordInput />
-<PasswordInput validation="error" />
+<div className="flex w-full max-w-64 flex-col gap-1.5">
+	<Label htmlFor="password">Password</Label>
+	<PasswordInput id="password" />
+</div>
+<div className="flex w-full max-w-64 flex-col gap-1.5">
+	<Label htmlFor="password-error">Password (error)</Label>
+	<PasswordInput id="password-error" validation="error" />
+</div>
 ```
 
 ## API Reference

--- a/apps/www/app/docs/components/select.mdx
+++ b/apps/www/app/docs/components/select.mdx
@@ -36,8 +36,8 @@ Displays a list of options for the user to pick from—triggered by a button.
 Use `Select` for a small, finite list of options (~2-15) where the user picks exactly one and search/filtering is unnecessary. For larger lists, async data, or any single-select where typing to filter is helpful, use [`Combobox`](/components/combobox). For picking multiple options, use [`Multi Select`](/components/multi-select).
 
 <Example className="flex-col gap-4">
-	<Label className="w-full max-w-64" htmlFor="fruits">
-		<p>Fruits</p>
+	<div className="flex w-full max-w-64 flex-col gap-1.5">
+		<Label htmlFor="fruits">Fruits</Label>
 		<Select.Root id="fruits" name="number">
 			<Select.Trigger>
 				<Select.Value placeholder="Select a fruit" />
@@ -65,7 +65,7 @@ Use `Select` for a small, finite list of options (~2-15) where the user picks ex
 				</Select.Group>
 			</Select.Content>
 		</Select.Root>
-	</Label>
+	</div>
 	<Select.Root validation="error">
 		<Select.Trigger className="max-w-64">
 			<Select.Value placeholder="Select a fruit" />
@@ -153,8 +153,8 @@ Use `Select` for a small, finite list of options (~2-15) where the user picks ex
 import { Label } from "@ngrok/mantle/label";
 import { Select } from "@ngrok/mantle/select";
 
-<Label className="w-full max-w-64" htmlFor="fruits">
-	<p>Fruits</p>
+<div className="flex w-full max-w-64 flex-col gap-1.5">
+	<Label htmlFor="fruits">Fruits</Label>
 	<Select.Root id="fruits" name="number">
 		<Select.Trigger>
 			<Select.Value placeholder="Select a fruit" />
@@ -182,7 +182,7 @@ import { Select } from "@ngrok/mantle/select";
 			</Select.Group>
 		</Select.Content>
 	</Select.Root>
-</Label>;
+</div>;
 ```
 
 ## Examples

--- a/apps/www/app/docs/components/text-area.mdx
+++ b/apps/www/app/docs/components/text-area.mdx
@@ -15,34 +15,56 @@ import { Example } from "~/components/example";
 A multi-line plain-text editing control, useful when you want to allow users to enter a sizeable amount of free-form text, for example a comment on a review or feedback form.
 
 <Example className="grid grid-cols-1 gap-6 sm:grid-cols-2">
-	<Label className="space-y-1">
-		<p>Default TextArea</p>
-		<TextArea placeholder="Tell us about your experience…" />
-	</Label>
-	<Label className="space-y-1">
-		<p>Monospaced TextArea</p>
-		<TextArea appearance="monospaced" placeholder="Tell us about your experience…" />
-	</Label>
-	<Label className="space-y-1">
-		<p>Error TextArea</p>
-		<TextArea placeholder="Tell us about your experience…" validation="error" />
-	</Label>
-	<Label className="space-y-1">
-		<p>Success TextArea</p>
-		<TextArea placeholder="Tell us about your experience…" validation="success" />
-	</Label>
-	<Label className="space-y-1">
-		<p>Warning TextArea</p>
-		<TextArea placeholder="Tell us about your experience…" validation="warning" />
-	</Label>
+	<div className="flex flex-col gap-1.5">
+		<Label htmlFor="textarea-default">Default TextArea</Label>
+		<TextArea id="textarea-default" placeholder="Tell us about your experience…" />
+	</div>
+	<div className="flex flex-col gap-1.5">
+		<Label htmlFor="textarea-monospaced">Monospaced TextArea</Label>
+		<TextArea
+			id="textarea-monospaced"
+			appearance="monospaced"
+			placeholder="Tell us about your experience…"
+		/>
+	</div>
+	<div className="flex flex-col gap-1.5">
+		<Label htmlFor="textarea-error">Error TextArea</Label>
+		<TextArea id="textarea-error" placeholder="Tell us about your experience…" validation="error" />
+	</div>
+	<div className="flex flex-col gap-1.5">
+		<Label htmlFor="textarea-success">Success TextArea</Label>
+		<TextArea
+			id="textarea-success"
+			placeholder="Tell us about your experience…"
+			validation="success"
+		/>
+	</div>
+	<div className="flex flex-col gap-1.5">
+		<Label htmlFor="textarea-warning">Warning TextArea</Label>
+		<TextArea
+			id="textarea-warning"
+			placeholder="Tell us about your experience…"
+			validation="warning"
+		/>
+	</div>
 </Example>
 
 ```tsx
+import { Label } from "@ngrok/mantle/label";
 import { TextArea } from "@ngrok/mantle/text-area";
 
-<TextArea placeholder="Tell us about your experience…" />
-<TextArea appearance="monospaced" placeholder="Tell us about your experience…" />
-<TextArea placeholder="Tell us about your experience…" validation="error" />
+<div className="flex flex-col gap-1.5">
+	<Label htmlFor="feedback">Default TextArea</Label>
+	<TextArea id="feedback" placeholder="Tell us about your experience…" />
+</div>
+<div className="flex flex-col gap-1.5">
+	<Label htmlFor="feedback-mono">Monospaced TextArea</Label>
+	<TextArea id="feedback-mono" appearance="monospaced" placeholder="Tell us about your experience…" />
+</div>
+<div className="flex flex-col gap-1.5">
+	<Label htmlFor="feedback-error">Error TextArea</Label>
+	<TextArea id="feedback-error" placeholder="Tell us about your experience…" validation="error" />
+</div>
 ```
 
 ## Examples

--- a/apps/www/vite.config.ts
+++ b/apps/www/vite.config.ts
@@ -72,6 +72,7 @@ export default defineConfig({
 	},
 	server: {
 		port: 3333,
+		allowedHosts: true,
 		warmup: {
 			clientFiles: [
 				"./app/**/!(*.server|*.test)*.tsx", // Include all .tsx files except server and test files (add more patterns if required)

--- a/packages/mantle/src/components/label/label.browser.test.tsx
+++ b/packages/mantle/src/components/label/label.browser.test.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import { render } from "@testing-library/react";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import { Label } from "./label.js";
+
+/**
+ * Mirrors the CSS Tailwind 4 emits for our utilities, paired with the `where`
+ * custom variant registered in `mantle.css`. We inline this instead of importing
+ * the full mantle stylesheet so the test stays hermetic and doesn't require a
+ * Tailwind build step in the test pipeline.
+ *
+ * Keep the selector form identical to Tailwind's output — that's what determines
+ * specificity and source order. The numeric values are inlined (vs. CSS vars) so
+ * the test doesn't depend on the mantle theme being loaded.
+ */
+const STYLE = `
+body { font-weight: 100; }
+@layer utilities {
+	.font-bold { font-weight: 700; }
+	.font-medium { font-weight: 500; }
+	.font-normal { font-weight: 400; }
+	.\\[\\:where\\(\\&\\:not\\(\\:has\\(input\\,textarea\\,select\\,button\\,\\[contenteditable\\]\\)\\)\\)\\]\\:font-medium {
+		:where(&:not(:has(input,textarea,select,button,[contenteditable]))) {
+			font-weight: 500;
+		}
+	}
+}
+`;
+
+let styleElement: HTMLStyleElement;
+
+beforeAll(() => {
+	styleElement = document.createElement("style");
+	styleElement.textContent = STYLE;
+	document.head.appendChild(styleElement);
+});
+
+afterAll(() => {
+	styleElement.remove();
+});
+
+describe("Label conditional font-weight", () => {
+	test("standalone label renders font-medium (500)", () => {
+		const { container } = render(<Label>Email</Label>);
+		const label = container.querySelector("label");
+		expect(label).not.toBeNull();
+		expect(getComputedStyle(label as HTMLLabelElement).fontWeight).toBe("500");
+	});
+
+	test("label wrapping <input> inherits its weight (does not become medium)", () => {
+		const { container } = render(
+			<Label>
+				<span>Email</span>
+				<input type="email" />
+			</Label>,
+		);
+		const label = container.querySelector("label");
+		expect(label).not.toBeNull();
+		expect(getComputedStyle(label as HTMLLabelElement).fontWeight).toBe("100");
+	});
+
+	test("label wrapping <textarea>, <select>, or <button> also opts out", () => {
+		const cases = [
+			<Label key="ta">
+				<textarea />
+			</Label>,
+			<Label key="sel">
+				<select>
+					<option>a</option>
+				</select>
+			</Label>,
+			<Label key="btn">
+				<button type="button">x</button>
+			</Label>,
+		];
+		for (const node of cases) {
+			const { container, unmount } = render(node);
+			const label = container.querySelector("label");
+			expect(label).not.toBeNull();
+			expect(getComputedStyle(label as HTMLLabelElement).fontWeight).toBe("100");
+			unmount();
+		}
+	});
+
+	test("user-supplied font-bold overrides the default on a standalone label", () => {
+		const { container } = render(<Label className="font-bold">Email</Label>);
+		const label = container.querySelector("label");
+		expect(label).not.toBeNull();
+		expect(getComputedStyle(label as HTMLLabelElement).fontWeight).toBe("700");
+	});
+
+	test("user-supplied font-normal overrides the default on a standalone label", () => {
+		const { container } = render(<Label className="font-normal">Email</Label>);
+		const label = container.querySelector("label");
+		expect(label).not.toBeNull();
+		expect(getComputedStyle(label as HTMLLabelElement).fontWeight).toBe("400");
+	});
+
+	test("user-supplied font-bold still applies when wrapping a control", () => {
+		const { container } = render(
+			<Label className="font-bold">
+				<span>Email</span>
+				<input type="email" />
+			</Label>,
+		);
+		const label = container.querySelector("label");
+		expect(label).not.toBeNull();
+		expect(getComputedStyle(label as HTMLLabelElement).fontWeight).toBe("700");
+	});
+
+	test("user-supplied font-bold still applies when wrapping a [contenteditable]", () => {
+		const { container } = render(
+			<Label className="font-bold">
+				<span>Bio</span>
+				<div contentEditable suppressContentEditableWarning>
+					hi
+				</div>
+			</Label>,
+		);
+		const label = container.querySelector("label");
+		expect(label).not.toBeNull();
+		expect(getComputedStyle(label as HTMLLabelElement).fontWeight).toBe("700");
+	});
+
+	test("label wrapping a [contenteditable] element opts out", () => {
+		const { container } = render(
+			<Label>
+				<span>Bio</span>
+				<div contentEditable suppressContentEditableWarning>
+					hello
+				</div>
+			</Label>,
+		);
+		const label = container.querySelector("label");
+		expect(label).not.toBeNull();
+		expect(getComputedStyle(label as HTMLLabelElement).fontWeight).toBe("100");
+	});
+
+	test("nested control deeper than direct child still suppresses the default", () => {
+		const { container } = render(
+			<Label>
+				<span>Email</span>
+				<div>
+					<div>
+						<input type="email" />
+					</div>
+				</div>
+			</Label>,
+		);
+		const label = container.querySelector("label");
+		expect(label).not.toBeNull();
+		expect(getComputedStyle(label as HTMLLabelElement).fontWeight).toBe("100");
+	});
+});

--- a/packages/mantle/src/components/label/label.tsx
+++ b/packages/mantle/src/components/label/label.tsx
@@ -34,6 +34,15 @@ type LabelProps = ComponentPropsWithoutRef<"label"> & {
  * style. Typically you'll want this to mirror the underlying control's
  * disabled state so the visual treatment stays consistent.
  *
+ * **Font weight.** A `Label` automatically gets `font-medium` when it does
+ * **not** contain a nested form control (`<input>`, `<textarea>`, `<select>`,
+ * `<button>`, or `[contenteditable]`). When the label *does* wrap a control,
+ * the auto default is intentionally skipped so the control's own typography
+ * isn't bolded — apply `font-medium` to your own caption element (e.g. a
+ * `<span>` or `<p>`) inside the label. Override the default at any time by
+ * passing a font-weight utility on the `Label` itself, e.g.
+ * `<Label className="font-bold">`.
+ *
  * @see https://mantle.ngrok.com/components/label
  *
  * @example
@@ -71,6 +80,13 @@ const Label = forwardRef<ComponentRef<"label">, LabelProps>(
 			data-slot="label"
 			className={cx(
 				"text-strong cursor-pointer text-sm peer-disabled:cursor-default has-disabled:cursor-default aria-disabled:cursor-default font-sans",
+				// Default to font-medium when the label isn't wrapping a form control. The
+				// arbitrary variant wraps the *entire* matched selector — class + the
+				// `:not(:has(...))` check — in `:where()`, flattening total specificity to 0.
+				// That lets a user-supplied font-weight utility (`font-bold`, `font-normal`,
+				// etc.) at (0,1,0) override cleanly, even though `[contenteditable]` is an
+				// attribute selector that would otherwise lift the rule to (0,1,0) and tie.
+				"[:where(&:not(:has(input,textarea,select,button,[contenteditable])))]:font-medium",
 				className,
 			)}
 			onMouseDown={(event) => {


### PR DESCRIPTION
Add an auto-applied font-medium to <Label> via a :where()-wrapped :not(:has(input,textarea,select,button,[contenteditable])) selector. Specificity stays at (0,0,0) so any user-supplied font-weight utility (font-bold / font-normal / font-semibold) overrides cleanly without the ! important modifier. When the label wraps a control, the default opts out so the control's own typography isn't bolded — apply font-medium to an inner caption element (e.g. <span>) instead.

- Add browser-mode tests covering standalone, wrapped, deep nesting, contenteditable, and override cases.
- Document the behavior in label.mdx with rendered examples and a useId() / TanStack Form association tip.
- Reauthor www docs (input, text-area, password-input, select, label) to use the sibling-association form with unique htmlFor/id pairs and gap-1.5 between label and control.
- Trim the Disabled state example to only show genuinely disabled cases.
- Strip stray trailing semicolons from standalone JSX statements in mdx code fences across the docs site.