### PR TITLE
feat(field): export toErrorMessages helper for TanStack Form

### DIFF
--- a/.changeset/field-to-error-messages.md
+++ b/.changeset/field-to-error-messages.md
@@ -1,0 +1,13 @@
+---
+"@ngrok/mantle": patch
+---
+
+Add `toErrorMessages`, a first-class helper exported from `@ngrok/mantle/field` for normalizing TanStack React Form's mixed `field.state.meta.errors` array into a clean `string[]` for `Field.Errors`. Folds together the shapes TanStack Form yields across its built-in validators — plain strings, `{ message }` issue objects (Zod / Standard Schema), thrown `Error` instances, and the falsy slots Standard Schema can produce — into trimmed, non-empty strings without coupling Mantle to a specific form library.
+
+```tsx
+import { Field, toErrorMessages } from "@ngrok/mantle/field";
+
+<Field.Errors messages={toErrorMessages(field.state.meta.errors)} />;
+```
+
+Also exports the `FieldError` input type (`{ message?: string } | string | null | undefined | false`) for callers that want to type their own error arrays against the helper's contract.

--- a/apps/www/app/docs/components/field.mdx
+++ b/apps/www/app/docs/components/field.mdx
@@ -4,7 +4,7 @@ description: Layout primitive for a single form field — label, control, helper
 ---
 
 import { Button } from "@ngrok/mantle/button";
-import { Field } from "@ngrok/mantle/field";
+import { Field, toErrorMessages } from "@ngrok/mantle/field";
 import { Input, PasswordInput } from "@ngrok/mantle/input";
 import { RadioGroup } from "@ngrok/mantle/radio-group";
 import { InfoIcon } from "@phosphor-icons/react/Info";
@@ -49,7 +49,7 @@ export const TanStackFormExample = () => {
     								onChange={(event) => field.handleChange(event.target.value)}
     							/>
     						</Field.Control>
-    						<Field.Errors messages={field.state.meta.errors.map((error) => error?.message)} />
+    						<Field.Errors messages={toErrorMessages(field.state.meta.errors)} />
     						<Field.Description>We'll never share your email.</Field.Description>
     					</Field.Item>
     				)}
@@ -67,7 +67,7 @@ export const TanStackFormExample = () => {
     								onChange={(event) => field.handleChange(event.target.value)}
     							/>
     						</Field.Control>
-    						<Field.Errors messages={field.state.meta.errors.map((error) => error?.message)} />
+    						<Field.Errors messages={toErrorMessages(field.state.meta.errors)} />
     						<Field.Description>At least 12 characters.</Field.Description>
     					</Field.Item>
     				)}
@@ -180,7 +180,7 @@ Pass multiple messages to `Field.Errors` when a validator produces more than one
 </Field.Item>
 ```
 
-When errors arrive from a validator as an array (e.g. `field.state.meta.errors` from TanStack Form), map them to messages and pass them to `Field.Errors`. Empty, blank, or missing messages render nothing and do not add an error message reference. See [With TanStack Form](#with-tanstack-form) below.
+When errors arrive from a validator as an array (e.g. `field.state.meta.errors` from TanStack Form), map them to messages and pass them to `Field.Errors`. Empty, blank, or missing messages render nothing and do not add an error message reference. Reach for `toErrorMessages` to handle the mixed string / `{ message }` / nullish shapes that TanStack Form yields — see [With TanStack Form](#with-tanstack-form) below.
 
 ## Manual error list
 
@@ -419,14 +419,16 @@ Keep the `Field.Legend` self-contained: it is the accessible name for the group.
 
 ## With TanStack Form
 
-`Field` is designed to slot directly into [TanStack Form](https://tanstack.com/form). `field.name` is a stable, unique string for each field — pass it as both `htmlFor` on `Field.Label` and `id` on the control to wire the label association without a separate `useId()` call. Wrap the input in `Field.Control` so descriptions and rendered errors are associated with the control. Map `field.state.meta.errors` (e.g. `ZodIssue[]`) to string messages for `Field.Errors`; the list renders nothing when the array is empty, and infers error state only when it has messages, so it's safe to leave mounted unconditionally:
+`Field` is designed to slot directly into [TanStack Form](https://tanstack.com/form). `field.name` is a stable, unique string for each field — pass it as both `htmlFor` on `Field.Label` and `id` on the control to wire the label association without a separate `useId()` call. Wrap the input in `Field.Control` so descriptions and rendered errors are associated with the control.
+
+`field.state.meta.errors` is a mixed array — TanStack Form yields plain strings, `{ message }` issue objects (Zod / Standard Schema), thrown `Error` instances, and falsy slots all in one place. Pass it through `toErrorMessages` to get a clean `string[]` for `Field.Errors`. The list renders nothing when the result is empty, and infers error state only when it has messages, so it's safe to leave mounted unconditionally:
 
 <Example className="w-full">
 	<TanStackFormExample />
 </Example>
 
 ```tsx
-import { Field } from "@ngrok/mantle/field";
+import { Field, toErrorMessages } from "@ngrok/mantle/field";
 import { Input, PasswordInput } from "@ngrok/mantle/input";
 import { Button } from "@ngrok/mantle/button";
 import { useForm } from "@tanstack/react-form";
@@ -470,7 +472,7 @@ export function AccountForm() {
 									onChange={(event) => field.handleChange(event.target.value)}
 								/>
 							</Field.Control>
-							<Field.Errors messages={field.state.meta.errors.map((error) => error?.message)} />
+							<Field.Errors messages={toErrorMessages(field.state.meta.errors)} />
 							<Field.Description>We'll never share your email.</Field.Description>
 						</Field.Item>
 					)}
@@ -488,7 +490,7 @@ export function AccountForm() {
 									onChange={(event) => field.handleChange(event.target.value)}
 								/>
 							</Field.Control>
-							<Field.Errors messages={field.state.meta.errors.map((error) => error?.message)} />
+							<Field.Errors messages={toErrorMessages(field.state.meta.errors)} />
 							<Field.Description>At least 12 characters.</Field.Description>
 						</Field.Item>
 					)}
@@ -501,6 +503,33 @@ export function AccountForm() {
 	);
 }
 ```
+
+### Without `toErrorMessages`
+
+`toErrorMessages` is a convenience — `Field.Errors` itself only needs a `string[]`. If you already know your validator's error shape (or you want to filter / re-format messages first), map the array inline and skip the helper. The example below mirrors the TanStack Form example above, but pulls `.message` off each entry by hand:
+
+```tsx
+<form.Field name="email">
+	{(field) => (
+		<Field.Item>
+			<Field.Label htmlFor={field.name}>Email</Field.Label>
+			<Field.Control>
+				<Input
+					id={field.name}
+					name={field.name}
+					type="email"
+					value={field.state.value}
+					onBlur={field.handleBlur}
+					onChange={(event) => field.handleChange(event.target.value)}
+				/>
+			</Field.Control>
+			<Field.Errors messages={field.state.meta.errors.map((error) => error?.message)} />
+		</Field.Item>
+	)}
+</form.Field>
+```
+
+`Field.Errors` already trims each string, filters empty / nullish / `false` entries, and renders nothing when no messages remain — so passing `undefined` / empty strings through the `.map` is safe and behaves the same as filtering them out. Use the inline form when the helper's mixed-shape handling isn't pulling its weight (e.g. a validator that always emits `{ message: string }`), and reach for `toErrorMessages` when you want a single call that handles the full TanStack Form error array shape.
 
 ## Composition
 
@@ -750,3 +779,21 @@ All props from [ul](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ul
 | Prop       | Type      | Default | Description                                       |
 | ---------- | --------- | ------- | ------------------------------------------------- |
 | `asChild?` | `boolean` | `false` | Render as a different element by passing a child. |
+
+### toErrorMessages
+
+Normalize a TanStack React Form field's `meta.errors` array (or any mixed array of `string` / `{ message }` / nullish / `false` entries) into a clean `string[]` ready to pass to `Field.Errors`. Trims whitespace and drops empty / whitespace-only entries so callers don't have to filter again.
+
+Use this for [TanStack Form](https://tanstack.com/form) with Zod, Standard Schema, or thrown `Error` validators — `field.state.meta.errors` is a union of all of those shapes, and this helper folds them down to plain strings without coupling Mantle to a specific form library. For other validators where the error shape is already a `string[]`, skip the helper and pass the array directly.
+
+```tsx
+import { Field, toErrorMessages } from "@ngrok/mantle/field";
+
+<Field.Errors messages={toErrorMessages(field.state.meta.errors)} />;
+```
+
+| Argument | Type                                         | Description                                                    |
+| -------- | -------------------------------------------- | -------------------------------------------------------------- |
+| `errors` | `readonly FieldError[] \| null \| undefined` | Mixed array of validator outputs. `null` / `undefined` → `[]`. |
+
+Returns `string[]`. `FieldError` is `{ message?: string } \| string \| null \| undefined \| false`.

--- a/apps/www/app/docs/components/field.mdx
+++ b/apps/www/app/docs/components/field.mdx
@@ -523,13 +523,17 @@ export function AccountForm() {
 					onChange={(event) => field.handleChange(event.target.value)}
 				/>
 			</Field.Control>
-			<Field.Errors messages={field.state.meta.errors.map((error) => error?.message)} />
+			<Field.Errors
+				messages={field.state.meta.errors.map((error) =>
+					typeof error === "string" ? error : error?.message,
+				)}
+			/>
 		</Field.Item>
 	)}
 </form.Field>
 ```
 
-`Field.Errors` already trims each string, filters empty / nullish / `false` entries, and renders nothing when no messages remain — so passing `undefined` / empty strings through the `.map` is safe and behaves the same as filtering them out. Use the inline form when the helper's mixed-shape handling isn't pulling its weight (e.g. a validator that always emits `{ message: string }`), and reach for `toErrorMessages` when you want a single call that handles the full TanStack Form error array shape.
+`Field.Errors` already trims each string, filters empty / nullish / `false` entries, and renders nothing when no messages remain — so passing `undefined` / empty strings through the `.map` is safe and behaves the same as filtering them out. Use the inline form when the helper's mixed-shape handling isn't pulling its weight (e.g. a validator that always emits `{ message: string }`, where a bare `error?.message` map is enough), and reach for `toErrorMessages` when you want a single call that handles the full TanStack Form error array shape.
 
 ## Composition
 

--- a/packages/mantle/src/components/field/field-error-messages.test.ts
+++ b/packages/mantle/src/components/field/field-error-messages.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "vitest";
+
+import { toErrorMessages } from "./field-error-messages.js";
+
+describe("toErrorMessages", () => {
+	test("returns [] when given undefined", () => {
+		expect(toErrorMessages(undefined)).toEqual([]);
+	});
+
+	test("returns [] when given null", () => {
+		expect(toErrorMessages(null)).toEqual([]);
+	});
+
+	test("returns [] for an empty array", () => {
+		expect(toErrorMessages([])).toEqual([]);
+	});
+
+	test("drops nullish, false, and empty entries", () => {
+		expect(toErrorMessages([undefined, null, false, "", "   "])).toEqual([]);
+	});
+
+	test("returns plain string entries", () => {
+		expect(toErrorMessages(["Required", "Too short"])).toEqual(["Required", "Too short"]);
+	});
+
+	test("returns .message from object entries (Zod/StandardSchema issue shape)", () => {
+		expect(
+			toErrorMessages([{ message: "Please enter a valid email." }, { message: "Too short." }]),
+		).toEqual(["Please enter a valid email.", "Too short."]);
+	});
+
+	test("returns .message from thrown Error instances", () => {
+		expect(toErrorMessages([new Error("boom")])).toEqual(["boom"]);
+	});
+
+	test("trims whitespace around messages", () => {
+		expect(toErrorMessages(["  Required  ", { message: "  Too short  " }])).toEqual([
+			"Required",
+			"Too short",
+		]);
+	});
+
+	test("handles a mixed array preserving order", () => {
+		expect(
+			toErrorMessages([
+				"first",
+				undefined,
+				{ message: "second" },
+				false,
+				{ message: undefined },
+				"third",
+			]),
+		).toEqual(["first", "second", "third"]);
+	});
+
+	test("normalizes Zod-issue-shaped objects (string `message`, ignored extra fields)", () => {
+		const zodLikeIssues = [
+			{ code: "invalid_string", path: ["email"], message: "Please enter a valid email." },
+			{
+				code: "too_small",
+				path: ["password"],
+				minimum: 12,
+				message: "Must be at least 12 characters.",
+			},
+		];
+		expect(toErrorMessages(zodLikeIssues)).toEqual([
+			"Please enter a valid email.",
+			"Must be at least 12 characters.",
+		]);
+	});
+});

--- a/packages/mantle/src/components/field/field-error-messages.ts
+++ b/packages/mantle/src/components/field/field-error-messages.ts
@@ -1,3 +1,5 @@
+import { normalizeErrorMessages } from "./error-helpers.js";
+
 /**
  * Shapes commonly found in `field.state.meta.errors` from TanStack React Form
  * across its built-in validators (Standard Schema / Zod issues, raw strings,
@@ -26,27 +28,10 @@ type FieldError = { readonly message?: string | undefined } | string | null | un
  * </Field.Item>
  * ```
  */
-const toErrorMessages = (errors: readonly FieldError[] | null | undefined): string[] => {
-	if (errors == null) {
-		return [];
-	}
-
-	const messages: string[] = [];
-	for (const error of errors) {
-		if (!error) {
-			continue;
-		}
-		const message = typeof error === "string" ? error : error.message;
-		if (typeof message !== "string") {
-			continue;
-		}
-		const trimmed = message.trim();
-		if (trimmed.length > 0) {
-			messages.push(trimmed);
-		}
-	}
-	return messages;
-};
+const toErrorMessages = (errors: readonly FieldError[] | null | undefined): string[] =>
+	normalizeErrorMessages(
+		errors?.map((error) => (typeof error === "string" || !error ? error : error.message)),
+	);
 
 export {
 	//,

--- a/packages/mantle/src/components/field/field-error-messages.ts
+++ b/packages/mantle/src/components/field/field-error-messages.ts
@@ -1,0 +1,59 @@
+/**
+ * Shapes commonly found in `field.state.meta.errors` from TanStack React Form
+ * across its built-in validators (Standard Schema / Zod issues, raw strings,
+ * thrown `Error` instances) plus the falsy slots Standard Schema can produce.
+ */
+type FieldError = { readonly message?: string | undefined } | string | null | undefined | false;
+
+/**
+ * Reduce a TanStack React Form field's `meta.errors` array (or any array of
+ * mixed string / `{ message }` / nullish error entries) to a clean `string[]`
+ * for passing directly to `Field.Errors`' `messages` prop.
+ *
+ * Handles the shapes TanStack form yields for Zod, Standard Schema, and
+ * thrown `Error` validators: items may be strings, objects with `.message`,
+ * `undefined`, `null`, or `false`. Empty / whitespace-only messages are
+ * dropped so callers don't have to filter again.
+ *
+ * @example
+ * ```tsx
+ * <Field.Item>
+ *   <Field.Label htmlFor={field.name}>Email</Field.Label>
+ *   <Field.Control>
+ *     <Input id={field.name} value={field.state.value} />
+ *   </Field.Control>
+ *   <Field.Errors messages={toErrorMessages(field.state.meta.errors)} />
+ * </Field.Item>
+ * ```
+ */
+const toErrorMessages = (errors: readonly FieldError[] | null | undefined): string[] => {
+	if (errors == null) {
+		return [];
+	}
+
+	const messages: string[] = [];
+	for (const error of errors) {
+		if (!error) {
+			continue;
+		}
+		const message = typeof error === "string" ? error : error.message;
+		if (typeof message !== "string") {
+			continue;
+		}
+		const trimmed = message.trim();
+		if (trimmed.length > 0) {
+			messages.push(trimmed);
+		}
+	}
+	return messages;
+};
+
+export {
+	//,
+	toErrorMessages,
+};
+
+export type {
+	//,
+	FieldError,
+};

--- a/packages/mantle/src/components/field/index.ts
+++ b/packages/mantle/src/components/field/index.ts
@@ -10,6 +10,14 @@ export {
 } from "./field.js";
 export {
 	//,
+	toErrorMessages,
+} from "./field-error-messages.js";
+export type {
+	//,
+	FieldError,
+} from "./field-error-messages.js";
+export {
+	//,
 	isAriaInvalid,
 	parseValidation,
 	resolveValidation,


### PR DESCRIPTION
Hoist `toErrorMessages` (and the `FieldError` input type) into `@ngrok/mantle/field` as a first-class helper for normalizing TanStack React Form's mixed `field.state.meta.errors` array — strings, `{ message }`
issue objects (Zod / Standard Schema), thrown `Error` instances, and the
falsy slots Standard Schema can produce — into a clean `string[]` for `Field.Errors`. Trims whitespace and drops empty entries so callers don't
have to filter again.

Docs:
- "With TanStack Form" now uses `toErrorMessages` as the default in
  both the live example and code block.
- Added a "Without `toErrorMessages`" subsection showing the inline
  `.map((e) => e?.message)` alternative and when to reach for each.
- Added a `toErrorMessages` entry to the API reference.