### PR TITLE
Refine Empty/Well styling; default example buttons to filled neutral

### DIFF
--- a/.changeset/strong-cobras-fly.md
+++ b/.changeset/strong-cobras-fly.md
@@ -1,0 +1,5 @@
+---
+"@ngrok/mantle": patch
+---
+
+Refine `Empty` and `Well` styling: `Empty` uses tighter padding (`p-6`), `Empty.Icon` is smaller with a neutral color, `Empty.Title` and `Empty.Description` adopt smaller sans-serif text with a muted description, and `Well` uses the muted card border.

--- a/apps/www/app/docs/components/checkbox.mdx
+++ b/apps/www/app/docs/components/checkbox.mdx
@@ -54,7 +54,7 @@ window.alert(`Submitted: ${JSON.stringify(value, null, 2)}`);
     				</Field.Item>
     			)}
     		</form.Field>
-    		<Button type="submit" appearance="filled">
+    		<Button type="submit" appearance="filled" priority="neutral">
     			Submit
     		</Button>
     	</form>
@@ -216,7 +216,7 @@ function Example() {
 					</Field.Item>
 				)}
 			</form.Field>
-			<Button type="submit" appearance="filled">
+			<Button type="submit" appearance="filled" priority="neutral">
 				Submit
 			</Button>
 		</form>

--- a/apps/www/app/docs/components/combobox.mdx
+++ b/apps/www/app/docs/components/combobox.mdx
@@ -60,7 +60,7 @@ window.alert(`Submitted: ${JSON.stringify(value, null, 2)}`);
     				</Field.Item>
     			)}
     		</form.Field>
-    		<Button type="submit" appearance="filled">
+    		<Button type="submit" appearance="filled" priority="neutral">
     			Submit
     		</Button>
     	</form>
@@ -295,7 +295,7 @@ function Example() {
 					</Field.Item>
 				)}
 			</form.Field>
-			<Button type="submit" appearance="filled">
+			<Button type="submit" appearance="filled" priority="neutral">
 				Submit
 			</Button>
 		</form>

--- a/apps/www/app/docs/components/dialog.mdx
+++ b/apps/www/app/docs/components/dialog.mdx
@@ -55,7 +55,7 @@ import { Button } from "@ngrok/mantle/button";
 
 <Dialog.Root>
 	<Dialog.Trigger asChild>
-		<Button type="button" appearance="outlined" priority="neutral">
+		<Button type="button" appearance="filled" priority="neutral">
 			Open dialog
 		</Button>
 	</Dialog.Trigger>

--- a/apps/www/app/docs/components/dialog.mdx
+++ b/apps/www/app/docs/components/dialog.mdx
@@ -20,7 +20,7 @@ Use `Dialog` for a centered modal that interrupts the user to gather input or co
 <Example className="flex-col gap-6">
 	<Dialog.Root>
 		<Dialog.Trigger asChild>
-			<Button type="button" appearance="filled">
+			<Button type="button" appearance="filled" priority="neutral">
 				Open dialog
 			</Button>
 		</Dialog.Trigger>

--- a/apps/www/app/docs/components/dropdown-menu.mdx
+++ b/apps/www/app/docs/components/dropdown-menu.mdx
@@ -22,7 +22,7 @@ export const DropdownMenuExample = () => {
     return (
     	<DropdownMenu.Root>
     		<DropdownMenu.Trigger asChild>
-    			<Button type="button" appearance="filled">
+    			<Button type="button" appearance="filled" priority="neutral">
     				Open Menu
     			</Button>
     		</DropdownMenu.Trigger>
@@ -109,7 +109,7 @@ import { Icon } from "@ngrok/mantle/icon";
 
 <DropdownMenu.Root>
 	<DropdownMenu.Trigger asChild>
-		<Button appearance="filled" type="button">
+		<Button appearance="filled" priority="neutral" type="button">
 			Open Menu
 		</Button>
 	</DropdownMenu.Trigger>

--- a/apps/www/app/docs/components/empty.mdx
+++ b/apps/www/app/docs/components/empty.mdx
@@ -21,7 +21,7 @@ inside tables, lists, or pages that have no results.
 			<p>Create your first endpoint to get started.</p>
 		</Empty.Description>
 		<Empty.Actions>
-			<Button type="button" appearance="filled">
+			<Button type="button" appearance="filled" priority="neutral">
 				<PlusIcon />
 				Create endpoint
 			</Button>
@@ -41,7 +41,7 @@ import { GhostIcon, PlusIcon } from "@phosphor-icons/react";
 		<p>Create your first endpoint to get started.</p>
 	</Empty.Description>
 	<Empty.Actions>
-		<Button type="button" appearance="filled">
+		<Button type="button" appearance="filled" priority="neutral">
 			<PlusIcon />
 			Create endpoint
 		</Button>

--- a/apps/www/app/docs/components/empty.mdx
+++ b/apps/www/app/docs/components/empty.mdx
@@ -51,12 +51,12 @@ import { GhostIcon, PlusIcon } from "@phosphor-icons/react";
 
 ## Error page
 
-A full-page error state with a larger heading and multiple description paragraphs.
+A full-page error state with a retry action.
 
 <Example>
 	<Empty.Root>
 		<Empty.Icon svg={<SmileyMeltingIcon />} />
-		<Empty.Title className="text-2xl">Oops, something went wrong.</Empty.Title>
+		<Empty.Title>Oops, something went wrong.</Empty.Title>
 		<Empty.Description>
 			<p>Please try again in a few minutes.</p>
 		</Empty.Description>
@@ -75,7 +75,7 @@ import { SmileyMeltingIcon } from "@phosphor-icons/react";
 
 <Empty.Root>
 	<Empty.Icon svg={<SmileyMeltingIcon />} />
-	<Empty.Title className="text-2xl">Oops, something went wrong.</Empty.Title>
+	<Empty.Title>Oops, something went wrong.</Empty.Title>
 	<Empty.Description>
 		<p>Please try again in a few minutes.</p>
 	</Empty.Description>
@@ -94,8 +94,8 @@ A common pattern for empty states when a filter or search yields no results.
 <Example>
 	<Empty.Root>
 		<Empty.Icon svg={<MagnifyingGlassIcon />} />
-		<Empty.Title className="text-lg">No results matched your filter.</Empty.Title>
-		<Empty.Description className="text-xs">
+		<Empty.Title>No results matched your filter.</Empty.Title>
+		<Empty.Description>
 			<p>Check your spelling. It's possible what you're looking for no longer exists.</p>
 		</Empty.Description>
 		<Empty.Actions>
@@ -113,8 +113,8 @@ import { MagnifyingGlassIcon } from "@phosphor-icons/react";
 
 <Empty.Root>
 	<Empty.Icon svg={<MagnifyingGlassIcon />} />
-	<Empty.Title className="text-lg">No results matched your filter.</Empty.Title>
-	<Empty.Description className="text-xs">
+	<Empty.Title>No results matched your filter.</Empty.Title>
+	<Empty.Description>
 		<p>Check your spelling. It's possible what you're looking for no longer exists.</p>
 	</Empty.Description>
 	<Empty.Actions>

--- a/apps/www/app/docs/components/input.mdx
+++ b/apps/www/app/docs/components/input.mdx
@@ -55,7 +55,7 @@ window.alert(`Submitted: ${JSON.stringify(value, null, 2)}`);
     				</Field.Item>
     			)}
     		</form.Field>
-    		<Button type="submit" appearance="filled">
+    		<Button type="submit" appearance="filled" priority="neutral">
     			Submit
     		</Button>
     	</form>
@@ -214,7 +214,7 @@ function Example() {
 					</Field.Item>
 				)}
 			</form.Field>
-			<Button type="submit" appearance="filled">
+			<Button type="submit" appearance="filled" priority="neutral">
 				Submit
 			</Button>
 		</form>

--- a/apps/www/app/docs/components/multi-select.mdx
+++ b/apps/www/app/docs/components/multi-select.mdx
@@ -519,7 +519,7 @@ const filteredVeggies = useMemo(
 
 <Sheet.Root>
 	<Sheet.Trigger asChild>
-		<Button type="button" appearance="filled">
+		<Button type="button" appearance="filled" priority="neutral">
 			Assign fruits
 		</Button>
 	</Sheet.Trigger>
@@ -607,7 +607,13 @@ const filteredVeggies = useMemo(
 				</Sheet.Close>
 				<form.Subscribe selector={(state) => state.isDirty}>
 					{(isDirty) => (
-						<Button type="submit" form={formId} appearance="filled" disabled={!isDirty}>
+						<Button
+							type="submit"
+							form={formId}
+							appearance="filled"
+							priority="neutral"
+							disabled={!isDirty}
+						>
 							Save
 						</Button>
 					)}
@@ -812,7 +818,7 @@ function Example() {
 					</Field.Item>
 				)}
 			</form.Field>
-			<Button type="submit" appearance="filled">
+			<Button type="submit" appearance="filled" priority="neutral">
 				Submit
 			</Button>
 		</form>
@@ -979,7 +985,7 @@ function Example() {
 							<p className="text-accent-600 text-sm font-medium">
 								Upgrade your plan to specify regions, PoPs, and dedicated IPs.
 							</p>
-							<Button appearance="filled" className="shrink-0" asChild>
+							<Button appearance="filled" priority="neutral" className="shrink-0" asChild>
 								<Link
 									to={{
 										pathname: href("/billing/choose-a-plan"),

--- a/apps/www/app/docs/components/otp-input.mdx
+++ b/apps/www/app/docs/components/otp-input.mdx
@@ -62,7 +62,7 @@ window.alert(`Submitted: ${JSON.stringify(value, null, 2)}`);
     				</Field.Item>
     			)}
     		</form.Field>
-    		<Button type="submit" appearance="filled">
+    		<Button type="submit" appearance="filled" priority="neutral">
     			Submit
     		</Button>
     	</form>
@@ -223,7 +223,7 @@ function Example() {
 					</Field.Item>
 				)}
 			</form.Field>
-			<Button type="submit" appearance="filled">
+			<Button type="submit" appearance="filled" priority="neutral">
 				Submit
 			</Button>
 		</form>

--- a/apps/www/app/docs/components/password-input.mdx
+++ b/apps/www/app/docs/components/password-input.mdx
@@ -74,7 +74,7 @@ window.alert(`Submitted: ${JSON.stringify(value, null, 2)}`);
     				</Field.Item>
     			)}
     		</form.Field>
-    		<Button type="submit" appearance="filled">
+    		<Button type="submit" appearance="filled" priority="neutral">
     			Submit
     		</Button>
     	</form>
@@ -217,7 +217,7 @@ function Example() {
 					</Field.Item>
 				)}
 			</form.Field>
-			<Button type="submit" appearance="filled">
+			<Button type="submit" appearance="filled" priority="neutral">
 				Submit
 			</Button>
 		</form>

--- a/apps/www/app/docs/components/popover.mdx
+++ b/apps/www/app/docs/components/popover.mdx
@@ -24,7 +24,7 @@ Popover is a non-modal dialog by default: focus moves into the content on open, 
 <Example className="gap-2">
 	<Popover.Root>
 		<Popover.Trigger asChild>
-			<Button type="button" appearance="filled">
+			<Button type="button" appearance="filled" priority="neutral">
 				Open popover
 			</Button>
 		</Popover.Trigger>
@@ -68,7 +68,7 @@ import { Popover } from "@ngrok/mantle/popover";
 
 <Popover.Root>
 	<Popover.Trigger asChild>
-		<Button type="button" appearance="filled">
+		<Button type="button" appearance="filled" priority="neutral">
 			Open popover
 		</Button>
 	</Popover.Trigger>

--- a/apps/www/app/docs/components/radio-group.mdx
+++ b/apps/www/app/docs/components/radio-group.mdx
@@ -68,7 +68,7 @@ window.alert(`Submitted: ${JSON.stringify(value, null, 2)}`);
     				</Field.Set>
     			)}
     		</form.Field>
-    		<Button type="submit" appearance="filled">
+    		<Button type="submit" appearance="filled" priority="neutral">
     			Submit
     		</Button>
     	</form>
@@ -408,7 +408,7 @@ function Example() {
 					</Field.Set>
 				)}
 			</form.Field>
-			<Button type="submit" appearance="filled">
+			<Button type="submit" appearance="filled" priority="neutral">
 				Submit
 			</Button>
 		</form>

--- a/apps/www/app/docs/components/select.mdx
+++ b/apps/www/app/docs/components/select.mdx
@@ -80,7 +80,7 @@ window.alert(`Submitted: ${JSON.stringify(value, null, 2)}`);
     				</Field.Item>
     			)}
     		</form.Field>
-    		<Button type="submit" appearance="filled">
+    		<Button type="submit" appearance="filled" priority="neutral">
     			Submit
     		</Button>
     	</form>
@@ -237,7 +237,7 @@ function Example() {
 					</Field.Item>
 				)}
 			</form.Field>
-			<Button type="submit" appearance="filled">
+			<Button type="submit" appearance="filled" priority="neutral">
 				Submit
 			</Button>
 		</form>

--- a/apps/www/app/docs/components/sheet.mdx
+++ b/apps/www/app/docs/components/sheet.mdx
@@ -65,7 +65,7 @@ Use `Sheet` for side-panel content that slides in from any edge — filter panel
 <Example>
 	<Sheet.Root>
 		<Sheet.Trigger asChild>
-			<Button type="button" appearance="filled">
+			<Button type="button" appearance="filled" priority="neutral">
 				Open Sheet
 			</Button>
 		</Sheet.Trigger>
@@ -147,7 +147,7 @@ Use `Sheet` for side-panel content that slides in from any edge — filter panel
 						Close
 					</Button>
 				</Sheet.Close>
-				<Button type="button" appearance="filled">
+				<Button type="button" appearance="filled" priority="neutral">
 					Save
 				</Button>
 			</Sheet.Footer>
@@ -165,7 +165,7 @@ import { TrashSimpleIcon } from "@phosphor-icons/react/TrashSimple";
 
 <Sheet.Root>
 	<Sheet.Trigger asChild>
-		<Button type="button" appearance="filled">
+		<Button type="button" appearance="filled" priority="neutral">
 			Open Sheet
 		</Button>
 	</Sheet.Trigger>
@@ -270,7 +270,7 @@ By default, a `Sheet`'s content width is responsive with a default _preferred wi
 <Example>
 	<Sheet.Root>
 		<Sheet.Trigger asChild>
-			<Button type="button" appearance="filled">
+			<Button type="button" appearance="filled" priority="neutral">
 				Open 800px wide Sheet
 			</Button>
 		</Sheet.Trigger>
@@ -296,7 +296,7 @@ By default, a `Sheet`'s content width is responsive with a default _preferred wi
 						Close
 					</Button>
 				</Sheet.Close>
-				<Button type="button" appearance="filled">
+				<Button type="button" appearance="filled" priority="neutral">
 					Save
 				</Button>
 			</Sheet.Footer>
@@ -310,7 +310,7 @@ import { Sheet } from "@ngrok/mantle/sheet";
 
 <Sheet.Root>
 	<Sheet.Trigger asChild>
-		<Button type="button" appearance="filled">
+		<Button type="button" appearance="filled" priority="neutral">
 			Open 800px wide Sheet
 		</Button>
 	</Sheet.Trigger>
@@ -337,7 +337,7 @@ import { Sheet } from "@ngrok/mantle/sheet";
 					Close
 				</Button>
 			</Sheet.Close>
-			<Button type="button" appearance="filled">
+			<Button type="button" appearance="filled" priority="neutral">
 				Save
 			</Button>
 		</Sheet.Footer>

--- a/apps/www/app/docs/components/slider.mdx
+++ b/apps/www/app/docs/components/slider.mdx
@@ -54,7 +54,7 @@ export function TanStackFormExample() {
     				</Field.Item>
     			)}
     		</form.Field>
-    		<Button type="submit" appearance="filled">
+    		<Button type="submit" appearance="filled" priority="neutral">
     			Submit
     		</Button>
     	</form>
@@ -173,7 +173,7 @@ function Example() {
 					</Field.Item>
 				)}
 			</form.Field>
-			<Button type="submit" appearance="filled">
+			<Button type="submit" appearance="filled" priority="neutral">
 				Submit
 			</Button>
 		</form>

--- a/apps/www/app/docs/components/slot.mdx
+++ b/apps/www/app/docs/components/slot.mdx
@@ -40,7 +40,7 @@ The `Slot` component is the foundation of the `asChild` pattern used throughout 
 
 <Example>
 	<div className="flex gap-4">
-		<Button appearance="filled" asChild>
+		<Button appearance="filled" priority="neutral" asChild>
 			<a href="https://ngrok.com">Visit ngrok</a>
 		</Button>
 		<Button appearance="outlined" priority="neutral" asChild>
@@ -52,7 +52,7 @@ The `Slot` component is the foundation of the `asChild` pattern used throughout 
 ```tsx
 import { Button } from "@ngrok/mantle/button";
 
-<Button appearance="filled" asChild>
+<Button appearance="filled" priority="neutral" asChild>
 	<a href="https://ngrok.com">Visit ngrok</a>
 </Button>
 

--- a/apps/www/app/docs/components/switch.mdx
+++ b/apps/www/app/docs/components/switch.mdx
@@ -137,7 +137,7 @@ export function FormExample() {
     			</Field.Item>
     		)}
     	</form.Field>
-    	<Button type="submit" appearance="filled">
+    	<Button type="submit" appearance="filled" priority="neutral">
     		Submit
     	</Button>
     </form>
@@ -199,7 +199,7 @@ function FormExample() {
 					</Field.Item>
 				)}
 			</form.Field>
-			<Button type="submit" appearance="filled">
+			<Button type="submit" appearance="filled" priority="neutral">
 				Submit
 			</Button>
 		</form>

--- a/apps/www/app/docs/components/text-area.mdx
+++ b/apps/www/app/docs/components/text-area.mdx
@@ -133,7 +133,7 @@ export function FormExample() {
     			</Field.Item>
     		)}
     	</form.Field>
-    	<Button type="submit" appearance="filled">
+    	<Button type="submit" appearance="filled" priority="neutral">
     		Submit
     	</Button>
     </form>
@@ -194,7 +194,7 @@ function FormExample() {
 					</Field.Item>
 				)}
 			</form.Field>
-			<Button type="submit" appearance="filled">
+			<Button type="submit" appearance="filled" priority="neutral">
 				Submit
 			</Button>
 		</form>

--- a/apps/www/app/docs/components/toast.mdx
+++ b/apps/www/app/docs/components/toast.mdx
@@ -27,6 +27,7 @@ export function ToastDemo() {
 			<Button
 				type="button"
 				appearance="filled"
+				priority="neutral"
 				onClick={() => {
 					makeToast(
 						<Toast.Root priority={priority}>
@@ -52,7 +53,7 @@ export function ToastDemo() {
 			</Button>
 			<Sheet.Root>
 				<Sheet.Trigger asChild>
-					<Button type="button" appearance="filled">
+					<Button type="button" appearance="filled" priority="neutral">
 						Open Sheet
 					</Button>
 				</Sheet.Trigger>
@@ -99,7 +100,7 @@ export function ToastDemo() {
 			</Sheet.Root>
 			<Dialog.Root>
 				<Dialog.Trigger asChild>
-					<Button type="button" appearance="filled">
+					<Button type="button" appearance="filled" priority="neutral">
 						Open dialog
 					</Button>
 				</Dialog.Trigger>
@@ -147,7 +148,7 @@ export function ToastDemo() {
 			</Dialog.Root>
 			<AlertDialog.Root priority="info">
 				<AlertDialog.Trigger asChild>
-					<Button type="button" appearance="filled">
+					<Button type="button" appearance="filled" priority="neutral">
 						Show Info Alert Dialog
 					</Button>
 				</AlertDialog.Trigger>

--- a/apps/www/app/docs/components/tooltip.mdx
+++ b/apps/www/app/docs/components/tooltip.mdx
@@ -26,7 +26,7 @@ Mount `TooltipProvider` once at the app root when you want shared tooltip behavi
 <Example>
 	<Tooltip.Root>
 		<Tooltip.Trigger asChild>
-			<Button type="button" appearance="filled" priority="default">
+			<Button type="button" appearance="filled" priority="neutral">
 				Hover me
 			</Button>
 		</Tooltip.Trigger>
@@ -42,7 +42,7 @@ import { Tooltip } from "@ngrok/mantle/tooltip";
 
 <Tooltip.Root>
 	<Tooltip.Trigger asChild>
-		<Button type="button" appearance="filled" priority="default">
+		<Button type="button" appearance="filled" priority="neutral">
 			Hover me
 		</Button>
 	</Tooltip.Trigger>

--- a/apps/www/app/docs/components/well.mdx
+++ b/apps/www/app/docs/components/well.mdx
@@ -74,7 +74,7 @@ container should also be a more semantic element, such as a labelled
 					<p>Try adjusting your search or filters to find what you're looking for.</p>
 				</Empty.Description>
 				<Empty.Actions>
-					<Button type="button" appearance="filled">
+					<Button type="button" appearance="filled" priority="neutral">
 						<PlusIcon />
 						Create new
 					</Button>

--- a/apps/www/app/docs/migrations/dialog-footer-dom-order-migration.mdx
+++ b/apps/www/app/docs/migrations/dialog-footer-dom-order-migration.mdx
@@ -48,7 +48,7 @@ right). Footers with a single child need no change.
 ```tsx
 // BEFORE — primary action written first to land on the right under flex-row-reverse
 <Dialog.Footer>
-	<Button type="button" appearance="filled">
+	<Button type="button" appearance="filled" priority="neutral">
 		Save
 	</Button>
 	<Dialog.Close asChild>
@@ -67,7 +67,7 @@ right). Footers with a single child need no change.
 			Cancel
 		</Button>
 	</Dialog.Close>
-	<Button type="button" appearance="filled">
+	<Button type="button" appearance="filled" priority="neutral">
 		Save
 	</Button>
 </Dialog.Footer>

--- a/apps/www/app/examples/multi-select/multi-select-in-sheet-demo.tsx
+++ b/apps/www/app/examples/multi-select/multi-select-in-sheet-demo.tsx
@@ -38,7 +38,7 @@ export function InSheetDemo() {
 	return (
 		<Sheet.Root>
 			<Sheet.Trigger asChild>
-				<Button type="button" appearance="filled">
+				<Button type="button" appearance="filled" priority="neutral">
 					Assign fruits
 				</Button>
 			</Sheet.Trigger>
@@ -130,7 +130,13 @@ export function InSheetDemo() {
 						</Sheet.Close>
 						<form.Subscribe selector={(state) => state.isDirty}>
 							{(isDirty) => (
-								<Button type="submit" form={formId} appearance="filled" disabled={!isDirty}>
+								<Button
+									type="submit"
+									form={formId}
+									appearance="filled"
+									priority="neutral"
+									disabled={!isDirty}
+								>
 									Save
 								</Button>
 							)}

--- a/apps/www/app/examples/multi-select/multi-select-region-pinning-demo.tsx
+++ b/apps/www/app/examples/multi-select/multi-select-region-pinning-demo.tsx
@@ -135,7 +135,7 @@ export function RegionPinningDemo() {
 							<p className="text-accent-600 text-sm font-medium flex-1">
 								Upgrade your plan to specify regions, PoPs, and dedicated IPs.
 							</p>
-							<Button appearance="filled" className="shrink-0" asChild>
+							<Button appearance="filled" priority="neutral" className="shrink-0" asChild>
 								<Link to="#">Upgrade to Pay-as-you-go</Link>
 							</Button>
 						</div>

--- a/apps/www/app/examples/multi-select/multi-select-tanstack-form-demo.tsx
+++ b/apps/www/app/examples/multi-select/multi-select-tanstack-form-demo.tsx
@@ -61,7 +61,7 @@ export function TanStackFormDemo() {
 					</Field.Item>
 				)}
 			</form.Field>
-			<Button type="submit" appearance="filled">
+			<Button type="submit" appearance="filled" priority="neutral">
 				Submit
 			</Button>
 		</form>

--- a/apps/www/app/features/code-block-demos.tsx
+++ b/apps/www/app/features/code-block-demos.tsx
@@ -396,7 +396,12 @@ export function ServerRenderedHighlightingDemo() {
 						)}
 					</form.Field>
 				</div>
-				<Button type="submit" appearance="filled" disabled={status === "loading"}>
+				<Button
+					type="submit"
+					appearance="filled"
+					priority="neutral"
+					disabled={status === "loading"}
+				>
 					{status === "loading" ? "Highlighting..." : "Highlight on Server"}
 				</Button>
 			</form>

--- a/packages/mantle/src/components/empty/empty.test.tsx
+++ b/packages/mantle/src/components/empty/empty.test.tsx
@@ -41,7 +41,9 @@ describe("Empty", () => {
 		);
 		const title = screen.getByTestId("title");
 		expect(title.className).toContain("text-2xl");
-		expect(title.className).toContain("text-strong");
+		// Verify base classes are preserved alongside the custom one without
+		// coupling to specific design-token utilities (which change on restyle).
+		expect(title).toHaveAttribute("data-slot", "empty-title");
 	});
 
 	test("Title renders as child element when asChild is true", () => {
@@ -55,7 +57,7 @@ describe("Empty", () => {
 		const title = screen.getByTestId("title");
 		expect(title.tagName).toBe("H1");
 		expect(title).toHaveTextContent("Heading");
-		expect(title.className).toContain("text-strong");
+		expect(title).toHaveAttribute("data-slot", "empty-title");
 	});
 
 	test("Description renders a div element by default", () => {
@@ -81,7 +83,7 @@ describe("Empty", () => {
 		);
 		const description = screen.getByTestId("desc");
 		expect(description.className).toContain("text-xs");
-		expect(description.className).toContain("text-body");
+		expect(description).toHaveAttribute("data-slot", "empty-description");
 	});
 
 	test("Description renders as child element when asChild is true", () => {
@@ -96,7 +98,7 @@ describe("Empty", () => {
 		);
 		const description = screen.getByTestId("desc");
 		expect(description.tagName).toBe("SECTION");
-		expect(description.className).toContain("text-body");
+		expect(description).toHaveAttribute("data-slot", "empty-description");
 	});
 
 	test("Actions renders a div element", () => {

--- a/packages/mantle/src/components/empty/empty.tsx
+++ b/packages/mantle/src/components/empty/empty.tsx
@@ -29,7 +29,7 @@ const Root = ({ asChild, children, className, ...props }: ComponentProps<"div"> 
 	return (
 		<Comp
 			data-slot="empty"
-			className={cx("mx-auto flex max-w-lg flex-col items-center py-14 text-center", className)}
+			className={cx("mx-auto flex max-w-lg flex-col items-center p-6 text-center", className)}
 			{...props}
 		>
 			{children}
@@ -67,7 +67,7 @@ const Icon = ({ className, svg, ...props }: EmptyIconProps) => {
 	return (
 		<SvgOnly
 			data-slot="empty-icon"
-			className={cx("mb-2 size-16 text-muted", className)}
+			className={cx("mb-1 size-10 text-neutral-400", className)}
 			svg={svg}
 			{...props}
 		/>
@@ -108,7 +108,7 @@ const Title = ({
 	return (
 		<Comp
 			data-slot="empty-title"
-			className={cx("text-strong text-xl font-medium", className)}
+			className={cx("text-strong text-sm font-medium font-sans", className)}
 			{...props}
 		>
 			{children}
@@ -152,7 +152,7 @@ const Description = ({
 	return (
 		<Comp
 			data-slot="empty-description"
-			className={cx("text-body mt-1 space-y-4 text-sm", className)}
+			className={cx("text-muted space-y-4 text-sm font-sans", className)}
 			{...props}
 		>
 			{children}

--- a/packages/mantle/src/components/well/well.tsx
+++ b/packages/mantle/src/components/well/well.tsx
@@ -39,7 +39,10 @@ const Well = forwardRef<ComponentRef<"div">, WellProps>(
 			<Comp
 				ref={ref}
 				data-slot="well"
-				className={cx("border-card bg-base relative rounded-md border shadow-inner", className)}
+				className={cx(
+					"border-card-muted bg-base relative rounded-md border shadow-inner",
+					className,
+				)}
 				{...props}
 			/>
 		);


### PR DESCRIPTION
packages/mantle:
- Empty: tighter padding (p-6), smaller neutral-colored icon (size-10), smaller sans-serif title, muted sans-serif description
- Well: use border-card-muted instead of border-card

apps/www:
- Use appearance="filled" priority="neutral" for filled buttons across component docs and examples (leaving intentional danger buttons and the sheet-async demos as-is); switch tooltip examples from default to neutral

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined Empty component styling with tighter spacing, smaller icons, and updated typography.
  * Updated Well component border appearance.

* **Documentation**
  * Updated documentation and code examples across multiple components for visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->