### PR TITLE
fix(www): align ToC active offset with heading scroll-margin

### DIFF
--- a/apps/www/app/components/table-of-contents.tsx
+++ b/apps/www/app/components/table-of-contents.tsx
@@ -34,7 +34,10 @@ function getHeadings(container: HTMLElement): Array<TocEntry> {
 	return entries;
 }
 
-const HEADER_OFFSET = 80;
+// Matches the `scroll-mt-24` (6rem = 96px) on `HashLinkHeading`. Aligning the
+// trigger with where headings land after a hash-link click ensures the clicked
+// entry — not its predecessor — is the one marked active.
+const HEADER_OFFSET = 96;
 const EASE_START = 0.75;
 
 function clamp01(value: number): number {

--- a/apps/www/app/root.tsx
+++ b/apps/www/app/root.tsx
@@ -138,7 +138,7 @@ declare global {
 export function Layout({ children }: PropsWithChildren) {
 	const loaderData = useRouteLoaderData<typeof loader>("root");
 	const initialHtmlThemeProps = useInitialHtmlThemeProps({
-		className: "h-full scroll-pt-16",
+		className: "h-full",
 	});
 	const scrollBehavior = useScrollBehavior();
 	const nonce = useNonce();


### PR DESCRIPTION
`<html>` had `scroll-pt-16` (64px) and headings have `scroll-mt-24` (96px); the two combine, so a clicked heading lands 160px below the viewport top — past the ToC's `HEADER_OFFSET=80` trigger line. The predecessor heading was the last entry above the trigger, so it won the active-detection loop instead of the entry the user actually clicked.

Drop the redundant `scroll-pt-16` and bump `HEADER_OFFSET` to 96 so the trigger sits exactly where headings land. Click-to-link now highlights the clicked entry; natural scroll tracking is unchanged.