### PR TITLE
fix(code-block): remove focus outline and stale tabIndex={-1} default on <pre>

### DIFF
--- a/.changeset/code-block-no-focus-outline.md
+++ b/.changeset/code-block-no-focus-outline.md
@@ -1,0 +1,9 @@
+---
+"@ngrok/mantle": patch
+---
+
+`CodeBlock.Code` no longer paints a browser-default focus outline on its `<pre>`, and no longer hardcodes `tabIndex={-1}` on the element.
+
+The `tabIndex={-1}` default was a leftover workaround from when Prism.js auto-injected `tabIndex={0}` on every `<pre>` it touched. Prism was replaced with build-time Shiki, so nothing is forcing a tabindex anymore — the override is dead weight that also opted the scroll container out of Chrome's keyboard-focusable-scroller heuristic, hurting keyboard-only users on overflowing blocks. The prop is now passed through cleanly via `...props`, so consumers can still set `tabIndex={-1}` (or any other value) per instance if they want to exclude a block from the tab order.
+
+The `outline-hidden` is paired with the tabindex change so the now-optionally-focusable `<pre>` doesn't paint the browser-default focus ring when scripted focus or scroll-container heuristics put focus on it. Nested controls (fold toggles, copy buttons) keep their own `:focus-visible` styles.

--- a/packages/mantle/src/components/code-block/code-block.tsx
+++ b/packages/mantle/src/components/code-block/code-block.tsx
@@ -321,7 +321,7 @@ type CodeBlockCodeProps = Omit<ComponentProps<"pre">, "children"> & {
  * ```
  */
 const Code = forwardRef<ComponentRef<"pre">, CodeBlockCodeProps>(
-	({ className, style, tabIndex, value, ...props }, ref) => {
+	({ className, style, value, ...props }, ref) => {
 		const id = useId();
 		const preRef = useRef<HTMLPreElement>(null);
 		const { copyTextRef, hasCodeExpander, isCodeExpanded, registerCodeId, unregisterCodeId } =
@@ -401,7 +401,7 @@ const Code = forwardRef<ComponentRef<"pre">, CodeBlockCodeProps>(
 					"scrollbar overflow-x-auto overflow-y-hidden py-4",
 					!isPreRendered && "pr-14",
 					"data-[mantle-line-numbers~='false']:pl-4",
-					"text-mono m-0 font-mono",
+					"text-mono m-0 font-mono outline-hidden",
 					"aria-collapsed:max-h-[13.6rem]",
 					className,
 				)}
@@ -426,7 +426,6 @@ const Code = forwardRef<ComponentRef<"pre">, CodeBlockCodeProps>(
 						MozTabSize: 2,
 					} as ComponentProps<"pre">["style"]
 				}
-				tabIndex={tabIndex ?? -1}
 				{...props}
 			>
 				<code


### PR DESCRIPTION
The hardcoded `tabIndex={-1}` was a Prism.js workaround (Prism auto-injected `tabIndex={0}` on every `<pre>`) that outlived its purpose when we switched to build-time Shiki. Pass tabIndex through `...props` so consumers can opt in/out per instance, and add `outline-hidden` so the now-optionally-focusable scroll container doesn't paint a browser-default focus ring