### PR TITLE
fix(dialog,sheet): reserve scrollbar gutter on Body to prevent content shift

### DIFF
--- a/.changeset/stable-scrollbar-gutter.md
+++ b/.changeset/stable-scrollbar-gutter.md
@@ -1,0 +1,5 @@
+---
+"@ngrok/mantle": patch
+---
+
+`Dialog.Body` and `Sheet.Body` now reserve space for the scrollbar via `scrollbar-gutter: stable`, preventing horizontal content shift when the body grows past its container and a scrollbar appears.

--- a/packages/mantle/src/components/dialog/dialog.tsx
+++ b/packages/mantle/src/components/dialog/dialog.tsx
@@ -408,7 +408,10 @@ CloseIconButton.displayName = "DialogCloseIconButton";
 const Body = ({ className, ...props }: ComponentProps<"div">) => (
 	<div
 		data-slot="dialog-body"
-		className={cx("scrollbar text-body flex-1 overflow-y-auto p-6", className)}
+		className={cx(
+			"scrollbar scrollbar-gutter-stable text-body flex-1 overflow-y-auto p-6",
+			className,
+		)}
 		{...props}
 	/>
 );

--- a/packages/mantle/src/components/sheet/sheet.tsx
+++ b/packages/mantle/src/components/sheet/sheet.tsx
@@ -444,7 +444,10 @@ CloseIconButton.displayName = "SheetCloseIconButton";
 const Body = ({ className, ...props }: HTMLAttributes<HTMLDivElement>) => (
 	<div
 		data-slot="sheet-body"
-		className={cx("scrollbar text-body flex-1 overflow-y-auto p-6", className)}
+		className={cx(
+			"scrollbar scrollbar-gutter-stable text-body flex-1 overflow-y-auto p-6",
+			className,
+		)}
 		{...props}
 	/>
 );


### PR DESCRIPTION
Add `scrollbar-gutter-stable` to `Dialog.Body` and `Sheet.Body` so the scrollbar gutter is always reserved. Prevents horizontal content shift when the body grows past its container and a scrollbar appears.