### PR TITLE
feat(mantle): add Well component

### DIFF
--- a/.changeset/well-component.md
+++ b/.changeset/well-component.md
@@ -1,0 +1,10 @@
+---
+"@ngrok/mantle": minor
+---
+
+feat(mantle): add Well component
+
+A recessed, inset container that renders like `Card.Root` but with the base
+background and an inset shadow, for grouping and de-emphasizing content such as
+empty states, code samples, and read-only summaries. Supports `asChild` for
+polymorphic rendering.

--- a/apps/www/app/components/navigation-data.ts
+++ b/apps/www/app/components/navigation-data.ts
@@ -58,6 +58,7 @@ export const prodReadyComponents = [
 	"Theme",
 	"Toast",
 	"Tooltip",
+	"Well",
 ] as const;
 
 /**
@@ -125,6 +126,7 @@ export const prodReadyComponentRouteLookup = {
 	Theme: "/components/theme",
 	Toast: "/components/toast",
 	Tooltip: "/components/tooltip",
+	Well: "/components/well",
 } as const satisfies Record<(typeof prodReadyComponents)[number], Route>;
 
 /** Route lookup for preview component pages. */

--- a/apps/www/app/docs/components/well.mdx
+++ b/apps/www/app/docs/components/well.mdx
@@ -1,0 +1,99 @@
+---
+title: Well
+description: A recessed, inset container used to group and de-emphasize content.
+---
+
+import { Well } from "@ngrok/mantle/well";
+import { Empty } from "@ngrok/mantle/empty";
+import { Button } from "@ngrok/mantle/button";
+import { MagnifyingGlassIcon, PlusIcon } from "@phosphor-icons/react";
+import { Example } from "~/components/example";
+
+# Well
+
+A recessed, inset container used to visually group and de-emphasize content
+relative to the surrounding surface. It renders like a `Card.Root` but with an
+inset shadow and the base background, making it feel sunken into the page. Reach
+for it to frame empty states, code samples, supplementary notes, or read-only
+summaries.
+
+<Example>
+	<Well className="w-full">
+		<Empty.Root>
+			<Empty.Icon svg={<MagnifyingGlassIcon />} />
+			<Empty.Title>No results found</Empty.Title>
+			<Empty.Description>
+				<p>Try adjusting your search or filters to find what you're looking for.</p>
+			</Empty.Description>
+			<Empty.Actions>
+				<Button type="button" appearance="outlined" priority="neutral">
+					Clear filters
+				</Button>
+			</Empty.Actions>
+		</Empty.Root>
+	</Well>
+</Example>
+
+```tsx
+import { Well } from "@ngrok/mantle/well";
+import { Empty } from "@ngrok/mantle/empty";
+import { Button } from "@ngrok/mantle/button";
+import { MagnifyingGlassIcon } from "@phosphor-icons/react";
+
+<Well>
+	<Empty.Root>
+		<Empty.Icon svg={<MagnifyingGlassIcon />} />
+		<Empty.Title>No results found</Empty.Title>
+		<Empty.Description>
+			<p>Try adjusting your search or filters to find what you're looking for.</p>
+		</Empty.Description>
+		<Empty.Actions>
+			<Button type="button" appearance="outlined" priority="neutral">
+				Clear filters
+			</Button>
+		</Empty.Actions>
+	</Empty.Root>
+</Well>;
+```
+
+## Polymorphism
+
+`Well` accepts an `asChild` prop. When `true`, it renders its single child
+instead of its default `<div>`, forwarding all class names, `data-*`
+attributes, and the ref onto that child. Reach for this when the recessed
+container should also be a more semantic element, such as a labelled
+`<section>`.
+
+<Example>
+	<Well asChild className="w-full">
+		<section aria-label="Search results">
+			<Empty.Root>
+				<Empty.Icon svg={<MagnifyingGlassIcon />} />
+				<Empty.Title>No results found</Empty.Title>
+				<Empty.Description>
+					<p>Try adjusting your search or filters to find what you're looking for.</p>
+				</Empty.Description>
+				<Empty.Actions>
+					<Button type="button" appearance="filled">
+						<PlusIcon />
+						Create new
+					</Button>
+				</Empty.Actions>
+			</Empty.Root>
+		</section>
+	</Well>
+</Example>
+
+```tsx
+<Well asChild>
+	<section aria-label="Search results">{/* … */}</section>
+</Well>
+```
+
+## API Reference
+
+### Well
+
+A recessed, inset container. Renders a `<div>` by default and spreads all
+standard `<div>` props onto the rendered element. Supports the `asChild` prop
+for polymorphic rendering.

--- a/apps/www/app/routes.ts
+++ b/apps/www/app/routes.ts
@@ -121,6 +121,7 @@ export default [
 		...docRoute("components/theme"),
 		...docRoute("components/toast"),
 		...docRoute("components/tooltip"),
+		...docRoute("components/well"),
 
 		// hooks 🪝
 		...docRoute("hooks"),

--- a/packages/mantle-vite-plugins/src/mantle-component-name.ts
+++ b/packages/mantle-vite-plugins/src/mantle-component-name.ts
@@ -67,6 +67,7 @@ export const MANTLE_COMPONENT_NAMES = [
 	"theme",
 	"toast",
 	"tooltip",
+	"well",
 ] as const;
 
 /**

--- a/packages/mantle/package.json
+++ b/packages/mantle/package.json
@@ -339,6 +339,11 @@
 			"@ngrok/src-live-types": "./src/utils/index.ts",
 			"types": "./dist/utils.d.ts",
 			"import": "./dist/utils.js"
+		},
+		"./well": {
+			"@ngrok/src-live-types": "./src/components/well/index.ts",
+			"types": "./dist/well.d.ts",
+			"import": "./dist/well.js"
 		}
 	},
 	"scripts": {

--- a/packages/mantle/src/components/well/index.ts
+++ b/packages/mantle/src/components/well/index.ts
@@ -1,0 +1,10 @@
+/**
+ * Re-exports for the Well component.
+ *
+ * @see https://mantle.ngrok.com/components/well
+ */
+
+export {
+	//,
+	Well,
+} from "./well.js";

--- a/packages/mantle/src/components/well/well.test.tsx
+++ b/packages/mantle/src/components/well/well.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from "@testing-library/react";
+import { createRef } from "react";
+import { describe, expect, test } from "vitest";
+import { Well } from "./well.js";
+
+describe("Well", () => {
+	test("renders a div with its data-slot", () => {
+		render(<Well data-testid="well">content</Well>);
+		const well = screen.getByTestId("well");
+		expect(well.tagName).toBe("DIV");
+		expect(well).toHaveAttribute("data-slot", "well");
+		expect(well).toHaveTextContent("content");
+	});
+
+	test("merges custom className with its defaults", () => {
+		render(
+			<Well data-testid="well" className="custom-class">
+				content
+			</Well>,
+		);
+		const well = screen.getByTestId("well");
+		expect(well.className).toContain("custom-class");
+		expect(well.className).toContain("bg-base");
+		expect(well.className).toContain("shadow-inner");
+	});
+
+	test("forwards ref to the underlying div", () => {
+		const ref = createRef<HTMLDivElement>();
+		render(<Well ref={ref}>content</Well>);
+		expect(ref.current).not.toBeNull();
+		expect(ref.current?.tagName).toBe("DIV");
+	});
+
+	test("forwards arbitrary data-* props", () => {
+		render(
+			<Well data-testid="well" data-analytics-id="empty-state">
+				content
+			</Well>,
+		);
+		expect(screen.getByTestId("well")).toHaveAttribute("data-analytics-id", "empty-state");
+	});
+
+	test("asChild renders its child, merging classes and data-slot onto it", () => {
+		render(
+			<Well asChild className="custom-class">
+				<section data-testid="well">content</section>
+			</Well>,
+		);
+		const well = screen.getByTestId("well");
+		expect(well.tagName).toBe("SECTION");
+		expect(well).toHaveAttribute("data-slot", "well");
+		expect(well.className).toContain("custom-class");
+	});
+});

--- a/packages/mantle/src/components/well/well.tsx
+++ b/packages/mantle/src/components/well/well.tsx
@@ -1,0 +1,53 @@
+import type { ComponentProps, ComponentRef } from "react";
+import { forwardRef } from "react";
+import type { WithAsChild } from "../../types/index.js";
+import { cx } from "../../utils/cx/cx.js";
+import { Slot } from "../slot/index.js";
+
+type WellProps = ComponentProps<"div"> & WithAsChild;
+
+/**
+ * A recessed, inset container used to visually group and de-emphasize content
+ * relative to the surrounding surface, such as code samples, supplementary
+ * notes, or read-only summaries.
+ *
+ * Renders a `<div>` by default. Pass `asChild` to render as a different element
+ * or your own component, forwarding all class names, `data-*` attributes, and
+ * the ref onto that child.
+ *
+ * @see https://mantle.ngrok.com/components/well
+ *
+ * @example
+ * ```tsx
+ * <Well>
+ *   <p>Eu ad sint laborum nostrud ullamco esse.</p>
+ * </Well>
+ * ```
+ *
+ * @example
+ * ```tsx
+ * <Well asChild>
+ *   <section aria-label="Summary">…</section>
+ * </Well>
+ * ```
+ */
+const Well = forwardRef<ComponentRef<"div">, WellProps>(
+	({ asChild = false, className, ...props }, ref) => {
+		const Comp = asChild ? Slot : "div";
+
+		return (
+			<Comp
+				ref={ref}
+				data-slot="well"
+				className={cx("border-card bg-base relative rounded-md border shadow-inner", className)}
+				{...props}
+			/>
+		);
+	},
+);
+Well.displayName = "Well";
+
+export {
+	//,
+	Well,
+};


### PR DESCRIPTION
A recessed, inset container that renders like Card.Root but with the base background and an inset shadow. Use it to group and de-emphasize content such as empty states, code samples, and read-only summaries.

- Simple forwardRef <div> with data-slot="well" and asChild support via Slot
- Docs page with Empty-based examples and a Polymorphism section
- Registered export, route, and prod-ready nav entry
- Changeset: minor bump for @ngrok/mantle

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced the new "Well" component—a recessed, inset container designed for grouping and de-emphasizing content such as empty states, code samples, and read-only summaries.
  * Supports polymorphic rendering via the `asChild` prop for flexible component composition.
  * Comprehensive documentation and examples now available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->