### PR TITLE
fix(toc): sync active heading on hash nav and stabilize boundary detection

### DIFF
--- a/apps/www/app/components/content-layout.tsx
+++ b/apps/www/app/components/content-layout.tsx
@@ -1,8 +1,7 @@
 import type { ReactNode } from "react";
-import { Suspense, useRef } from "react";
+import { Suspense } from "react";
 import { DocActions } from "~/components/doc-actions";
 import { MdxProvider } from "~/components/mdx-provider";
-import { TableOfContents } from "~/components/table-of-contents";
 
 type ContentLayoutProps = {
 	/**
@@ -19,27 +18,20 @@ type ContentLayoutProps = {
 
 /**
  * Shared layout for doc pages. Provides the doc actions button,
- * MdxProvider context, Suspense boundary, and table of contents sidebar.
+ * MdxProvider context, and Suspense boundary.
  */
 export function ContentLayout({ children, markdownPath }: ContentLayoutProps) {
-	const contentRef = useRef<HTMLDivElement>(null);
-
 	return (
-		<>
-			<div className="relative">
-				<div className="mb-4 sm:absolute sm:right-0 sm:top-0 sm:z-10 sm:mb-0">
-					<DocActions markdownPath={markdownPath} />
-				</div>
-				<div ref={contentRef}>
-					<MdxProvider>
-						<Suspense fallback={null}>
-							{/* don't overlap the doc actions */}
-							<div className="sm:[&>h1:first-child]:pr-40">{children}</div>
-						</Suspense>
-					</MdxProvider>
-				</div>
+		<div className="relative">
+			<div className="mb-4 sm:absolute sm:right-0 sm:top-0 sm:z-10 sm:mb-0">
+				<DocActions markdownPath={markdownPath} />
 			</div>
-			<TableOfContents contentRef={contentRef} />
-		</>
+			<MdxProvider>
+				<Suspense fallback={null}>
+					{/* don't overlap the doc actions */}
+					<div className="sm:[&>h1:first-child]:pr-40">{children}</div>
+				</Suspense>
+			</MdxProvider>
+		</div>
 	);
 }

--- a/apps/www/app/components/page-layout.tsx
+++ b/apps/www/app/components/page-layout.tsx
@@ -1,8 +1,9 @@
 import type { ComponentProps, ReactNode } from "react";
-import { href, Link } from "react-router";
+import { href, Link, useMatches } from "react-router";
+import { z } from "zod";
 import { useNavigation } from "./navigation-context";
 import { ScrollMask } from "./scroll-mask";
-import { TOC_PORTAL_ID } from "./table-of-contents";
+import { TableOfContents } from "./table-of-contents";
 import { cx } from "@ngrok/mantle/cx";
 import { Main } from "@ngrok/mantle/main";
 
@@ -17,6 +18,16 @@ const mobileDrawerLinks = [
 	{ to: href("/blocks"), label: "Blocks" },
 ];
 
+const matchDataWithTocSchema = z.object({
+	toc: z.array(
+		z.object({
+			id: z.string(),
+			text: z.string(),
+			level: z.union([z.literal(1), z.literal(2), z.literal(3)]),
+		}),
+	),
+});
+
 /**
  * Shared page frame used by section layouts (docs, blocks, …). Renders the
  * three-column grid (sidebar | main | TOC aside) and the mobile drawer. The
@@ -25,6 +36,9 @@ const mobileDrawerLinks = [
  */
 export function PageLayout({ className, children, sidebar, ...props }: PageLayoutProps) {
 	const { showNavigation, setShowNavigation } = useNavigation();
+	const matches = useMatches();
+	const leafToc =
+		matchDataWithTocSchema.safeParse(matches[matches.length - 1]?.data).data?.toc ?? [];
 
 	const closeMobileNavigation = () => {
 		setShowNavigation(false);
@@ -37,7 +51,9 @@ export function PageLayout({ className, children, sidebar, ...props }: PageLayou
 					{sidebar}
 				</ScrollMask>
 				<Main className="w-0 flex-1 pb-[80vh] sm:px-8">{children}</Main>
-				<aside id={TOC_PORTAL_ID} className="hidden w-40 xl:block" />
+				<aside className="hidden w-40 xl:block">
+					<TableOfContents entries={leafToc} />
+				</aside>
 			</div>
 			{showNavigation && (
 				<div className="bg-card fixed bottom-0 left-0 right-0 top-15 z-50 p-4 md:hidden">

--- a/apps/www/app/components/table-of-contents.tsx
+++ b/apps/www/app/components/table-of-contents.tsx
@@ -1,38 +1,8 @@
 import { cx } from "@ngrok/mantle/cx";
-import { useCallback, useEffect, useRef, useState, type RefObject } from "react";
-import { createPortal } from "react-dom";
+import { useEffect, useRef, useState } from "react";
 import { Link, useLocation } from "react-router";
+import type { TocEntry } from "~/utilities/docs";
 import { ScrollMask } from "./scroll-mask";
-
-type TocEntry = {
-	/** The heading's `id` attribute (from rehype-slug). */
-	id: string;
-	/** The visible text content of the heading. */
-	text: string;
-	/** The heading level (1, 2, or 3). */
-	level: number;
-};
-
-/**
- * Extracts h1, h2, and h3 headings from a container element.
- * Only includes headings that have an `id` attribute (added by rehype-slug).
- */
-function getHeadings(container: HTMLElement): Array<TocEntry> {
-	const headings = container.querySelectorAll<HTMLHeadingElement>("h1[id], h2[id], h3[id]");
-	const entries: Array<TocEntry> = [];
-	for (const heading of headings) {
-		const id = heading.id;
-		const text = heading.textContent?.trim();
-		if (id && text) {
-			entries.push({
-				id,
-				text,
-				level: Number(heading.tagName[1]),
-			});
-		}
-	}
-	return entries;
-}
 
 // Matches the `scroll-mt-24` (6rem = 96px) on `HashLinkHeading`. Aligning the
 // trigger with where headings land after a hash-link click ensures the clicked
@@ -54,12 +24,8 @@ function clamp01(value: number): number {
  * See https://thirty-five.com/overengineered-anchoring.
  */
 function useActiveHeading(entries: Array<TocEntry>): string | undefined {
-	const [activeId, setActiveId] = useState<string | undefined>(undefined);
+	const [activeId, setActiveId] = useState<string | undefined>(() => entries[0]?.id);
 	const location = useLocation();
-
-	useEffect(() => {
-		setActiveId(undefined);
-	}, [location.pathname]);
 
 	useEffect(() => {
 		if (entries.length === 0) {
@@ -69,8 +35,9 @@ function useActiveHeading(entries: Array<TocEntry>): string | undefined {
 		// immediately — otherwise scroll-based detection lags the smooth-scroll
 		// animation and briefly highlights the predecessor heading.
 		const hash = location.hash.slice(1);
-		const initial = hash && entries.some((entry) => entry.id === hash) ? hash : entries[0]?.id;
-		setActiveId(initial);
+		if (hash && entries.some((entry) => entry.id === hash)) {
+			setActiveId(hash);
+		}
 	}, [entries, location.hash]);
 
 	useEffect(() => {
@@ -133,70 +100,11 @@ function useActiveHeading(entries: Array<TocEntry>): string | undefined {
 	return activeId;
 }
 
-/** The id of the DOM element where the ToC portals into (placed in layout.tsx). */
-const TOC_PORTAL_ID = "toc-portal";
-
 /**
- * A table of contents sidebar that portals outside of `<main>` into a layout-level
- * container. Lists h2/h3 headings from the current MDX page and highlights the
- * active section based on scroll position.
- *
- * The portal target (`#toc-portal`) is rendered in `layout.tsx` alongside `<main>`.
- *
- * The `contentRef` should point to the container element that holds the MDX content
- * so headings can be extracted from it.
+ * A table of contents sidebar listing h1/h2/h3 headings from the current MDX
+ * page and highlighting the active section based on scroll position.
  */
-function TableOfContents({ contentRef }: { contentRef: RefObject<HTMLDivElement | null> }) {
-	const [entries, setEntries] = useState<Array<TocEntry>>([]);
-	const [portalTarget, setPortalTarget] = useState<HTMLElement | null>(null);
-	const location = useLocation();
-
-	useEffect(() => {
-		setPortalTarget(document.getElementById(TOC_PORTAL_ID));
-	}, []);
-
-	const updateEntries = useCallback(() => {
-		if (contentRef.current) {
-			setEntries(getHeadings(contentRef.current));
-		}
-	}, [contentRef]);
-
-	// MutationObserver catches Suspense-deferred MDX that mounts after the route effect fires.
-	useEffect(() => {
-		updateEntries();
-
-		const container = contentRef.current;
-		if (!container) {
-			return;
-		}
-
-		const observer = new MutationObserver((mutations) => {
-			for (const mutation of mutations) {
-				const nodes = [...mutation.addedNodes, ...mutation.removedNodes];
-				for (const node of nodes) {
-					if (!(node instanceof HTMLElement)) {
-						continue;
-					}
-
-					const tagName = node.tagName;
-					if ((tagName === "H1" || tagName === "H2" || tagName === "H3") && node.id) {
-						updateEntries();
-						return;
-					}
-
-					if (node.querySelector("h1[id], h2[id], h3[id]")) {
-						updateEntries();
-						return;
-					}
-				}
-			}
-		});
-		observer.observe(container, { childList: true, subtree: true });
-		return () => {
-			observer.disconnect();
-		};
-	}, [location.pathname, updateEntries, contentRef]);
-
+export function TableOfContents({ entries }: { entries: Array<TocEntry> }) {
 	const activeId = useActiveHeading(entries);
 	const itemRefs = useRef<Map<string, HTMLLIElement>>(new Map());
 
@@ -210,11 +118,11 @@ function TableOfContents({ contentRef }: { contentRef: RefObject<HTMLDivElement 
 		}
 	}, [activeId]);
 
-	if (entries.length === 0 || !portalTarget) {
+	if (entries.length === 0) {
 		return null;
 	}
 
-	return createPortal(
+	return (
 		<nav
 			aria-label="Table of contents"
 			className="sticky top-15 flex max-h-[calc(100vh-3.75rem)] w-40 flex-col pt-4"
@@ -266,13 +174,6 @@ function TableOfContents({ contentRef }: { contentRef: RefObject<HTMLDivElement 
 					))}
 				</ol>
 			</ScrollMask>
-		</nav>,
-		portalTarget,
+		</nav>
 	);
 }
-
-export {
-	//,
-	TableOfContents,
-	TOC_PORTAL_ID,
-};

--- a/apps/www/app/components/table-of-contents.tsx
+++ b/apps/www/app/components/table-of-contents.tsx
@@ -65,10 +65,14 @@ function useActiveHeading(entries: Array<TocEntry>): string | undefined {
 		if (entries.length === 0) {
 			return;
 		}
-		const hash = window.location.hash.slice(1);
+		const hash = location.hash.slice(1);
+		// Sync the active entry to the URL hash on initial mount, when the
+		// heading list changes, AND when the user clicks a ToC link (hash-only
+		// navigation) — otherwise scroll-based detection would lag behind the
+		// smooth-scroll animation and briefly highlight the predecessor.
 		const initial = hash && entries.some((entry) => entry.id === hash) ? hash : entries[0]?.id;
 		setActiveId(initial);
-	}, [entries]);
+	}, [entries, location.hash]);
 
 	useEffect(() => {
 		if (entries.length === 0) {
@@ -86,7 +90,12 @@ function useActiveHeading(entries: Array<TocEntry>): string | undefined {
 			const progress = clamp01(scrollTop / maxScroll);
 			const easeT = clamp01((progress - EASE_START) / (1 - EASE_START));
 			const smoothstep = easeT * easeT * (3 - 2 * easeT);
-			const trigger = scrollTop + HEADER_OFFSET + smoothstep * (clientHeight - HEADER_OFFSET);
+			// Round to whole pixels so a heading landing at the scroll-margin
+			// position (where `offsetTop` and `trigger` are mathematically equal)
+			// can't be off-by-sub-pixel and lose the `<=` check to its predecessor.
+			const trigger = Math.round(
+				scrollTop + HEADER_OFFSET + smoothstep * (clientHeight - HEADER_OFFSET),
+			);
 
 			let next: string | undefined;
 			for (const entry of entries) {
@@ -94,7 +103,7 @@ function useActiveHeading(entries: Array<TocEntry>): string | undefined {
 				if (!element) {
 					continue;
 				}
-				const offsetTop = element.getBoundingClientRect().top + scrollTop;
+				const offsetTop = Math.round(element.getBoundingClientRect().top + scrollTop);
 				if (offsetTop <= trigger) {
 					next = entry.id;
 				} else {
@@ -232,8 +241,20 @@ function TableOfContents({ contentRef }: { contentRef: RefObject<HTMLDivElement 
 								preventScrollReset
 								aria-current={activeId === entry.id ? "location" : undefined}
 								className={cx(
-									"-ml-px block border-l py-1 text-xs leading-snug transition-colors",
-									entry.level <= 2 ? "pl-3" : "pl-6",
+									// 3px left bar that overlays the ol's 1px gray edge (descendant
+									// paints over ancestor) and extends 2px rightward into the content
+									// area. We can't extend leftward — `ScrollMask`'s `overflow-y-auto`
+									// implicitly clips horizontal overflow, so any negative-margin
+									// extension just gets cut off. Padding compensates so content text
+									// position stays the same as the previous 1px-bar layout.
+									"relative -ml-px block border-l-[3px] py-1 text-xs leading-snug transition-colors",
+									// Focus ring uses the same `ring-focus-accent` token as the rest of
+									// the design system (sidebar nav-link, etc.) — subtle by design.
+									// Rendered as a rounded pseudo-element offset past the 3px bar so
+									// the active/gray left edge stays visible through the focused area.
+									"focus:outline-hidden",
+									"focus-visible:before:pointer-events-none focus-visible:before:absolute focus-visible:before:inset-y-0 focus-visible:before:left-[3px] focus-visible:before:right-0 focus-visible:before:rounded-md focus-visible:before:content-[''] focus-visible:before:ring-3 focus-visible:before:ring-inset focus-visible:before:ring-focus-accent",
+									entry.level <= 2 ? "pl-[10px]" : "pl-[22px]",
 									activeId === entry.id
 										? "text-strong border-accent-500 font-medium"
 										: "text-muted border-transparent hover:text-strong hover:border-gray-400",

--- a/apps/www/app/components/table-of-contents.tsx
+++ b/apps/www/app/components/table-of-contents.tsx
@@ -65,11 +65,10 @@ function useActiveHeading(entries: Array<TocEntry>): string | undefined {
 		if (entries.length === 0) {
 			return;
 		}
+		// Depend on `location.hash` so ToC link clicks update the highlight
+		// immediately — otherwise scroll-based detection lags the smooth-scroll
+		// animation and briefly highlights the predecessor heading.
 		const hash = location.hash.slice(1);
-		// Sync the active entry to the URL hash on initial mount, when the
-		// heading list changes, AND when the user clicks a ToC link (hash-only
-		// navigation) — otherwise scroll-based detection would lag behind the
-		// smooth-scroll animation and briefly highlight the predecessor.
 		const initial = hash && entries.some((entry) => entry.id === hash) ? hash : entries[0]?.id;
 		setActiveId(initial);
 	}, [entries, location.hash]);
@@ -248,13 +247,14 @@ function TableOfContents({ contentRef }: { contentRef: RefObject<HTMLDivElement 
 									// extension just gets cut off. Padding compensates so content text
 									// position stays the same as the previous 1px-bar layout.
 									"relative -ml-px block border-l-[3px] py-1 text-xs leading-snug transition-colors",
-									// Focus ring uses the same `ring-focus-accent` token as the rest of
-									// the design system (sidebar nav-link, etc.) — subtle by design.
-									// Rendered as a rounded pseudo-element offset past the 3px bar so
-									// the active/gray left edge stays visible through the focused area.
+									// Focus ring is a pseudo-element offset past the 3px bar so the
+									// active/gray left edge stays visible through the focused area.
 									"focus:outline-hidden",
-									"focus-visible:before:pointer-events-none focus-visible:before:absolute focus-visible:before:inset-y-0 focus-visible:before:left-[3px] focus-visible:before:right-0 focus-visible:before:rounded-md focus-visible:before:content-[''] focus-visible:before:ring-3 focus-visible:before:ring-inset focus-visible:before:ring-focus-accent",
-									entry.level <= 2 ? "pl-[10px]" : "pl-[22px]",
+									"focus-visible:before:pointer-events-none focus-visible:before:absolute",
+									"focus-visible:before:inset-y-0 focus-visible:before:left-0.75 focus-visible:before:right-0",
+									"focus-visible:before:rounded-md focus-visible:before:content-['']",
+									"focus-visible:before:ring-3 focus-visible:before:ring-inset focus-visible:before:ring-focus-accent",
+									entry.level <= 2 ? "pl-2.5" : "pl-5.5",
 									activeId === entry.id
 										? "text-strong border-accent-500 font-medium"
 										: "text-muted border-transparent hover:text-strong hover:border-gray-400",

--- a/apps/www/app/routes/$.tsx
+++ b/apps/www/app/routes/$.tsx
@@ -1,12 +1,7 @@
 import { Suspense, use } from "react";
 import { z } from "zod";
 import { ContentLayout } from "~/components/content-layout";
-import {
-	getDocComponent,
-	loadFrontmatter,
-	resolveDocComponent,
-	urlToFileMap,
-} from "~/utilities/docs";
+import { getDoc, loadDoc, loadFrontmatter, resolveDoc, urlToFileMap } from "~/utilities/docs";
 import { canonicalHref } from "~/utilities/canonical-origin";
 import {
 	jsonLdGraphMetaDescriptor,
@@ -83,9 +78,12 @@ export async function loader({ request }: Route.LoaderArgs) {
 		);
 	}
 
+	const doc = await loadDoc(filePath);
+
 	return {
 		filePath,
 		frontmatter: frontmatterResult.data,
+		toc: doc.toc,
 	};
 }
 
@@ -118,10 +116,11 @@ type DocContentProps = {
  * ensuring content is fully prerendered in the HTML.
  */
 function ProdDocContent({ filePath }: DocContentProps) {
-	const Component = getDocComponent(filePath);
-	if (!Component) {
+	const doc = getDoc(filePath);
+	if (!doc) {
 		throw Response.json({ message: "Not Found" }, { status: 404 });
 	}
+	const { Component } = doc;
 	return <Component />;
 }
 
@@ -131,7 +130,7 @@ function ProdDocContent({ filePath }: DocContentProps) {
  * individual MDX modules without a full page reload.
  */
 function DevDocContent({ filePath }: DocContentProps) {
-	const componentPromise = resolveDocComponent(filePath);
-	const Component = use(componentPromise);
+	const docPromise = resolveDoc(filePath);
+	const { Component } = use(docPromise);
 	return <Component />;
 }

--- a/apps/www/app/routes/_index.tsx
+++ b/apps/www/app/routes/_index.tsx
@@ -1,7 +1,7 @@
 import { Suspense, use } from "react";
 import { ContentLayout } from "~/components/content-layout";
 import { canonicalHref } from "~/utilities/canonical-origin";
-import { getDocComponent, resolveDocComponent } from "~/utilities/docs";
+import { getDoc, loadDoc, resolveDoc } from "~/utilities/docs";
 import {
 	jsonLdGraphMetaDescriptor,
 	mantleWebPageJsonLd,
@@ -12,6 +12,11 @@ import type { Route } from "./+types/_index";
 const indexFilePath = "../docs/index.mdx";
 const title = "@ngrok/mantle";
 const description = "mantle is ngrok's UI library and design system";
+
+export async function loader() {
+	const doc = await loadDoc(indexFilePath);
+	return { toc: doc.toc };
+}
 
 export const meta: Route.MetaFunction = () => {
 	const canonicalUrl = canonicalHref("/");
@@ -57,15 +62,16 @@ export default function Page() {
 }
 
 function ProdIndexContent() {
-	const Component = getDocComponent(indexFilePath);
-	if (!Component) {
+	const doc = getDoc(indexFilePath);
+	if (!doc) {
 		throw Response.json({ message: "Not Found" }, { status: 404 });
 	}
+	const { Component } = doc;
 	return <Component />;
 }
 
 function DevIndexContent() {
-	const componentPromise = resolveDocComponent(indexFilePath);
-	const Component = use(componentPromise);
+	const docPromise = resolveDoc(indexFilePath);
+	const { Component } = use(docPromise);
 	return <Component />;
 }

--- a/apps/www/app/utilities/docs.ts
+++ b/apps/www/app/utilities/docs.ts
@@ -1,5 +1,6 @@
 import type { ComponentType } from "react";
 import rawMdxDocs from "virtual:raw-mdx-docs";
+import type { TocEntry } from "../../vite-plugins/rehype-mdx-toc";
 
 type MdxComponent = ComponentType & {
 	frontmatter?: Record<string, unknown>;
@@ -7,7 +8,10 @@ type MdxComponent = ComponentType & {
 
 type MdxModule = {
 	default: MdxComponent;
+	toc?: Array<TocEntry>;
 };
+
+export type { TocEntry };
 
 /**
  * Eager glob imports for production builds. All MDX modules are resolved at
@@ -48,52 +52,69 @@ async function getDocMdxModule(filePath: string): Promise<MdxModule | null> {
 	return mod;
 }
 
+/** A resolved MDX doc — its React component and the table-of-contents entries. */
+export type ResolvedDoc = {
+	Component: ComponentType;
+	toc: Array<TocEntry>;
+};
+
 // Cache promises by filePath so use() sees the same promise across renders.
 // In dev, we clear the cache each time this module re-executes (which Vite
 // triggers when an MDX file changes) so the next render re-imports the
 // updated module.
-const componentPromiseCache = new Map<string, Promise<ComponentType>>();
+const resolvedDocCache = new Map<string, Promise<ResolvedDoc>>();
 
 /**
- * Resolve the React component for a doc MDX module asynchronously.
+ * Resolve a doc MDX module asynchronously, returning its component and toc.
  * Used in dev with `use()` + Suspense for granular HMR.
  *
  * Caches promises so `use()` sees the same promise reference across renders,
  * preventing Suspense from re-suspending.
  *
  * @param filePath - A key from the MDX glob (e.g. "../docs/button.mdx").
- * @returns A promise that resolves to the MDX component.
  */
-export function resolveDocComponent(filePath: string): Promise<ComponentType> {
-	if (!componentPromiseCache.has(filePath)) {
-		const promise = (async () => {
-			const mod = await getDocMdxModule(filePath);
-			if (!mod) {
-				throw Response.json({ message: "Not Found" }, { status: 404 });
-			}
-			return mod.default;
-		})();
-		componentPromiseCache.set(filePath, promise);
+export function resolveDoc(filePath: string): Promise<ResolvedDoc> {
+	const existing = resolvedDocCache.get(filePath);
+	if (existing) {
+		return existing;
 	}
-
-	const componentPromise = componentPromiseCache.get(filePath);
-	if (!componentPromise) {
-		throw Response.json({ message: "Not Found" }, { status: 404 });
-	}
-	return componentPromise;
+	const promise = (async () => {
+		const mod = await getDocMdxModule(filePath);
+		if (!mod) {
+			throw Response.json({ message: "Not Found" }, { status: 404 });
+		}
+		return { Component: mod.default, toc: mod.toc ?? [] };
+	})();
+	resolvedDocCache.set(filePath, promise);
+	return promise;
 }
 
 /**
- * Get the React component for a doc MDX module synchronously.
+ * Get a doc MDX module synchronously, returning its component and toc.
  * Used in production builds where all modules are eagerly imported
  * at build time for prerendering.
  *
  * @param filePath - A key from the MDX glob (e.g. "../docs/button.mdx").
- * @returns The MDX component, or null if not found.
+ * @returns The resolved doc, or null if not found.
  */
-export function getDocComponent(filePath: string): ComponentType | null {
+export function getDoc(filePath: string): ResolvedDoc | null {
 	const mod = eagerDocModules[filePath];
-	return mod?.default ?? null;
+	if (!mod) {
+		return null;
+	}
+	return { Component: mod.default, toc: mod.toc ?? [] };
+}
+
+/**
+ * Loader-side helper: resolves a doc using the eager (prod) or lazy (dev)
+ * path, throwing 404 if the file isn't a known doc module.
+ */
+export async function loadDoc(filePath: string): Promise<ResolvedDoc> {
+	const doc = import.meta.env.PROD ? getDoc(filePath) : await resolveDoc(filePath);
+	if (!doc) {
+		throw Response.json({ message: "Not Found" }, { status: 404 });
+	}
+	return doc;
 }
 
 /**

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -52,6 +52,7 @@
     "@types/react": "19.2.14",
     "@types/react-dom": "19.2.3",
     "@vitejs/plugin-react": "catalog:",
+    "estree-util-value-to-estree": "3.5.0",
     "mdast-util-mdx-jsx": "3.2.0",
     "rehype-mdx-code-props": "3.0.1",
     "rehype-slug": "6.0.0",

--- a/apps/www/vite-plugins/rehype-mdx-toc.ts
+++ b/apps/www/vite-plugins/rehype-mdx-toc.ts
@@ -1,0 +1,94 @@
+import { valueToEstree } from "estree-util-value-to-estree";
+import type { ElementContent, Root } from "hast";
+
+/** A heading entry collected for a doc page's table of contents. */
+export type TocEntry = {
+	/** The heading's `id` attribute (set upstream by rehype-slug). */
+	id: string;
+	/** The visible text content of the heading. */
+	text: string;
+	/** The heading level — 1, 2, or 3. */
+	level: 1 | 2 | 3;
+};
+
+const HEADING_LEVELS: Record<string, 1 | 2 | 3> = {
+	h1: 1,
+	h2: 2,
+	h3: 3,
+};
+
+/** Recursively concatenate text nodes inside an element. */
+function getElementText(nodes: Array<ElementContent>): string {
+	let text = "";
+	for (const node of nodes) {
+		if (node.type === "text") {
+			text += node.value;
+		} else if (node.type === "element") {
+			text += getElementText(node.children);
+		}
+	}
+	return text;
+}
+
+/**
+ * Rehype plugin that collects top-level h1/h2/h3 headings from a compiled MDX
+ * document and emits an `export const toc = [...]` named export on the module.
+ *
+ * Must run after `rehype-slug` so headings have their `id` attribute. The
+ * exported entries match the ids in the rendered HTML, allowing the TOC
+ * sidebar to be rendered during SSR without scanning the DOM client-side.
+ */
+export function rehypeMdxToc() {
+	return (tree: Root) => {
+		const entries: Array<TocEntry> = [];
+
+		for (const node of tree.children) {
+			if (node.type !== "element") {
+				continue;
+			}
+			const level = HEADING_LEVELS[node.tagName];
+			if (level == null) {
+				continue;
+			}
+			const id = node.properties?.id;
+			if (typeof id !== "string" || !id) {
+				continue;
+			}
+			const text = getElementText(node.children).trim();
+			if (!text) {
+				continue;
+			}
+			entries.push({ id, text, level });
+		}
+
+		tree.children.unshift({
+			type: "mdxjsEsm",
+			value: "",
+			data: {
+				estree: {
+					type: "Program",
+					sourceType: "module",
+					body: [
+						{
+							type: "ExportNamedDeclaration",
+							specifiers: [],
+							attributes: [],
+							source: null,
+							declaration: {
+								type: "VariableDeclaration",
+								kind: "const",
+								declarations: [
+									{
+										type: "VariableDeclarator",
+										id: { type: "Identifier", name: "toc" },
+										init: valueToEstree(entries),
+									},
+								],
+							},
+						},
+					],
+				},
+			},
+		});
+	};
+}

--- a/apps/www/vite.config.ts
+++ b/apps/www/vite.config.ts
@@ -15,6 +15,7 @@ import { remarkMdxNoParagraphWrap } from "@ngrok/remark-mdx-no-paragraph-wrap";
 import { mantleChangelogMdx } from "./vite-plugins/mantle-changelog-mdx";
 import { mdxDocComponentImports } from "./vite-plugins/mdx-doc-component-imports";
 import { rawMdxDocs } from "./vite-plugins/raw-mdx-docs";
+import { rehypeMdxToc } from "./vite-plugins/rehype-mdx-toc";
 
 const codeBlockPlugins = mantleCodeBlockPlugins();
 
@@ -51,7 +52,7 @@ export default defineConfig({
 				remarkMdxGithubAlerts,
 				remarkMdxNoParagraphWrap,
 			],
-			rehypePlugins: [rehypeSlug, ...codeBlockPlugins.rehypePlugins],
+			rehypePlugins: [rehypeSlug, rehypeMdxToc, ...codeBlockPlugins.rehypePlugins],
 			providerImportSource: "@mdx-js/react",
 		}),
 		reactRouter(),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,42 +6,9 @@ settings:
 
 catalogs:
   default:
-    '@phosphor-icons/react':
-      specifier: 2.1.10
-      version: 2.1.10
-    '@tailwindcss/vite':
-      specifier: 4.2.4
-      version: 4.2.4
-    '@testing-library/jest-dom':
-      specifier: 6.9.1
-      version: 6.9.1
-    '@tsdown/css':
-      specifier: 0.21.10
-      version: 0.21.10
-    '@vitest/browser-playwright':
-      specifier: 4.1.5
-      version: 4.1.5
-    happy-dom:
-      specifier: 20.9.0
-      version: 20.9.0
-    playwright:
-      specifier: 1.59.1
-      version: 1.59.1
-    tailwindcss:
-      specifier: 4.2.4
-      version: 4.2.4
-    tsdown:
-      specifier: 0.21.10
-      version: 0.21.10
     tsx:
       specifier: 4.21.0
       version: 4.21.0
-    typescript:
-      specifier: 6.0.3
-      version: 6.0.3
-    vite:
-      specifier: 8.0.10
-      version: 8.0.10
 
 overrides:
   '@types/node': 24.12.2
@@ -207,6 +174,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: 6.0.1
         version: 6.0.1(vite@8.0.10(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      estree-util-value-to-estree:
+        specifier: 3.5.0
+        version: 3.5.0
       mdast-util-mdx-jsx:
         specifier: 3.2.0
         version: 3.2.0


### PR DESCRIPTION
- Re-run initial-active sync on `location.hash` changes so ToC link clicks update the highlight
immediately instead of lagging behind smooth scroll
- Round `trigger` and `offsetTop` to whole pixels to avoid sub-pixel off-by-one that highlighted the
predecessor heading
- Render the active/hover left bar as a 3px border with adjusted padding, and add a `focus-visible`
ring via a pseudo-element so the gray edge remains visible through focus
