### PR TITLE
feat(field): add Field.LabelText for control-less field rows

### DIFF
--- a/.changeset/field-label-text.md
+++ b/.changeset/field-label-text.md
@@ -1,0 +1,13 @@
+---
+"@ngrok/mantle": patch
+---
+
+Add `Field.LabelText` — static, label-styled text for `Field.Item` rows that do **not** caption a focusable form control. Renders a `<p>` (not a `<label>`) with the same `text-strong text-sm font-medium` typography as `Field.Label`, so read-only rows (owner cards, derived values, system-managed metadata inside sheets and detail panels) compose cleanly alongside real form fields without misrepresenting themselves as control captions. Supports `asChild` for polymorphic rendering. For rows with a real focusable control, keep using `Field.Label` so the label-to-control association stays wired.
+
+```tsx
+<Field.Item name="owner">
+	<Field.LabelText>Owner</Field.LabelText>
+	<CredentialOwnerCard owner={owner} />
+	<Field.Description>The user or service user that owns this API key.</Field.Description>
+</Field.Item>
+```

--- a/apps/www/app/docs/components/field.mdx
+++ b/apps/www/app/docs/components/field.mdx
@@ -585,13 +585,13 @@ All props from [`Label`](/components/label).
 
 ### Field.LabelText
 
-Static, label-styled text for a `Field.Item` row that does **not** caption a focusable control. Renders a `<p>` (not a `<label>`) with the same `text-strong text-sm font-medium` typography as `Field.Label`, so a read-only row composes cleanly alongside real form fields without misrepresenting itself as a control caption.
+Static, label-styled text for a `Field.Item` row that does **not** caption a focusable control. Renders a `<p>` (not a `<label>`) with the same typography as `Field.Label`, so a read-only row composes cleanly alongside real form fields without misrepresenting itself as a control caption.
 
 #### When to use
 
 - A `Field.Item` row that displays a derived or system-managed value — owner, created-at, computed status, an identity card — where there is no `<input>`, `<select>`, `<button>`, or other focusable target to caption.
 - Read-only summary rows inside a sheet or details panel that should visually align with sibling `Field.Item`s but have no editable control.
-- Anywhere you'd otherwise hand-roll `<p className="text-strong text-sm font-medium">` to mimic label typography. Use `Field.LabelText` so the intent is explicit at the call site.
+- Anywhere you'd otherwise hand-roll a `<p>` styled to mimic `Field.Label` typography. Use `Field.LabelText` so the intent is explicit at the call site.
 
 #### When _not_ to use
 

--- a/apps/www/app/docs/components/field.mdx
+++ b/apps/www/app/docs/components/field.mdx
@@ -537,7 +537,7 @@ Most forms only need a `Field.Group` of `Field.Item`s — that's the default tre
 Field.Group
 └── Field.Item
     ├── Field.LabelRow
-    │   ├── Field.Label
+    │   ├── Field.Label            (or Field.LabelText for control-less rows)
     │   │   └── Field.Optional
     │   └── Field.Help
     │       ├── Field.HelpTrigger
@@ -582,6 +582,35 @@ Layout parts plus `Field.Description`, `Field.Optional`, and `Field.ErrorList` a
 See the [Label docs](/components/label) for association patterns, disabled state, and typography behavior.
 
 All props from [`Label`](/components/label).
+
+### Field.LabelText
+
+Static, label-styled text for a `Field.Item` row that does **not** caption a focusable control. Renders a `<p>` (not a `<label>`) with the same `text-strong text-sm font-medium` typography as `Field.Label`, so a read-only row composes cleanly alongside real form fields without misrepresenting itself as a control caption.
+
+#### When to use
+
+- A `Field.Item` row that displays a derived or system-managed value — owner, created-at, computed status, an identity card — where there is no `<input>`, `<select>`, `<button>`, or other focusable target to caption.
+- Read-only summary rows inside a sheet or details panel that should visually align with sibling `Field.Item`s but have no editable control.
+- Anywhere you'd otherwise hand-roll `<p className="text-strong text-sm font-medium">` to mimic label typography. Use `Field.LabelText` so the intent is explicit at the call site.
+
+#### When _not_ to use
+
+- The row has a focusable control. Use `Field.Label` so the `htmlFor` ↔ control association, click-to-focus, and accessible name are wired automatically.
+- For body copy, section headings, or any text whose typography only happens to match by accident. Reach for a heading or a plain `<p>` instead — `Field.LabelText` exists specifically to slot into the `Field.Label` position of a `Field.Item`.
+
+```tsx
+<Field.Item name="owner">
+	<Field.LabelText>Owner</Field.LabelText>
+	<CredentialOwnerCard owner={owner} />
+	<Field.Description>The user or service user that owns this API key.</Field.Description>
+</Field.Item>
+```
+
+All props from [p](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/p#attributes), plus:
+
+| Prop       | Type      | Default | Description                                       |
+| ---------- | --------- | ------- | ------------------------------------------------- |
+| `asChild?` | `boolean` | `false` | Render as a different element by passing a child. |
 
 ### Field.Item
 

--- a/packages/mantle/src/components/field/field.test.tsx
+++ b/packages/mantle/src/components/field/field.test.tsx
@@ -827,6 +827,47 @@ describe("Field", () => {
 		});
 	});
 
+	describe("Field.LabelText", () => {
+		test("renders a <p> with data-slot and label typography", () => {
+			render(<Field.LabelText data-testid="lt">Owner</Field.LabelText>);
+			const labelText = screen.getByTestId("lt");
+			expect(labelText.tagName).toBe("P");
+			expect(labelText).toHaveAttribute("data-slot", "field-label-text");
+			expect(labelText).toHaveTextContent("Owner");
+			expect(labelText.className).toContain("text-strong");
+			expect(labelText.className).toContain("text-sm");
+			expect(labelText.className).toContain("font-medium");
+		});
+
+		test("merges custom className", () => {
+			render(
+				<Field.LabelText className="italic" data-testid="lt">
+					Owner
+				</Field.LabelText>,
+			);
+			const labelText = screen.getByTestId("lt");
+			expect(labelText.className).toContain("italic");
+			expect(labelText.className).toContain("text-strong");
+		});
+
+		test("does not render a <label> — has no focusable control to caption", () => {
+			const { container } = render(<Field.LabelText>Owner</Field.LabelText>);
+			expect(container.querySelector("label")).toBeNull();
+		});
+
+		test("renders as child element when asChild is true", () => {
+			render(
+				<Field.LabelText asChild>
+					<span data-testid="lt">Owner</span>
+				</Field.LabelText>,
+			);
+			const labelText = screen.getByTestId("lt");
+			expect(labelText.tagName).toBe("SPAN");
+			expect(labelText).toHaveAttribute("data-slot", "field-label-text");
+			expect(labelText.className).toContain("text-strong");
+		});
+	});
+
 	describe("Field.ErrorList", () => {
 		test("renders a ul with data-slot=field-error-list", () => {
 			render(

--- a/packages/mantle/src/components/field/field.tsx
+++ b/packages/mantle/src/components/field/field.tsx
@@ -161,6 +161,58 @@ const FieldLabel = forwardRef<ComponentRef<"label">, ComponentProps<typeof Label
 FieldLabel.displayName = "FieldLabel";
 
 /**
+ * Static, label-styled text for a `Field.Item` row that does **not** caption a
+ * focusable form control. Renders a `<p>` (not a `<label>`) with the same
+ * `text-strong text-sm font-medium` typography as `Field.Label`, so a read-only
+ * row inside a sheet or details panel composes cleanly next to real form fields
+ * without misrepresenting itself as a control caption.
+ *
+ * **When to use**
+ * - A `Field.Item` row that displays a derived or system-managed value
+ *   (owner, created-at, computed status) where there is no `<input>`,
+ *   `<select>`, `<button>`, or other focusable target to label.
+ * - Read-only summary rows inside a sheet or detail panel that should
+ *   visually align with sibling `Field.Item`s but have no editable control.
+ * - Anywhere you would otherwise write `<p className="text-strong text-sm font-medium">`
+ *   to mimic label typography — prefer this so intent is explicit at the call site.
+ *
+ * **When not to use**
+ * - The row has a focusable control (input, select, checkbox, switch,
+ *   button trigger). Use `Field.Label` so the click-to-focus and
+ *   accessible-name association are wired correctly.
+ * - For body copy, section headings, or any text whose typography happens
+ *   to look similar by accident — use the appropriate heading or `<p>`
+ *   directly. `Field.LabelText` exists specifically to slot into the
+ *   `Field.Label` position of a `Field.Item`.
+ *
+ * @see https://mantle.ngrok.com/components/field
+ *
+ * @example
+ * ```tsx
+ * <Field.Item name="owner">
+ *   <Field.LabelText>Owner</Field.LabelText>
+ *   <CredentialOwnerCard owner={owner} />
+ *   <Field.Description>The user or service user that owns this API key.</Field.Description>
+ * </Field.Item>
+ * ```
+ */
+const LabelText = forwardRef<ComponentRef<"p">, ComponentProps<"p"> & WithAsChild>(
+	({ asChild, className, ...props }, ref) => {
+		const Comp = asChild ? Slot : "p";
+
+		return (
+			<Comp
+				ref={ref}
+				data-slot="field-label-text"
+				className={cx("text-strong text-sm font-medium font-sans", className)}
+				{...props}
+			/>
+		);
+	},
+);
+LabelText.displayName = "FieldLabelText";
+
+/**
  * Horizontal layout container for the label area of a field. Aligns a
  * `<Field.Label>` (which may contain `Field.Optional`) with adjacent affordances
  * like a help-icon `Popover.Trigger` on a shared center line with a tight
@@ -987,7 +1039,7 @@ FieldErrorList.displayName = "FieldErrorList";
  * Field.Group
  * └── Field.Item
  *     ├── Field.LabelRow
- *     │   ├── Field.Label
+ *     │   ├── Field.Label            (or Field.LabelText for control-less rows)
  *     │   │   └── Field.Optional
  *     │   └── Field.Help
  *     │       ├── Field.HelpTrigger
@@ -1190,6 +1242,28 @@ const Field = {
 	 * ```
 	 */
 	Label: FieldLabel,
+	/**
+	 * Static, label-styled text for a `Field.Item` row that has no focusable
+	 * control to caption. Renders a `<p>` with the same typography as
+	 * `Field.Label`, so a read-only row composes cleanly alongside real form
+	 * fields without misrepresenting itself as a control caption.
+	 *
+	 * Use for derived / system-managed values (owner, created-at, computed
+	 * status) inside sheets or detail panels. For rows with a real control,
+	 * use `Field.Label` instead so the label-to-control association is wired.
+	 *
+	 * @see https://mantle.ngrok.com/components/field
+	 *
+	 * @example
+	 * ```tsx
+	 * <Field.Item name="owner">
+	 *   <Field.LabelText>Owner</Field.LabelText>
+	 *   <CredentialOwnerCard owner={owner} />
+	 *   <Field.Description>The user or service user that owns this API key.</Field.Description>
+	 * </Field.Item>
+	 * ```
+	 */
+	LabelText,
 	/**
 	 * Horizontal layout container for the label area of a field. Aligns a
 	 * `<Field.Label>` (which may contain `Field.Optional`) with adjacent affordances

--- a/packages/mantle/src/components/field/field.tsx
+++ b/packages/mantle/src/components/field/field.tsx
@@ -163,9 +163,9 @@ FieldLabel.displayName = "FieldLabel";
 /**
  * Static, label-styled text for a `Field.Item` row that does **not** caption a
  * focusable form control. Renders a `<p>` (not a `<label>`) with the same
- * `text-strong text-sm font-medium` typography as `Field.Label`, so a read-only
- * row inside a sheet or details panel composes cleanly next to real form fields
- * without misrepresenting itself as a control caption.
+ * typography as `Field.Label`, so a read-only row inside a sheet or details
+ * panel composes cleanly next to real form fields without misrepresenting
+ * itself as a control caption.
  *
  * **When to use**
  * - A `Field.Item` row that displays a derived or system-managed value
@@ -173,8 +173,8 @@ FieldLabel.displayName = "FieldLabel";
  *   `<select>`, `<button>`, or other focusable target to label.
  * - Read-only summary rows inside a sheet or detail panel that should
  *   visually align with sibling `Field.Item`s but have no editable control.
- * - Anywhere you would otherwise write `<p className="text-strong text-sm font-medium">`
- *   to mimic label typography — prefer this so intent is explicit at the call site.
+ * - Anywhere you would otherwise hand-roll a `<p>` styled to mimic
+ *   `Field.Label` typography — prefer this so intent is explicit at the call site.
  *
  * **When not to use**
  * - The row has a focusable control (input, select, checkbox, switch,


### PR DESCRIPTION
Add a static, label-styled text part for Field.Item rows that have no
focusable control to caption — owner cards, derived values, system-managed
metadata in sheets and detail panels. Renders a <p> (not a <label>) with
the same text-strong text-sm font-medium typography as Field.Label so
read-only rows align visually with sibling Field.Items without misrepresenting themselves as control captions. Supports asChild.

For rows with a real focusable control, keep using Field.Label so the
label-to-control association stays wired.

Docs:
- New Field.LabelText API section with explicit "When to use" and "When not to use" subsections.
- Composition tree updated to show LabelText as the control-less alternative to Field.Label.