### PR TITLE
Add overlay animation recipe for floating surfaces

### DIFF
--- a/.changeset/smooth-overlay-animations.md
+++ b/.changeset/smooth-overlay-animations.md
@@ -1,0 +1,10 @@
+---
+"@ngrok/mantle": patch
+---
+
+**Smoother enter/exit motion for `Tooltip`, `Popover`, and `HoverCard`.** Their content surfaces now share a single `overlay-animation` recipe that layers opacity, scale, a short directional translate toward the trigger, and a brief blur that resolves to sharp — so the surface materializes instead of snapping in.
+
+- The scale now emanates from the trigger via Radix's `--radix-*-content-transform-origin`.
+- `prefers-reduced-motion: reduce` drops the animation entirely (instant mount/unmount).
+
+No API changes. Consumers passing a custom `className` continue to override as before.

--- a/packages/mantle/src/components/hover-card/hover-card.tsx
+++ b/packages/mantle/src/components/hover-card/hover-card.tsx
@@ -119,8 +119,7 @@ const Content = forwardRef<
 			align={align}
 			sideOffset={sideOffset}
 			className={cx(
-				"bg-popover border-popover z-50 w-64 rounded-md border p-4 shadow-md outline-hidden",
-				"data-state-open:animate-in data-state-closed:animate-out data-state-closed:fade-out-0 data-state-open:fade-in-0 data-state-closed:zoom-out-95 data-state-open:zoom-in-95 data-side-bottom:slide-in-from-top-2 data-side-left:slide-in-from-right-2 data-side-right:slide-in-from-left-2 data-side-top:slide-in-from-bottom-2",
+				"bg-popover border-popover overlay-animation origin-(--radix-hover-card-content-transform-origin) z-50 w-64 rounded-md border p-4 shadow-md outline-hidden",
 				className,
 			)}
 			onClick={(event) => {

--- a/packages/mantle/src/components/popover/popover.tsx
+++ b/packages/mantle/src/components/popover/popover.tsx
@@ -147,7 +147,7 @@ const Content = forwardRef<ComponentRef<"div">, PopoverContentProps>(
 				align={align}
 				data-slot="popover-content"
 				className={cx(
-					"text-popover-foreground border-popover bg-popover data-side-bottom:slide-in-from-top-2 data-side-left:slide-in-from-right-2 data-side-right:slide-in-from-left-2 data-side-top:slide-in-from-bottom-2 data-state-closed:animate-out data-state-closed:fade-out-0 data-state-closed:zoom-out-95 data-state-open:animate-in data-state-open:fade-in-0 data-state-open:zoom-in-95 z-50 rounded-md border p-4 shadow-md outline-hidden",
+					"text-popover-foreground border-popover bg-popover overlay-animation origin-(--radix-popover-content-transform-origin) z-50 rounded-md border p-4 shadow-md outline-hidden",
 					preferredWidth,
 					className,
 				)}

--- a/packages/mantle/src/components/tooltip/tooltip.tsx
+++ b/packages/mantle/src/components/tooltip/tooltip.tsx
@@ -116,7 +116,7 @@ const Content = forwardRef<
 	<TooltipPrimitive.Portal>
 		<TooltipPrimitive.Content
 			className={cx(
-				"bg-tooltip text-tooltip animate-in fade-in-0 zoom-in-95 data-side-bottom:slide-in-from-top-2 data-side-left:slide-in-from-right-2 data-side-right:slide-in-from-left-2 data-side-top:slide-in-from-bottom-2 data-state-closed:animate-out data-state-closed:fade-out-0 data-state-closed:zoom-out-95 z-50 max-w-72 overflow-visible wrap-break-word rounded-md px-3 py-1.5 text-sm font-sans shadow",
+				"bg-tooltip text-tooltip overlay-animation origin-(--radix-tooltip-content-transform-origin) z-50 max-w-72 overflow-visible wrap-break-word rounded-md px-3 py-1.5 text-sm font-sans shadow",
 				className,
 			)}
 			data-slot="tooltip-content"

--- a/packages/mantle/src/mantle.css
+++ b/packages/mantle/src/mantle.css
@@ -589,6 +589,83 @@ MARK: UTILITIES
 }
 
 /*
+MARK: OVERLAY ANIMATIONS
+Shared enter/exit motion for floating surfaces that pop from an anchor —
+Tooltip, Popover, and HoverCard content. The recipe layers four properties so
+the surface materializes instead of snapping in: opacity (fade), scale (grow
+from the trigger), a short directional translate toward the anchor, and a blur
+that resolves to sharp. Credit: https://x.com/samitkapoorr/status/2062170061813821753
+
+Apply `overlay-animation` to a Radix content element and pair it with an
+`origin-(--radix-…-content-transform-origin)` so the scale emanates from the
+trigger. The directional translate is driven by Radix's `data-side`, and both
+phases key off `data-state` (Tooltip uses `delayed-open`/`instant-open`, hence
+the `:not([data-state="closed"])` selector for the enter phase rather than a
+literal `open`).
+*/
+@keyframes overlay-in {
+	from {
+		opacity: 0;
+		transform: translate3d(var(--overlay-translate-x, 0), var(--overlay-translate-y, 0), 0)
+			scale(0.95);
+		filter: blur(4px);
+	}
+	to {
+		opacity: 1;
+		transform: translate3d(0, 0, 0) scale(1);
+		filter: blur(0);
+	}
+}
+
+@keyframes overlay-out {
+	from {
+		opacity: 1;
+		transform: translate3d(0, 0, 0) scale(1);
+		filter: blur(0);
+	}
+	to {
+		opacity: 0;
+		transform: scale(0.95);
+		filter: blur(4px);
+	}
+}
+
+@utility overlay-animation {
+	&[data-side="top"] {
+		--overlay-translate-y: 0.5rem;
+	}
+	&[data-side="bottom"] {
+		--overlay-translate-y: -0.5rem;
+	}
+	&[data-side="left"] {
+		--overlay-translate-x: 0.5rem;
+	}
+	&[data-side="right"] {
+		--overlay-translate-x: -0.5rem;
+	}
+
+	/* Enter: ease-out so it decelerates into place. Exit: quicker ease-in. */
+	&:not([data-state="closed"]) {
+		animation: overlay-in 160ms cubic-bezier(0.16, 1, 0.3, 1) both;
+	}
+	&[data-state="closed"] {
+		animation: overlay-out 130ms cubic-bezier(0.3, 0, 0.8, 0.15) both;
+	}
+
+	/*
+	 * Respect reduced-motion: drop the animation entirely. Radix's presence
+	 * machinery reads `animation-name: none` as "nothing to wait for" and
+	 * mounts/unmounts the content instantly, which is the desired behavior here.
+	 */
+	@media (prefers-reduced-motion: reduce) {
+		&:not([data-state="closed"]),
+		&[data-state="closed"] {
+			animation: none;
+		}
+	}
+}
+
+/*
 MARK: SHIKI SYNTAX HIGHLIGHT
 */
 :root {


### PR DESCRIPTION
Introduces a shared `overlay-animation` utility that provides smooth enter/exit motion for floating surfaces (`Tooltip`, `Popover`, and `HoverCard`). This replaces individual animation classes with a cohesive recipe that layers multiple properties for a polished materialization effect.

## Changes

- **New `overlay-animation` utility** in `mantle.css`:
  - Defines `overlay-in` and `overlay-out` keyframes that animate opacity, scale, directional translate, and blur
  - Scales emanate from the trigger via Radix's `--radix-*-content-transform-origin`
  - Directional translate (0.5rem toward anchor) is driven by `data-side` attribute
  - Enter animation: 160ms ease-out; Exit animation: 130ms ease-in
  - Respects `prefers-reduced-motion: reduce` by dropping animation entirely (instant mount/unmount)

- **Updated component classNames**:
  - `Tooltip`: Replaced individual fade/zoom/slide classes with `overlay-animation origin-(--radix-tooltip-content-transform-origin)`
  - `Popover`: Same replacement with `origin-(--radix-popover-content-transform-origin)`
  - `HoverCard`: Same replacement with `origin-(--radix-hover-card-content-transform-origin)`

## Implementation Details

The animation recipe layers four properties to create a materialization effect rather than a snap-in:
- **Opacity**: Fades from 0 to 1
- **Scale**: Grows from 0.95 to 1
- **Translate**: Short directional movement (0.5rem) toward the anchor, resolving to 0
- **Blur**: Resolves from 4px to sharp (0)

The `data-state` attribute drives animation phase selection, with special handling for Tooltip's `delayed-open`/`instant-open` states via `:not([data-state="closed"])` selector.

No API changes. Custom `className` props continue to override as before.

https://claude.ai/code/session_01JPNSP5mjXRRbtzwthdDznS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced enter/exit animations for Tooltip, Popover, and HoverCard components with smoother opacity, scale, directional translation, and blur effects for improved visual polish.

* **Accessibility**
  * Animations automatically disabled when system prefers reduced motion, improving user experience for motion-sensitive users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->