### PR TITLE
feat(code-block): add label prop to CopyButton

### DIFF
--- a/.changeset/code-block-copy-button-label.md
+++ b/.changeset/code-block-copy-button-label.md
@@ -1,0 +1,5 @@
+---
+"@ngrok/mantle": patch
+---
+
+`CodeBlock.CopyButton` now accepts an optional `label` prop for the accessible (screen-reader) label, defaulting to `"Copy code"`.

--- a/apps/www/app/docs/components/code-block.mdx
+++ b/apps/www/app/docs/components/code-block.mdx
@@ -467,11 +467,12 @@ The (optional) copy button of the `CodeBlock`. Render this as a child of the `Co
 
 All props from [standard HTML button attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#attributes), plus:
 
-| Prop           | Type                       | Default | Description                                                                                                                                         |
-| :------------- | :------------------------- | :------ | :-------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `onCopy?`      | `(value: string) => void`  |         | Callback fired when the copy button is clicked, passes the copied text as an argument.                                                              |
-| `onCopyError?` | `(error: unknown) => void` |         | Callback fired when an error occurs during copying.                                                                                                 |
-| `asChild?`     | `boolean`                  | `false` | Use the `asChild` prop to compose the `CodeBlock.CopyButton` styling and functionality onto alternative element types or your own React components. |
+| Prop           | Type                       | Default       | Description                                                                                                                                         |
+| :------------- | :------------------------- | :------------ | :-------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `label?`       | `string`                   | `"Copy code"` | The accessible label for the copy button. Visually hidden but announced to screen reader users.                                                     |
+| `onCopy?`      | `(value: string) => void`  |               | Callback fired when the copy button is clicked, passes the copied text as an argument.                                                              |
+| `onCopyError?` | `(error: unknown) => void` |               | Callback fired when an error occurs during copying.                                                                                                 |
+| `asChild?`     | `boolean`                  | `false`       | Use the `asChild` prop to compose the `CodeBlock.CopyButton` styling and functionality onto alternative element types or your own React components. |
 
 ### CodeBlock.ExpanderButton
 

--- a/packages/mantle/src/components/code-block/code-block.test.tsx
+++ b/packages/mantle/src/components/code-block/code-block.test.tsx
@@ -124,6 +124,45 @@ describe("CodeBlock", () => {
 	});
 
 	describe("CopyButton", () => {
+		test("uses the label prop as the accessible name", () => {
+			render(
+				<CodeBlock.Root>
+					<CodeBlock.Body>
+						<CodeBlock.CopyButton label="Copy TypeScript example" />
+						<CodeBlock.Code value={makeValue("code")} />
+					</CodeBlock.Body>
+				</CodeBlock.Root>,
+			);
+
+			expect(screen.getByRole("button", { name: "Copy TypeScript example" })).toBeInTheDocument();
+			expect(screen.queryByRole("button", { name: /copy code/i })).not.toBeInTheDocument();
+		});
+
+		test("supports asChild composition", async () => {
+			const user = userEvent.setup();
+			const onCopy = vi.fn();
+			const code = "const x = 1;";
+
+			render(
+				<CodeBlock.Root>
+					<CodeBlock.Body>
+						<CodeBlock.CopyButton asChild onCopy={onCopy}>
+							<button type="button" data-testid="custom-copy-button" />
+						</CodeBlock.CopyButton>
+						<CodeBlock.Code value={makeValue(code)} />
+					</CodeBlock.Body>
+				</CodeBlock.Root>,
+			);
+
+			const button = screen.getByTestId("custom-copy-button");
+			expect(screen.getByRole("button", { name: /copy code/i })).toBe(button);
+			expect(button).toHaveAttribute("data-slot", "icon-button");
+
+			await user.click(button);
+
+			expect(onCopy).toHaveBeenCalledWith(code);
+		});
+
 		test("fires onCopy with the code text after clicking", async () => {
 			const user = userEvent.setup();
 			const onCopy = vi.fn();

--- a/packages/mantle/src/components/code-block/code-block.tsx
+++ b/packages/mantle/src/components/code-block/code-block.tsx
@@ -512,6 +512,12 @@ Title.displayName = "CodeBlockTitle";
 
 type CodeBlockCopyButtonProps = Omit<ComponentProps<"button">, "children" | "type"> & {
 	/**
+	 * The accessible label for the copy button. This label will be visually hidden but announced to screen reader users, similar to alt text for img tags.
+	 *
+	 * @default "Copy code"
+	 */
+	label?: string;
+	/**
 	 * Callback fired when the copy button is clicked, passes the copied text as an argument.
 	 */
 	onCopy?: (value: string) => void;
@@ -541,7 +547,7 @@ type CodeBlockCopyButtonProps = Omit<ComponentProps<"button">, "children" | "typ
  * ```
  */
 const CopyButton = forwardRef<ComponentRef<"button">, CodeBlockCopyButtonProps>(
-	({ className, onCopy, onCopyError, onClick, ...props }, ref) => {
+	({ className, label = "Copy code", onCopy, onCopyError, onClick, ...props }, ref) => {
 		const { copyTextRef } = useCodeBlockContext();
 		const copyToClipboard = useCopyToClipboard();
 		const [wasCopied, setWasCopied] = useState(false);
@@ -564,7 +570,7 @@ const CopyButton = forwardRef<ComponentRef<"button">, CodeBlockCopyButtonProps>(
 					type="button"
 					appearance="ghost"
 					size="sm"
-					label="Copy code"
+					label={label}
 					icon={wasCopied ? <CheckIcon /> : <CopyIcon />}
 					className={className}
 					ref={ref}

--- a/packages/mantle/src/components/code-block/code-block.tsx
+++ b/packages/mantle/src/components/code-block/code-block.tsx
@@ -33,7 +33,7 @@ import {
 } from "@radix-ui/react-tabs";
 import assert from "tiny-invariant";
 import { useCopyToClipboard } from "../../hooks/use-copy-to-clipboard.js";
-import type { WithAsChild } from "../../types/as-child.js";
+import type { SelfClosingWithAsChild, WithAsChild } from "../../types/as-child.js";
 import { composeRefs } from "../../utils/compose-refs/compose-refs.js";
 import { cx } from "../../utils/cx/cx.js";
 import { Icon as MantleIcon } from "../icon/icon.js";
@@ -510,22 +510,23 @@ const Title = forwardRef<
 });
 Title.displayName = "CodeBlockTitle";
 
-type CodeBlockCopyButtonProps = Omit<ComponentProps<"button">, "children" | "type"> & {
-	/**
-	 * The accessible label for the copy button. This label will be visually hidden but announced to screen reader users, similar to alt text for img tags.
-	 *
-	 * @default "Copy code"
-	 */
-	label?: string;
-	/**
-	 * Callback fired when the copy button is clicked, passes the copied text as an argument.
-	 */
-	onCopy?: (value: string) => void;
-	/**
-	 * Callback fired when an error occurs during copying.
-	 */
-	onCopyError?: (error: unknown) => void;
-};
+type CodeBlockCopyButtonProps = Omit<ComponentProps<"button">, "children" | "type"> &
+	SelfClosingWithAsChild & {
+		/**
+		 * The accessible label for the copy button. This label will be visually hidden but announced to screen reader users, similar to alt text for img tags.
+		 *
+		 * @default "Copy code"
+		 */
+		label?: string;
+		/**
+		 * Callback fired when the copy button is clicked, passes the copied text as an argument.
+		 */
+		onCopy?: (value: string) => void;
+		/**
+		 * Callback fired when an error occurs during copying.
+		 */
+		onCopyError?: (error: unknown) => void;
+	};
 
 /**
  * The (optional) copy button of the `CodeBlock`. Copies the code content


### PR DESCRIPTION
CodeBlock.CopyButton now accepts an optional `label` prop for the accessible screen-reader label, defaulting to "Copy code".